### PR TITLE
Parallelise batch verifier

### DIFF
--- a/zk_stdlib/CHANGELOG.md
+++ b/zk_stdlib/CHANGELOG.md
@@ -21,6 +21,7 @@ verification keys break backwards compatibility.
 * Updated Rust toolchain to 1.90.0 [#210](https://github.com/midnightntwrk/midnight-zk/pull/210)
 * `CircuitField` refactor  [#201](https://github.com/midnightntwrk/midnight-zk/pull/201)
 * Replace `secp256k1` with `k256`  [#192](https://github.com/midnightntwrk/midnight-zk/pull/192)
+* Parallelise batch_verifier [#236](https://github.com/midnightntwrk/midnight-zk/pull/236)
 
 ### Removed
 * Move Blake2b and SHA3-256/Keccak256 implementations to zk-stdlib [#178](https://github.com/midnightntwrk/midnight-zk/pull/178)

--- a/zk_stdlib/Cargo.toml
+++ b/zk_stdlib/Cargo.toml
@@ -24,6 +24,7 @@ blake2b = { package = "blake2b_halo2", version = "0.1.0" }
 serde = { workspace = true, optional = true }
 sha2 = { workspace = true }
 rand = { workspace = true }
+rayon = { workspace = true }
 
 num-bigint = { version = "0.4" }
 num-traits = "0.2"

--- a/zk_stdlib/Cargo.toml
+++ b/zk_stdlib/Cargo.toml
@@ -61,6 +61,10 @@ truncated-challenges = [
 [lib]
 bench = false
 
+[[bench]]
+name = "verify"
+harness = false
+
 [[example]]
 name = "cred_full"
 path = "examples/identity/full_credential.rs"

--- a/zk_stdlib/benches/verify.rs
+++ b/zk_stdlib/benches/verify.rs
@@ -1,0 +1,126 @@
+//! Benchmarks for single and batch proof verification.
+
+#[macro_use]
+extern crate criterion;
+
+use criterion::{BenchmarkId, Criterion, Throughput};
+use ff::Field;
+use midnight_circuits::{
+    hash::poseidon::PoseidonChip,
+    instructions::{hash::HashCPU, AssignmentInstructions, PublicInputInstructions},
+};
+use midnight_proofs::{
+    circuit::{Layouter, Value},
+    plonk::Error,
+};
+use midnight_zk_stdlib::{utils::plonk_api::filecoin_srs, Relation, ZkStdLib, ZkStdLibArch};
+use rand::{rngs::OsRng, SeedableRng};
+use rand_chacha::ChaCha8Rng;
+
+type F = midnight_curves::Fq;
+
+/// Minimal Poseidon circuit used as the benchmark relation.
+#[derive(Clone, Default)]
+struct PoseidonBench;
+
+impl Relation for PoseidonBench {
+    type Instance = F;
+    type Witness = [F; 3];
+
+    fn format_instance(instance: &Self::Instance) -> Result<Vec<F>, Error> {
+        Ok(vec![*instance])
+    }
+
+    fn circuit(
+        &self,
+        std_lib: &ZkStdLib,
+        layouter: &mut impl Layouter<F>,
+        _instance: Value<Self::Instance>,
+        witness: Value<Self::Witness>,
+    ) -> Result<(), Error> {
+        let assigned_message = std_lib.assign_many(layouter, &witness.transpose_array())?;
+        let output = std_lib.poseidon(layouter, &assigned_message)?;
+        std_lib.constrain_as_public_input(layouter, &output)
+    }
+
+    fn used_chips(&self) -> ZkStdLibArch {
+        ZkStdLibArch {
+            poseidon: true,
+            sha2_256: true,
+            ..ZkStdLibArch::default()
+        }
+    }
+
+    fn write_relation<W: std::io::Write>(&self, _writer: &mut W) -> std::io::Result<()> {
+        Ok(())
+    }
+
+    fn read_relation<R: std::io::Read>(_reader: &mut R) -> std::io::Result<Self> {
+        Ok(PoseidonBench)
+    }
+}
+
+const BATCH_SIZE: usize = 25;
+
+fn bench_verify(c: &mut Criterion) {
+    let srs = filecoin_srs(6);
+    let relation = PoseidonBench;
+    let vk = midnight_zk_stdlib::setup_vk(&srs, &relation);
+    let pk = midnight_zk_stdlib::setup_pk(&relation, &vk);
+    let params_verifier = srs.verifier_params();
+
+    let proofs: Vec<(F, Vec<u8>)> = (0..BATCH_SIZE)
+        .map(|_| {
+            let mut rng = ChaCha8Rng::from_entropy();
+            let witness: [F; 3] = core::array::from_fn(|_| F::random(&mut rng));
+            let instance = <PoseidonChip<F> as HashCPU<F, F>>::hash(&witness);
+            let proof = midnight_zk_stdlib::prove::<PoseidonBench, blake2b_simd::State>(
+                &srs, &pk, &relation, &instance, witness, OsRng,
+            )
+            .expect("proof generation failed");
+            (instance, proof)
+        })
+        .collect();
+
+    let vks: Vec<_> = (0..BATCH_SIZE).map(|_| vk.clone()).collect();
+    let pis: Vec<Vec<F>> = proofs
+        .iter()
+        .map(|(inst, _)| PoseidonBench::format_instance(inst).expect("format_instance failed"))
+        .collect();
+    let proof_bytes: Vec<Vec<u8>> = proofs.iter().map(|(_, p)| p.clone()).collect();
+
+    let (instance, proof) = &proofs[0];
+    let mut group = c.benchmark_group("verify");
+    group.sample_size(20);
+    group.throughput(Throughput::Elements(1));
+    group.bench_function("single", |b| {
+        b.iter(|| {
+            midnight_zk_stdlib::verify::<PoseidonBench, blake2b_simd::State>(
+                &params_verifier,
+                &vk,
+                instance,
+                None,
+                proof,
+            )
+            .expect("verify failed");
+        });
+    });
+
+    group.throughput(Throughput::Elements(BATCH_SIZE as u64));
+    group.bench_function(BenchmarkId::new("batch", BATCH_SIZE), |b| {
+        b.iter(|| {
+            midnight_zk_stdlib::batch_verify::<blake2b_simd::State>(
+                &params_verifier,
+                &vks,
+                &pis,
+                &proof_bytes,
+            )
+            .expect("batch_verify failed");
+        });
+    });
+
+    group.finish();
+}
+
+criterion_group!(benches, bench_verify);
+criterion_main!(benches);

--- a/zk_stdlib/src/lib.rs
+++ b/zk_stdlib/src/lib.rs
@@ -1875,7 +1875,7 @@ where
         .for_each(|(i, guard)| guard.scale(powers[i]));
 
     // Phase 4: add scaled guards sequentially.
-    let mut acc_guard = guards.remove(0);
+    let mut acc_guard = guards.pop();
     for guard in guards {
         acc_guard.add_msm(guard);
     }

--- a/zk_stdlib/src/lib.rs
+++ b/zk_stdlib/src/lib.rs
@@ -1808,7 +1808,7 @@ where
 /// in raw format (`Vec<F>`).
 ///
 /// Returns `Ok(())` if all proofs are valid.
-pub fn batch_verify<H: TranscriptHash>(
+pub fn batch_verify<H: TranscriptHash + Send + Sync>(
     params_verifier: &ParamsVerifierKZG<midnight_curves::Bls12>,
     vks: &[MidnightVK],
     pis: &[Vec<F>],
@@ -1818,6 +1818,8 @@ where
     G1Projective: Hashable<H>,
     F: Hashable<H> + Sampleable<H>,
 {
+    use rayon::prelude::*;
+
     // TODO: For the moment, committed instances are not supported.
     let n = vks.len();
     if pis.len() != n || proofs.len() != n {
@@ -1825,12 +1827,10 @@ where
         return Err(Error::InvalidInstances);
     }
 
-    let mut r_transcript = CircuitTranscript::init();
-
-    let guards = vks
-        .iter()
-        .zip(pis.iter())
-        .zip(proofs.iter())
+    let prepared: Vec<(_, F)> = vks
+        .par_iter()
+        .zip(pis.par_iter())
+        .zip(proofs.par_iter())
         .map(|((vk, pi), proof)| {
             if pi.len() != vk.nb_public_inputs {
                 return Err(Error::InvalidInstances);
@@ -1849,17 +1849,34 @@ where
                 &mut transcript,
             )?;
             let summary: F = transcript.squeeze_challenge();
-            r_transcript.common(&summary)?;
             transcript.assert_empty().map_err(|_| Error::Opening)?;
-            Ok(dual_msm)
+            Ok((dual_msm, summary))
         })
         .collect::<Result<Vec<_>, Error>>()?;
 
-    let r = r_transcript.squeeze_challenge();
+    let mut r_transcript = CircuitTranscript::init();
+    let mut guards = Vec::with_capacity(n);
+    for (guard, summary) in prepared {
+        r_transcript.common(&summary)?;
+        guards.push(guard);
+    }
+    let r: F = r_transcript.squeeze_challenge();
 
-    let mut acc_guard = guards[0].clone();
-    for guard in guards.into_iter().skip(1) {
-        acc_guard.scale(r);
+    let n_guards = guards.len();
+    let mut powers = Vec::with_capacity(n_guards);
+    let mut p = <F as ff::Field>::ONE;
+    for _ in 0..n_guards {
+        powers.push(p);
+        p *= r;
+    }
+    guards
+        .par_iter_mut()
+        .enumerate()
+        .for_each(|(i, guard)| guard.scale(powers[i]));
+
+    // Phase 4: add scaled guards sequentially.
+    let mut acc_guard = guards.remove(0);
+    for guard in guards {
         acc_guard.add_msm(guard);
     }
     // TODO: Have richer error types

--- a/zk_stdlib/src/lib.rs
+++ b/zk_stdlib/src/lib.rs
@@ -1869,10 +1869,7 @@ where
         powers.push(p);
         p *= r;
     }
-    guards
-        .par_iter_mut()
-        .enumerate()
-        .for_each(|(i, guard)| guard.scale(powers[i]));
+    guards.par_iter_mut().enumerate().for_each(|(i, guard)| guard.scale(powers[i]));
 
     // Phase 4: add scaled guards sequentially.
     let mut acc_guard = guards.pop();

--- a/zk_stdlib/src/lib.rs
+++ b/zk_stdlib/src/lib.rs
@@ -36,7 +36,7 @@ use blake2b::blake2b::{
     blake2b_chip::{Blake2bChip, Blake2bConfig},
     NB_BLAKE2B_ADVICE_COLS,
 };
-use ff::PrimeField;
+use ff::{Field, PrimeField};
 use group::{prime::PrimeCurveAffine, Group};
 use keccak_sha3::packed_chip::{PackedChip, PackedConfig, PACKED_ADVICE_COLS, PACKED_FIXED_COLS};
 use midnight_circuits::{
@@ -1863,16 +1863,14 @@ where
     let r: F = r_transcript.squeeze_challenge();
 
     let n_guards = guards.len();
-    let mut powers = Vec::with_capacity(n_guards);
-    let mut p = <F as ff::Field>::ONE;
-    for _ in 0..n_guards {
-        powers.push(p);
-        p *= r;
-    }
+    let powers: Vec<F> =
+        std::iter::successors(Some(F::ONE), |p| Some(*p * r)).take(n_guards).collect();
     guards.par_iter_mut().enumerate().for_each(|(i, guard)| guard.scale(powers[i]));
 
     // Phase 4: add scaled guards sequentially.
-    let mut acc_guard = guards.pop();
+    let Some(mut acc_guard) = guards.pop() else {
+        return Ok(());
+    };
     for guard in guards {
         acc_guard.add_msm(guard);
     }


### PR DESCRIPTION
By paralellising the batch_verifier, we achieve an 80% performance improvement for batches of 25 proofs: 

```
verify/single           time:   [2.8947 ms 2.9161 ms 2.9324 ms]
                        thrpt:  [341.02  elem/s 342.93  elem/s 345.46  elem/s]
                 change:
                        time:   [−0.9977% −0.1449% +0.6960%] (p = 0.75 > 0.05)
                        thrpt:  [−0.6911% +0.1451% +1.0077%]
                        No change in performance detected.
verify/batch/25         time:   [10.958 ms 11.207 ms 11.478 ms]
                        thrpt:  [2.1780 Kelem/s 2.2308 Kelem/s 2.2814 Kelem/s]
                 change:
                        time:   [−79.585% −78.965% −78.138%] (p = 0.00 < 0.05)
                        thrpt:  [+357.41% +375.39% +389.83%]
                        Performance has improved.
```