### PR TITLE
Implement parallel computation for running product polynomial

### DIFF
--- a/proofs/Cargo.toml
+++ b/proofs/Cargo.toml
@@ -32,6 +32,10 @@ name = "zswap_output"
 required-features = ["bench-internal"]
 harness = false
 
+[[bench]]
+name = "par_running_prod"
+harness = false
+
 [dependencies]
 backtrace = { version = "0.3", optional = true }
 ff = { workspace = true }

--- a/proofs/benches/par_running_prod.rs
+++ b/proofs/benches/par_running_prod.rs
@@ -1,0 +1,47 @@
+use criterion::{criterion_group, criterion_main, Criterion};
+use ff::Field;
+use midnight_proofs::utils::arithmetic::parallelize_running_prod;
+use rand::SeedableRng;
+use rand_chacha::ChaCha8Rng;
+
+type F = midnight_curves::Fq;
+
+fn bench_speedup(c: &mut Criterion) {
+    for k in 13..=18 {
+        let n = 1usize << k;
+        let mut rng = ChaCha8Rng::from_seed([0; 32]);
+        let input: Vec<F> = (0..n).map(|_| F::random(&mut rng)).collect();
+
+        let group_name = format!("running_product_k_{}", k);
+        let mut group = c.benchmark_group(&group_name);
+        group.sample_size(100);
+
+        // Benchmark sequential implementation
+        group.bench_function("sequential", |b| {
+            b.iter(|| {
+                let mut result: Vec<F> = Vec::with_capacity(n);
+                result.push(input[0]);
+                for row in 1..n {
+                    let mut tmp = result[row - 1];
+                    tmp *= input[row];
+                    result.push(tmp);
+                }
+                std::hint::black_box(result)
+            });
+        });
+
+        // Benchmark parallel implementation
+        group.bench_function("parallel", |b| {
+            b.iter(|| {
+                let mut data = input.clone();
+                parallelize_running_prod(&mut data, n);
+                std::hint::black_box(data)
+            });
+        });
+
+        group.finish();
+    }
+}
+
+criterion_group!(benches, bench_speedup);
+criterion_main!(benches);

--- a/proofs/src/plonk/permutation/prover.rs
+++ b/proofs/src/plonk/permutation/prover.rs
@@ -12,7 +12,7 @@ use crate::{
         Rotation,
     },
     transcript::{Hashable, Transcript},
-    utils::arithmetic::{eval_polynomial, parallelize, parallelize_prefix_prod},
+    utils::arithmetic::{eval_polynomial, parallelize, parallelize_running_prod},
 };
 
 #[cfg_attr(feature = "bench-internal", derive(Clone))]
@@ -143,9 +143,9 @@ impl Argument {
             aux.push(last_z);
             aux.extend_from_slice(&modified_values[..domain.n as usize - 1]);
 
-            let z = parallelize_prefix_prod(&mut aux, domain.k() as usize);
+            parallelize_running_prod(&mut aux, domain.n as usize);
 
-            let mut z = domain.lagrange_from_vec(z);
+            let mut z = domain.lagrange_from_vec(aux);
             // Set blinding factors
             for z in &mut z[domain.n as usize - blinding_factors..] {
                 *z = F::random(&mut rng);


### PR DESCRIPTION
Although the improvement regarding computing the running product is significient (`2 ~ 4` times speedup when `k = 11, .. 16`), the `commit()` function of permutation argument almost remains the same, since the cost of running product computation is not the bottleneck. Therefore, we discard this PR. See below the benchmark about `zswap circuit`:

- with parallel computation of running product:
   ZSwap Prover/Commit permutation functions
                        time:   [77.289 ms 77.443 ms 77.613 ms]

- initial implementation: 
   ZSwap Prover/Commit permutation functions
                        time:   [78.203 ms 78.444 ms 78.722 ms]