### PR TITLE
Allow assignment of a verifying key from a constant verifying key hash

### DIFF
--- a/circuits/CHANGELOG.md
+++ b/circuits/CHANGELOG.md
@@ -14,6 +14,7 @@ verification keys break backwards compatibility.
 ### Added
 * Add Curve25519 [#181](https://github.com/midnightntwrk/midnight-zk/pull/181)
 * `CircuitField` refactor: remove helpers, add `ScalarField` in `CircuitCurve` [#201](https://github.com/midnightntwrk/midnight-zk/pull/201)
+* Add method to assign a verifying key as a constant [#202](https://github.com/midnightntwrk/midnight-zk/pull/202)
 
 ### Changed
 * Change nr of bits to represent JubJub scalar field modulus from 255 -> 252 [#179](https://github.com/midnightntwrk/midnight-zk/pull/179)


### PR DESCRIPTION
Add `VerifierGadget::assign_vk_to_fixed` in `circuits/src/verifier/verifier_gadget.rs` to allow assigning a verifying key to a fixed verifying key hash.
