### PR TITLE
Clarify the default `srs_dir`

### DIFF
--- a/circuits/CHANGELOG.md
+++ b/circuits/CHANGELOG.md
@@ -23,6 +23,7 @@ verification keys break backwards compatibility.
 * Reduce poseidon identities degree to 5 with an additive selector [#59](https://github.com/midnightntwrk/midnight-zk/pull/59)
 * Updated bincode to v2.0.0 - This is a breaking change [#82](https://github.com/midnightntwrk/midnight-zk/pull/82)
 * Adapted in-circuit verifier to changes of off-circuit counterpart [#76](https://github.com/midnightntwrk/midnight-zk/pull/76)
+* Clarified the default directory to download SRS [#95](https://github.com/midnightntwrk/midnight-zk/pull/95)
 
 ### Removed
 

--- a/circuits/src/utils/plonk_api.rs
+++ b/circuits/src/utils/plonk_api.rs
@@ -285,7 +285,7 @@ pub fn filecoin_srs(k: u32) -> ParamsKZG<Bls12> {
     }
 
     let params_fs = File::open(Path::new(&fetching_path))
-        .unwrap_or_else(|_| panic!("\nIt seems you have not downloaded and/or parsed the SRS from filecoin. Either download it with:
+        .unwrap_or_else(|_| panic!("\nIt seems you have not downloaded and/or parsed the SRS from filecoin. Either download it with (make sure you are under the directory `circuits/` first):
 
             * `curl -L -o {srs_dir}/bls_filecoin_2p19 https://midnight-s3-fileshare-dev-eu-west-1.s3.eu-west-1.amazonaws.com/bls_filecoin_2p19`
 


### PR DESCRIPTION
As we are now under `midnight_zk` repo, the previous default directory to download SRS should be clarified accordingly. 