### PR TITLE
fix: replace assert_eq! with error return in public_inputs

### DIFF
--- a/zkir/src/zkir.rs
+++ b/zkir/src/zkir.rs
@@ -70,7 +70,13 @@ impl ZkirRelation {
         // in-circuit parser pass.
         dummy_synthesize_run(&MidnightCircuit::from_relation(self, None))?;
         let pi_types = self.public_input_types.borrow().clone();
-        assert_eq!(pis.len(), pi_types.len());
+        if pis.len() != pi_types.len() {
+            return Err(Error::Other(format!(
+            "public input count mismatch: {} values vs {} types",
+            pis.len(),
+            pi_types.len()
+            )));
+    }
         Ok(pis.into_iter().zip(pi_types).collect())
     }
 }


### PR DESCRIPTION
A panic here is inconsistent with the rest of the function which uses ? and returns Result. Library code should propagate errors rather than panic on unexpected state.