### PR TITLE
Adding AssignedNative conversion

### DIFF
--- a/proofs/CHANGELOG.md
+++ b/proofs/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 ### Added
+* Added a conversion to any AssignedCell to AssignedNative for external crates [#148](https://github.com/midnightntwrk/midnight-zk/pull/148)
 
 ### Changed
 * Address feedback from ZK Sec audit 3 [#125](https://github.com/midnightntwrk/midnight-zk/pull/125)

--- a/proofs/src/circuit/mod.rs
+++ b/proofs/src/circuit/mod.rs
@@ -174,6 +174,25 @@ impl<V: Clone, F: Field> AssignedCell<V, F>
 where
     for<'v> Rational<F>: From<&'v V>,
 {
+    /// Converts any `AssignedCell<V,F>` to an `AssignedNative<F>`, using
+    /// back-and-forth conversion to rationals. All specific information
+    /// specific to the structure of `V` is lost. Can be useful when interacting
+    /// with external circuits that produce `AssignedCell` types that
+    /// `midnight-circuits` cannot interact with.
+    pub fn convert_to_native(self) -> AssignedCell<F, F> {
+        AssignedCell {
+            value: self.value_field(),
+            cell: self.cell,
+            _marker: self._marker,
+        }
+        .evaluate()
+    }
+}
+
+impl<V: Clone, F: Field> AssignedCell<V, F>
+where
+    for<'v> Rational<F>: From<&'v V>,
+{
     /// Copies the value to a given advice cell and constrains them to be equal.
     ///
     /// Returns an error if either this cell or the given cell are in columns


### PR DESCRIPTION
Very short PR adding the possibility to convert any `AssignedCell` into an `AssignedNative`. Necessary to interact with external crates.