### PR TITLE
Fix `assigned_to_le` functions in field chip

### DIFF
--- a/circuits/CHANGELOG.md
+++ b/circuits/CHANGELOG.md
@@ -62,6 +62,7 @@ verification keys break backwards compatibility.
 * Optimize `linear_combination` in `NativeChip` [#260](https://github.com/midnightntwrk/midnight-zk/pull/260)
 * Optimize `mul` and `square` in `BigUintGadget` with `F::add_and_mul` [#260](https://github.com/midnightntwrk/midnight-zk/pull/260)
 * Adapt `foreign_params_gen.py` to general Weierstrass equations [#282](https://github.com/midnightntwrk/midnight-zk/pull/282)
+* Fix `assigned_to_le` functions in field chip [#303](https://github.com/midnightntwrk/midnight-zk/pull/303)
 
 ### Removed
 * Move external implementations to zk-stdlib [#178](https://github.com/midnightntwrk/midnight-zk/pull/178)

--- a/circuits/src/field/foreign/field_chip.rs
+++ b/circuits/src/field/foreign/field_chip.rs
@@ -1158,7 +1158,7 @@ where
         bits = bits[0..nb_bits].to_vec();
 
         // The case nb_bits > K::NUM_BITS cannot happen since by above definition
-        // nb_bits = min(K::NUM_BITS,...), and thus nb_bits <= K::NUM_BITS
+        // nb_bits = min(K::NUM_BITS,...), and thus nb_bits <= K::NUM_BITS.
         if enforce_canonical && nb_bits == K::NUM_BITS as usize {
             let canonical = self.is_canonical(layouter, &bits)?;
             self.assert_equal_to_fixed(layouter, &canonical, true)?;

--- a/circuits/src/field/foreign/field_chip.rs
+++ b/circuits/src/field/foreign/field_chip.rs
@@ -1145,14 +1145,19 @@ where
             .into_iter()
             .for_each(|new_bits| bits.extend(new_bits));
 
+        let nb_bits = min(
+            K::NUM_BITS as usize,
+            nb_bits.unwrap_or(K::NUM_BITS as usize),
+        );
+
         // Drop the most significant bits up to the desired length, but make sure
         // they encode 0.
-        let nb_bits = nb_bits.unwrap_or(K::NUM_BITS as usize);
         bits[nb_bits..]
             .iter()
             .try_for_each(|byte| self.native_gadget.assert_equal_to_fixed(layouter, byte, false))?;
-        let bits = bits[0..nb_bits].to_vec();
-        if enforce_canonical && nb_bits >= K::NUM_BITS as usize {
+        bits = bits[0..nb_bits].to_vec();
+
+        if enforce_canonical && nb_bits == K::NUM_BITS as usize {
             let canonical = self.is_canonical(layouter, &bits)?;
             self.assert_equal_to_fixed(layouter, &canonical, true)?;
         }

--- a/circuits/src/field/foreign/field_chip.rs
+++ b/circuits/src/field/foreign/field_chip.rs
@@ -1157,6 +1157,8 @@ where
             .try_for_each(|byte| self.native_gadget.assert_equal_to_fixed(layouter, byte, false))?;
         bits = bits[0..nb_bits].to_vec();
 
+        // The case nb_bits > K::NUM_BITS cannot happen since by above definition
+        // nb_bits = min(K::NUM_BITS,...), and thus nb_bits <= K::NUM_BITS
         if enforce_canonical && nb_bits == K::NUM_BITS as usize {
             let canonical = self.is_canonical(layouter, &bits)?;
             self.assert_equal_to_fixed(layouter, &canonical, true)?;

--- a/circuits/src/instructions/decomposition.rs
+++ b/circuits/src/instructions/decomposition.rs
@@ -112,8 +112,9 @@ where
     /// constraints.
     ///
     /// The number of bytes (the length of the resulting vector) can be
-    /// specified, but will be capped at `ceil(Self::Assigned::Element::NUM_BITS
-    /// / 8)`. If unspecified, the resulting vector will contain exactly
+    /// specified, but will be capped at
+    /// `ceil(Self::Assigned::Element::NUM_BITS / 8)`. If unspecified, the
+    /// resulting vector will contain exactly
     /// `ceil(Self::Assigned::Element::NUM_BITS / 8)` bytes (the minimum number
     /// of bytes necessary to represent any element).
     ///

--- a/circuits/src/instructions/decomposition.rs
+++ b/circuits/src/instructions/decomposition.rs
@@ -45,7 +45,8 @@ where
     /// element in little-endian.
     ///
     /// The number of bits (the length of the resulting vector) can be
-    /// specified. If unspecified, the resulting vector will contain exactly
+    /// specified, but will be capped at `Self::Assigned::Element::NUM_BITS`. If
+    /// unspecified, the resulting vector will contain exactly
     /// `Self::Assigned::Element::NUM_BITS` bits (the minimum number of bits
     /// necessary to represent any element).
     ///
@@ -111,7 +112,8 @@ where
     /// constraints.
     ///
     /// The number of bytes (the length of the resulting vector) can be
-    /// specified. If unspecified, the resulting vector will contain exactly
+    /// specified, but will be capped at `ceil(Self::Assigned::Element::NUM_BITS
+    /// / 8)`. If unspecified, the resulting vector will contain exactly
     /// `ceil(Self::Assigned::Element::NUM_BITS / 8)` bytes (the minimum number
     /// of bytes necessary to represent any element).
     ///


### PR DESCRIPTION
# The Problem
When calling `assigned_to_le_bytes` or `assigned_to_le_bits` with `nb_bits` exceeding `K::NUM_BITS`, the functions cause an index-out-of-bound error when trying to access the `bits` vector at an invalid index:

```
// Drop the most significant bits up to the desired length, but make sure they encode 0.
bits[nb_bits..]
    .iter()
    .try_for_each(|byte| self.native_gadget.assert_equal_to_fixed(layouter, byte, false))?;
bits = bits[0..nb_bits].to_vec();
```
# The Proposed Fix
Always cap the specified bit length via `nb_bits` at `K::NUM_BITS`:

```
let nb_bits = min(
    K::NUM_BITS as usize,
    nb_bits.unwrap_or(K::NUM_BITS as usize),
);
```

# Another Solution
If `nb_bits` is strictly greater than `K::NUM_BITS`, pad the resulting vector with 0 bits up to the requested length. But in the function `assigned_to_le_bits` panic if `enforce_canonical && nb_bits > K::NUM_BITS`.