### PR TITLE
Fix minor issue on aggregator (serialize u32 instead of u8 for lengths)

### DIFF
--- a/aggregator/CHANGELOG.md
+++ b/aggregator/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://book.async.rs/overview
 * Update dependency names [#32](https://github.com/midnightntwrk/midnight-zk/pull/32)
 * Fix versions of crates in monorepo [#33](https://github.com/midnightntwrk/midnight-zk/pull/33)
 * Unify transcript style [#34](https://github.com/midnightntwrk/midnight-zk/pull/34)
+* Fix minor issue (serialize u32 instead of u8 on acc lengths) [#75](https://github.com/midnightntwrk/midnight-zk/pull/75)
 
 ### Removed
 * Add a turned-off automaton configuration due to the automaton chip being exposed in std_lib [#30](https://github.com/midnightntwrk/midnight-zk/pull/30)

--- a/aggregator/src/light_aggregator.rs
+++ b/aggregator/src/light_aggregator.rs
@@ -298,7 +298,7 @@ impl<const NB_PROOFS: usize> LightAggregator<NB_PROOFS> {
         T: Transcript,
         C: Hashable<T::Hash>,
         F: Sampleable<T::Hash> + Hashable<T::Hash>,
-        u8: Hashable<T::Hash>,
+        u32: Hashable<T::Hash>,
     {
         // We first verify all proofs off-circuit, to get the final batched accumulator,
         // which must be a public input of the aggregator circuit.
@@ -371,13 +371,13 @@ impl<const NB_PROOFS: usize> LightAggregator<NB_PROOFS> {
         let acc_rhs_evaluated = acc.rhs().eval(&fixed_bases);
 
         // Add the LHS of acc to the transcript.
-        transcript.write(&(acc.lhs().bases().len() as u8))?;
+        transcript.write(&(acc.lhs().bases().len() as u32))?;
         (acc.lhs().bases().iter()).try_for_each(|p| transcript.write(p))?;
         (acc.lhs().scalars().iter()).try_for_each(|s| transcript.write(s))?;
         assert!(acc.lhs().fixed_base_scalars().is_empty());
 
         // Add the RHS of the acc to the transcript (with scalars in committed form).
-        transcript.write(&(acc.rhs().bases().len() as u8))?;
+        transcript.write(&(acc.rhs().bases().len() as u32))?;
         (acc.rhs().bases().iter()).try_for_each(|p| transcript.write(p))?;
         transcript.write(&acc_rhs_scalars_committed)?;
         transcript.write(&acc_rhs_evaluated)?;
@@ -424,11 +424,11 @@ impl<const NB_PROOFS: usize> LightAggregator<NB_PROOFS> {
         T: Transcript,
         C: Hashable<T::Hash>,
         F: Sampleable<T::Hash> + Hashable<T::Hash>,
-        u8: Hashable<T::Hash>,
+        u32: Hashable<T::Hash>,
     {
         // Read the LHS of the acc from the transcript.
         let acc_lhs: Msm<S> = {
-            let n: u8 = transcript.read()?;
+            let n: u32 = transcript.read()?;
             let lhs_bases: Result<Vec<C>, io::Error> = (0..n).map(|_| transcript.read()).collect();
             let lhs_scalars: Result<Vec<F>, io::Error> =
                 (0..n).map(|_| transcript.read()).collect();
@@ -437,7 +437,7 @@ impl<const NB_PROOFS: usize> LightAggregator<NB_PROOFS> {
 
         // Read the RHS of the acc from the transcript (with scalars in committed form).
         let acc_rhs_bases = {
-            let n: u8 = transcript.read()?;
+            let n: u32 = transcript.read()?;
             (0..n)
                 .map(|_| transcript.read())
                 .collect::<Result<Vec<C>, io::Error>>()?

--- a/proofs/CHANGELOG.md
+++ b/proofs/CHANGELOG.md
@@ -22,5 +22,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * Split `create_proof` into `trace` and `finalize` [#47](https://github.com/midnightntwrk/midnight-zk/pull/47)
 * Optimize ops for `Expression<F>` and implement them for `&Expression<F>` [#52](https://github.com/midnightntwrk/midnight-zk/pull/52)
 * Introduce trash arguments for additive selectors [#59](https://github.com/midnightntwrk/midnight-zk/pull/59)
+* Implement TranscriptHash for u32 [#75](https://github.com/midnightntwrk/midnight-zk/pull/75)
 
 ### Removed

--- a/proofs/src/transcript/implementors.rs
+++ b/proofs/src/transcript/implementors.rs
@@ -35,19 +35,19 @@ impl TranscriptHash for Blake2bState {
 // /// Implementation of Hashable for BN with Blake //
 // ///////////////////////////////////////////////////
 
-impl<T: TranscriptHash<Input = Vec<u8>>> Hashable<T> for u8 {
+impl<T: TranscriptHash<Input = Vec<u8>>> Hashable<T> for u32 {
     fn to_input(&self) -> Vec<u8> {
-        vec![*self]
+        self.to_le_bytes().to_vec()
     }
 
     fn to_bytes(&self) -> Vec<u8> {
-        vec![*self]
+        self.to_le_bytes().to_vec()
     }
 
     fn read(buffer: &mut impl Read) -> io::Result<Self> {
-        let mut byte = [0u8; 1];
-        buffer.read_exact(&mut byte)?;
-        Ok(byte[0])
+        let mut bytes = [0u8; 4];
+        buffer.read_exact(&mut bytes)?;
+        Ok(u32::from_le_bytes(bytes))
     }
 }
 


### PR DESCRIPTION
Only when aggregating very few proofs will the acc length fit in a u8. Let's serialize a u32 instead.