### PR TITLE
Passport verification (2/5) – library asjustments

### DIFF
--- a/circuits/CHANGELOG.md
+++ b/circuits/CHANGELOG.md
@@ -15,6 +15,7 @@ verification keys break backwards compatibility.
 * `FromScratch::configure_from_scratch` now takes shared `advice_columns` and `fixed_columns` pools [#306](https://github.com/midnightntwrk/midnight-zk/pull/306)
 * Optimize foreign Edwards MSM: windowed scalar multiplication and improved point addition [#305](https://github.com/midnightntwrk/midnight-zk/pull/305)
 * Refactoring static specs to handle more identity-related examples [#330](https://github.com/midnightntwrk/midnight-zk/pull/330)
+* Boxing assigned vectors to assign overflows [#331](https://github.com/midnightntwrk/midnight-zk/pull/331)
 
 ### Added
 * Add functions to mark the region of a circuit to be measured for cost modelling [#296](https://github.com/midnightntwrk/midnight-zk/pull/296)

--- a/circuits/goldenfiles/cost-model.json
+++ b/circuits/goldenfiles/cost-model.json
@@ -141,7 +141,7 @@
       "max_deg": "5",
       "permutations": "10",
       "point_sets": "4",
-      "rows": "910",
+      "rows": "914",
       "table_rows": "99"
     }
   },

--- a/circuits/src/biguint/biguint_gadget.rs
+++ b/circuits/src/biguint/biguint_gadget.rs
@@ -562,7 +562,7 @@ where
     }
 
     /// Returns a vector of assigned bits representing the given assigned big
-    /// unsigned integer little-endian.
+    /// unsigned integer in little-endian order.
     pub fn to_le_bits(
         &self,
         layouter: &mut impl Layouter<F>,
@@ -589,8 +589,22 @@ where
         Ok(bits)
     }
 
+    /// Returns a vector of assigned bits representing the given assigned big
+    /// unsigned integer in big-endian order. Delegates to
+    /// [`to_le_bits`](Self::to_le_bits) and reverses the result.
+    pub fn to_be_bits(
+        &self,
+        layouter: &mut impl Layouter<F>,
+        x: &AssignedBigUint<F>,
+    ) -> Result<Vec<AssignedBit<F>>, Error> {
+        let mut bits = self.to_le_bits(layouter, x)?;
+        bits.reverse();
+
+        Ok(bits)
+    }
+
     /// Returns a vector of assigned bytes representing the given assigned big
-    /// unsigned integer little-endian.
+    /// unsigned integer in little-endian order.
     #[allow(clippy::assertions_on_constants)]
     pub fn to_le_bytes(
         &self,
@@ -615,8 +629,22 @@ where
         Ok(bytes)
     }
 
+    /// Returns a vector of assigned bytes representing the given assigned big
+    /// unsigned integer in big-endian order. Delegates to
+    /// [`to_le_bytes`](Self::to_le_bytes) and reverses the result.
+    #[allow(clippy::assertions_on_constants)]
+    pub fn to_be_bytes(
+        &self,
+        layouter: &mut impl Layouter<F>,
+        x: &AssignedBigUint<F>,
+    ) -> Result<Vec<AssignedByte<F>>, Error> {
+        let mut bytes = self.to_le_bytes(layouter, x)?;
+        bytes.reverse();
+        Ok(bytes)
+    }
+
     /// Returns the assigned big unsigned integer represented by the given
-    /// vector of assigned bits, by interpreting it in little-endian.
+    /// vector of assigned bits, by interpreting it in little-endian order.
     pub fn from_le_bits(
         &self,
         layouter: &mut impl Layouter<F>,
@@ -639,7 +667,21 @@ where
     }
 
     /// Returns the assigned big unsigned integer represented by the given
-    /// vector of assigned bytes, by interpreting it in little-endian.
+    /// vector of assigned bits, by interpreting it in big-endian order.
+    /// Delegates to [`from_le_bits`](Self::from_le_bits) with the input
+    /// reversed.
+    pub fn from_be_bits(
+        &self,
+        layouter: &mut impl Layouter<F>,
+        bits: &[AssignedBit<F>],
+    ) -> Result<AssignedBigUint<F>, Error> {
+        let mut bits = bits.to_vec();
+        bits.reverse();
+        self.from_le_bits(layouter, &bits)
+    }
+
+    /// Returns the assigned big unsigned integer represented by the given
+    /// vector of assigned bytes, by interpreting it in little-endian order.
     #[allow(clippy::assertions_on_constants)]
     pub fn from_le_bytes(
         &self,
@@ -663,6 +705,21 @@ where
             limbs,
             limb_size_bounds,
         })
+    }
+
+    /// Returns the assigned big unsigned integer represented by the given
+    /// vector of assigned bytes, by interpreting it in big-endian order.
+    /// Delegates to [`from_le_bytes`](Self::from_le_bytes) with the input
+    /// reversed.
+    #[allow(clippy::assertions_on_constants)]
+    pub fn from_be_bytes(
+        &self,
+        layouter: &mut impl Layouter<F>,
+        bytes: &[AssignedByte<F>],
+    ) -> Result<AssignedBigUint<F>, Error> {
+        let mut bytes = bytes.to_vec();
+        bytes.reverse();
+        self.from_le_bytes(layouter, &bytes)
     }
 
     /// Returns `1` iff `x < y`.

--- a/circuits/src/biguint/biguint_gadget.rs
+++ b/circuits/src/biguint/biguint_gadget.rs
@@ -590,8 +590,7 @@ where
     }
 
     /// Returns a vector of assigned bits representing the given assigned big
-    /// unsigned integer in big-endian order. Delegates to
-    /// [`to_le_bits`](Self::to_le_bits) and reverses the result.
+    /// unsigned integer in big-endian order.
     pub fn to_be_bits(
         &self,
         layouter: &mut impl Layouter<F>,
@@ -599,7 +598,6 @@ where
     ) -> Result<Vec<AssignedBit<F>>, Error> {
         let mut bits = self.to_le_bits(layouter, x)?;
         bits.reverse();
-
         Ok(bits)
     }
 
@@ -630,8 +628,7 @@ where
     }
 
     /// Returns a vector of assigned bytes representing the given assigned big
-    /// unsigned integer in big-endian order. Delegates to
-    /// [`to_le_bytes`](Self::to_le_bytes) and reverses the result.
+    /// unsigned integer in big-endian order.
     #[allow(clippy::assertions_on_constants)]
     pub fn to_be_bytes(
         &self,
@@ -668,8 +665,6 @@ where
 
     /// Returns the assigned big unsigned integer represented by the given
     /// vector of assigned bits, by interpreting it in big-endian order.
-    /// Delegates to [`from_le_bits`](Self::from_le_bits) with the input
-    /// reversed.
     pub fn from_be_bits(
         &self,
         layouter: &mut impl Layouter<F>,
@@ -709,8 +704,6 @@ where
 
     /// Returns the assigned big unsigned integer represented by the given
     /// vector of assigned bytes, by interpreting it in big-endian order.
-    /// Delegates to [`from_le_bytes`](Self::from_le_bytes) with the input
-    /// reversed.
     #[allow(clippy::assertions_on_constants)]
     pub fn from_be_bytes(
         &self,

--- a/circuits/src/hash/poseidon/constants/mod.rs
+++ b/circuits/src/hash/poseidon/constants/mod.rs
@@ -17,7 +17,7 @@ use crate::CircuitField;
 pub(crate) const WIDTH: usize = 3;
 
 /// Hash rate of Poseidon.
-pub(crate) const RATE: usize = 2;
+pub const RATE: usize = 2;
 
 /// Number of full rounds of the Poseidon permutation.
 pub(crate) const NB_FULL_ROUNDS: usize = 8;

--- a/circuits/src/hash/poseidon/poseidon_varlen.rs
+++ b/circuits/src/hash/poseidon/poseidon_varlen.rs
@@ -94,37 +94,12 @@ impl<F: PoseidonField> VarLenPoseidonGadget<F> {
         Ok(result)
     }
 
-    /// Format the last chunk of data so it is zeroed after the effective
-    /// payload. Given chunk = [x1, x2, ..., xn], with n = RATE, returns
-    /// [x1, ..., x_{offset-1}, 0, ..., 0]. If offset = 0, the chunk is
-    /// returned intact.
-    fn constrain_last_chunk(
-        &self,
-        layouter: &mut impl Layouter<F>,
-        chunk: &[AssignedNative<F>],
-        offset: &AssignedNative<F>,
-    ) -> Result<Vec<AssignedNative<F>>, Error> {
-        assert_eq!(chunk.len(), RATE);
-        let ng = &self.native_gadget;
-
-        let mut chunk = chunk.to_vec();
-        let zero = ng.assign_fixed(layouter, F::ZERO)?;
-        let mut after_data: AssignedBit<F> = ng.assign_fixed(layouter, false)?;
-        for (i, elem) in chunk.iter_mut().enumerate().skip(1) {
-            let b = ng.is_equal_to_fixed(layouter, offset, F::from(i as u64))?;
-            after_data = ng.xor(layouter, &[b, after_data])?;
-            *elem = ng.select(layouter, &after_data, &zero, elem)?;
-        }
-
-        Ok(chunk)
-    }
-
     /// Hashes the variable-length vector inputs.
     ///
     /// # Panics
     ///
     /// If `MAX_LEN` is not a multiple of `RATE`.
-    pub(crate) fn poseidon_varlen<const MAX_LEN: usize>(
+    pub fn poseidon_varlen<const MAX_LEN: usize>(
         &self,
         layouter: &mut impl Layouter<F>,
         input: &AssignedVector<F, AssignedNative<F>, MAX_LEN, RATE>,
@@ -165,13 +140,7 @@ impl<F: PoseidonField> VarLenPoseidonGadget<F> {
             )?;
             updating = ng.xor(layouter, &[b, updating])?;
 
-            register = if i == MAX_LEN / RATE {
-                // Constrain vector filler values in the last chunk.
-                let last_chunk = self.constrain_last_chunk(layouter, chunk, &last_chunk_len)?;
-                self.cond_update(layouter, &register, &last_chunk, &updating)?
-            } else {
-                self.cond_update(layouter, &register, chunk, &updating)?
-            }
+            register = self.cond_update(layouter, &register, chunk, &updating)?;
         }
         Ok(register[0].clone())
     }

--- a/circuits/src/hash/poseidon/poseidon_varlen.rs
+++ b/circuits/src/hash/poseidon/poseidon_varlen.rs
@@ -94,6 +94,31 @@ impl<F: PoseidonField> VarLenPoseidonGadget<F> {
         Ok(result)
     }
 
+    /// Format the last chunk of data so it is zeroed after the effective
+    /// payload. Given chunk = [x1, x2, ..., xn], with n = RATE, returns
+    /// [x1, ..., x_{offset}, 0, ..., 0]. If offset = 0, the chunk is
+    /// returned intact.
+    fn constrain_last_chunk(
+        &self,
+        layouter: &mut impl Layouter<F>,
+        chunk: &[AssignedNative<F>],
+        offset: &AssignedNative<F>,
+    ) -> Result<Vec<AssignedNative<F>>, Error> {
+        assert_eq!(chunk.len(), RATE);
+        let ng = &self.native_gadget;
+
+        let mut chunk = chunk.to_vec();
+        let zero = ng.assign_fixed(layouter, F::ZERO)?;
+        let mut after_data: AssignedBit<F> = ng.assign_fixed(layouter, false)?;
+        for (i, elem) in chunk.iter_mut().enumerate().skip(1) {
+            let b = ng.is_equal_to_fixed(layouter, offset, F::from(i as u64))?;
+            after_data = ng.xor(layouter, &[b, after_data])?;
+            *elem = ng.select(layouter, &after_data, &zero, elem)?;
+        }
+
+        Ok(chunk)
+    }
+
     /// Hashes the variable-length vector inputs.
     ///
     /// # Panics
@@ -140,7 +165,12 @@ impl<F: PoseidonField> VarLenPoseidonGadget<F> {
             )?;
             updating = ng.xor(layouter, &[b, updating])?;
 
-            register = self.cond_update(layouter, &register, chunk, &updating)?;
+            register = if i == MAX_LEN / RATE - 1 {
+                let last_chunk = self.constrain_last_chunk(layouter, chunk, &last_chunk_len)?;
+                self.cond_update(layouter, &register, &last_chunk, &updating)?
+            } else {
+                self.cond_update(layouter, &register, chunk, &updating)?
+            };
         }
         Ok(register[0].clone())
     }

--- a/circuits/src/hash/sha256/sha256_chip.rs
+++ b/circuits/src/hash/sha256/sha256_chip.rs
@@ -135,6 +135,16 @@ pub struct Sha256Chip<F: CircuitField> {
     pub(super) native_gadget: NativeGadget<F, P2RDecompositionChip<F>, NativeChip<F>>,
 }
 
+impl<F: CircuitField> Sha256Chip<F> {
+    /// Returns a [`VarLenSha256Gadget`] wrapping this chip for variable-length
+    /// hashing.
+    pub fn varlen_gadget(&self) -> super::VarLenSha256Gadget<F> {
+        super::VarLenSha256Gadget {
+            sha256chip: self.clone(),
+        }
+    }
+}
+
 impl<F: CircuitField> Chip<F> for Sha256Chip<F> {
     type Config = Sha256Config;
     type Loaded = ();

--- a/circuits/src/hash/sha256/sha256_chip.rs
+++ b/circuits/src/hash/sha256/sha256_chip.rs
@@ -136,8 +136,8 @@ pub struct Sha256Chip<F: CircuitField> {
 }
 
 impl<F: CircuitField> Sha256Chip<F> {
-    /// Returns a [`VarLenSha256Gadget`] wrapping this chip for variable-length
-    /// hashing.
+    /// Returns a [`VarLenSha256Gadget`](super::VarLenSha256Gadget) wrapping
+    /// this chip for variable-length hashing.
     pub fn varlen_gadget(&self) -> super::VarLenSha256Gadget<F> {
         super::VarLenSha256Gadget {
             sha256chip: self.clone(),

--- a/circuits/src/hash/sha256/sha256_chip.rs
+++ b/circuits/src/hash/sha256/sha256_chip.rs
@@ -135,16 +135,6 @@ pub struct Sha256Chip<F: CircuitField> {
     pub(super) native_gadget: NativeGadget<F, P2RDecompositionChip<F>, NativeChip<F>>,
 }
 
-impl<F: CircuitField> Sha256Chip<F> {
-    /// Returns a [`VarLenSha256Gadget`](super::VarLenSha256Gadget) wrapping
-    /// this chip for variable-length hashing.
-    pub fn varlen_gadget(&self) -> super::VarLenSha256Gadget<F> {
-        super::VarLenSha256Gadget {
-            sha256chip: self.clone(),
-        }
-    }
-}
-
 impl<F: CircuitField> Chip<F> for Sha256Chip<F> {
     type Config = Sha256Config;
     type Loaded = ();

--- a/circuits/src/hash/sha256/sha256_varlen.rs
+++ b/circuits/src/hash/sha256/sha256_varlen.rs
@@ -40,6 +40,15 @@ pub struct VarLenSha256Gadget<F: CircuitField> {
 }
 
 impl<F: CircuitField> VarLenSha256Gadget<F> {
+    /// Create a new variable-length SHA256 gadget from its dependencies.
+    pub fn new(sha256chip: &Sha256Chip<F>) -> Self {
+        Self {
+            sha256chip: sha256chip.clone(),
+        }
+    }
+}
+
+impl<F: CircuitField> VarLenSha256Gadget<F> {
     fn ng(&self) -> &NativeGadget<F, P2RDecompositionChip<F>, NativeChip<F>> {
         &self.sha256chip.native_gadget
     }

--- a/circuits/src/instructions/mod.rs
+++ b/circuits/src/instructions/mod.rs
@@ -60,5 +60,5 @@ pub use public_input::PublicInputInstructions;
 pub use range_check::RangeCheckInstructions;
 pub use scalar_field::ScalarFieldInstructions;
 pub use sponge::{SpongeCPU, SpongeInstructions};
-pub use vector::VectorInstructions;
+pub use vector::{VectorBounds, VectorInstructions};
 pub use zero::ZeroInstructions;

--- a/circuits/src/instructions/vector.rs
+++ b/circuits/src/instructions/vector.rs
@@ -29,6 +29,10 @@ use crate::{
     CircuitField,
 };
 
+/// Indicator of the number of filler elements at the beginning and end of an
+/// assigned vector's buffer, as returned by `get_limits`.
+pub type VectorBounds<F> = (AssignedNative<F>, AssignedNative<F>);
+
 /// Instructions for Vector manipulation..
 pub trait VectorInstructions<F, T, const M: usize, const A: usize>
 where
@@ -75,16 +79,19 @@ where
 
     /// Returns a vector of AssignedBits signaling the cells that represent
     /// padding with a 1, and the ones that represent payload data with a 0.
+    /// Also returns the (start, end) limits of the data in the buffer, since
+    /// they are computed internally.
+    #[allow(clippy::type_complexity)]
     fn padding_flag(
         &self,
         layouter: &mut impl Layouter<F>,
         input: &AssignedVector<F, T, M, A>,
-    ) -> Result<[AssignedBit<F>; M], Error>;
+    ) -> Result<(Box<[AssignedBit<F>; M]>, VectorBounds<F>), Error>;
 
     /// Returns the first and last positions of data in the buffer.
     fn get_limits(
         &self,
         layouter: &mut impl Layouter<F>,
         input: &AssignedVector<F, T, M, A>,
-    ) -> Result<(AssignedNative<F>, AssignedNative<F>), Error>;
+    ) -> Result<VectorBounds<F>, Error>;
 }

--- a/circuits/src/parsing/base64_chip.rs
+++ b/circuits/src/parsing/base64_chip.rs
@@ -173,7 +173,7 @@ impl<F: CircuitField, const M: usize, const A: usize> Base64VarInstructions<F, M
         let ng = &self.native_gadget;
         let vg = &self.vector_gadget;
         let filler = ng.assign_fixed(layouter, ALT_PAD as u8)?;
-        let flags = vg.padding_flag(layouter, vec)?;
+        let (flags, _limits) = vg.padding_flag(layouter, vec)?;
         let result = vec
             .buffer
             .iter()
@@ -193,10 +193,10 @@ impl<F: CircuitField, const M: usize, const A: usize> Base64VarInstructions<F, M
         layouter: &mut impl Layouter<F>,
         b64url_input: &Base64Vec<F, M, A>,
     ) -> Result<AssignedVector<F, AssignedByte<F>, M_OUT, A_OUT>, Error> {
-        let vec = self.url_to_standard(layouter, &b64url_input.0.buffer)?;
+        let vec = self.url_to_standard(layouter, &*b64url_input.0.buffer)?;
 
         let b64_input = Base64Vec::<F, M, A>(AssignedVector {
-            buffer: vec.try_into().unwrap(),
+            buffer: Box::new(vec.try_into().unwrap()),
             len: b64url_input.0.len.clone(),
         });
 
@@ -233,10 +233,10 @@ impl<F: CircuitField, const M: usize, const A: usize> Base64VarInstructions<F, M
         self.native_gadget.assert_zero(layouter, &check)?;
 
         // Compute decoded buffer.
-        let out_buffer = self.decode_base64(layouter, &b64_input.0.buffer, true)?;
+        let out_buffer = self.decode_base64(layouter, &*b64_input.0.buffer, true)?;
 
         Ok(AssignedVector::<_, _, M_OUT, A_OUT> {
-            buffer: out_buffer.try_into().unwrap(),
+            buffer: Box::new(out_buffer.try_into().unwrap()),
             len: new_len,
         })
     }

--- a/circuits/src/parsing/data_types.rs
+++ b/circuits/src/parsing/data_types.rs
@@ -16,17 +16,23 @@ use num_bigint::BigUint;
 
 use super::ParserGadget;
 use crate::{
-    field::AssignedNative, instructions::NativeInstructions, types::AssignedByte, CircuitField,
+    field::{native::AssignedBit, AssignedNative},
+    instructions::NativeInstructions,
+    types::{AssignedByte, InnerValue},
+    CircuitField,
 };
 
 /// Order of day, month and year in the date string.
 #[allow(clippy::upper_case_acronyms)]
 #[derive(Clone, Copy, Debug)]
 pub enum DateFormat {
-    /// Year, month, day.
+    /// Four-digit year, month, day.
     YYYYMMDD,
-    /// Day, month, year.
+    /// Day, month, four-digit year.
     DDMMYYYY,
+    /// Two-digit year, month, day. Requires a `century_base` parameter
+    /// in [`ParserGadget::date_to_int`] to resolve the century.
+    YYMMDD,
 }
 
 /// Date strings may have 1 character separating year, month and day
@@ -103,60 +109,173 @@ where
     }
 
     /// Given an ASCII string of assigned bytes, representing a date in the
-    /// specified format, returns  DD + 100 * MM + 10_000 * YYYY as an assigned
-    /// native value. This function does not check the validity of the date,
-    /// i.e. (in DDMMYYYY, NoSep) format, "32011990" will be accepted as 32
-    /// January 1990. Concretely, no range check is performed on the values,
-    /// so implicitly all *dates* in the range 0-99 / 0-99 / 0-9999 are
-    /// accepted.
+    /// specified format, returns `DD + 100 * MM + 10_000 * YYYY` as an
+    /// assigned native value. This function does not check the validity of
+    /// the date (e.g. `"32011990"` in DDMMYYYY is accepted as 32 January
+    /// 1990).
+    ///
+    /// For two-digit year formats ([`DateFormat::YYMMDD`]), `century_base`
+    /// must be `Some(N)` where N is an assigned value in [0, 99]. The year
+    /// is then resolved as `1900 + YY + (if YY < N { 100 } else { 0 })`,
+    /// i.e. the 100-year window is [1900+N, 2000+N). The caller is
+    /// responsible for constraining N < 100.
+    ///
+    /// For four-digit year formats, `century_base` must be `None`.
     pub fn date_to_int(
         &self,
         layouter: &mut impl Layouter<F>,
         input: &[AssignedByte<F>],
         format: (DateFormat, Separator),
+        century_base: Option<&AssignedNative<F>>,
     ) -> Result<AssignedNative<F>, Error> {
         let native = &self.native_gadget;
         let n = input.len();
 
-        // Indices for day, month, year bytes in the input.
-        let indices: (_, _, _) = match format {
-            (DateFormat::DDMMYYYY, Separator::NoSep) => {
-                assert_eq!(n, 8, "Date format must be 8 characters long: DDMMYYYY");
-                ((0..2), (2..4), (4..8))
+        match format {
+            (DateFormat::YYMMDD, Separator::NoSep) => {
+                assert_eq!(n, 6, "Date format must be 6 characters long: YYMMDD");
+                let century_base =
+                    century_base.expect("YYMMDD format requires a century_base parameter");
+                self.date_to_int_short_year(layouter, input, century_base)
             }
-
-            (DateFormat::DDMMYYYY, Separator::Sep(sep)) => {
-                assert_eq!(
-                    n, 10,
-                    "Date format must be 10 characters long: DD{sep}MM{sep}YYYY"
+            (DateFormat::YYMMDD, Separator::Sep(_)) => {
+                panic!("YYMMDD with separator is not supported")
+            }
+            _ => {
+                assert!(
+                    century_base.is_none(),
+                    "century_base is only used with YYMMDD format"
                 );
-
-                native.assert_equal_to_fixed(layouter, &input[2], sep as u8)?;
-                native.assert_equal_to_fixed(layouter, &input[5], sep as u8)?;
-                ((0..2), (3..5), (6..10))
+                // Indices for day, month, year bytes in the input.
+                let indices: (_, _, _) = match format {
+                    (DateFormat::DDMMYYYY, Separator::NoSep) => {
+                        assert_eq!(n, 8, "Date format must be 8 characters long: DDMMYYYY");
+                        ((0..2), (2..4), (4..8))
+                    }
+                    (DateFormat::DDMMYYYY, Separator::Sep(sep)) => {
+                        assert_eq!(
+                            n, 10,
+                            "Date format must be 10 characters long: DD{sep}MM{sep}YYYY"
+                        );
+                        native.assert_equal_to_fixed(layouter, &input[2], sep as u8)?;
+                        native.assert_equal_to_fixed(layouter, &input[5], sep as u8)?;
+                        ((0..2), (3..5), (6..10))
+                    }
+                    (DateFormat::YYYYMMDD, Separator::NoSep) => {
+                        assert_eq!(n, 8, "Date format must be 8 characters long: YYYYMMDD");
+                        ((6..8), (4..6), (0..4))
+                    }
+                    (DateFormat::YYYYMMDD, Separator::Sep(sep)) => {
+                        assert_eq!(
+                            n, 10,
+                            "Date format must be 10 characters long: YYYY{sep}MM{sep}DD"
+                        );
+                        native.assert_equal_to_fixed(layouter, &input[4], sep as u8)?;
+                        native.assert_equal_to_fixed(layouter, &input[7], sep as u8)?;
+                        ((8..10), (5..7), (0..4))
+                    }
+                    (DateFormat::YYMMDD, _) => unreachable!(),
+                };
+                let bytes = [&input[indices.2], &input[indices.1], &input[indices.0]].concat();
+                self.ascii_to_int(layouter, &bytes)
             }
+        }
+    }
 
-            (DateFormat::YYYYMMDD, Separator::NoSep) => {
-                assert_eq!(n, 8, "Date format must be 8 characters long: YYYYMMDD");
-                ((6..8), (4..6), (0..4))
-            }
+    /// Resolves a 6-byte YYMMDD date into a YYYYMMDD integer using the
+    /// century base N. The year is `1900 + YY + (if YY < N { 100 } else { 0
+    /// })`.
+    fn date_to_int_short_year(
+        &self,
+        layouter: &mut impl Layouter<F>,
+        input: &[AssignedByte<F>],
+        century_base: &AssignedNative<F>,
+    ) -> Result<AssignedNative<F>, Error> {
+        let native = &self.native_gadget;
 
-            (DateFormat::YYYYMMDD, Separator::Sep(sep)) => {
-                assert_eq!(
-                    n, 10,
-                    "Date format must be 10 characters long: YYYY{sep}MM{sep}DD"
-                );
+        let yy = self.ascii_to_int(layouter, &input[0..2])?;
+        let mmdd = self.ascii_to_int(layouter, &input[2..6])?;
 
-                native.assert_equal_to_fixed(layouter, &input[4], sep as u8)?;
-                native.assert_equal_to_fixed(layouter, &input[7], sep as u8)?;
+        // Off-circuit: compute is_20xx = (YY < N).
+        let yy_val = input[0]
+            .value()
+            .zip(input[1].value())
+            .map(|(d0, d1)| (d0 - 48) as u64 * 10 + (d1 - 48) as u64);
+        let n_val =
+            InnerValue::value(century_base).map(|be| u64::try_from(be.to_biguint()).unwrap());
+        let is_20xx_val = yy_val.zip(n_val).map(|(yy, n)| yy < n);
 
-                ((8..10), (5..7), (0..4))
-            }
-        };
+        // Assign is_20xx as a bit (constrains it to {0, 1}).
+        let is_20xx: AssignedBit<F> = native.assign(layouter, is_20xx_val)?;
+        let is_20xx_native: AssignedNative<F> = is_20xx.into();
 
-        let bytes = [&input[indices.2], &input[indices.1], &input[indices.0]].concat();
+        // Constrain: yy - century_base + is_20xx * 100 ∈ [0, 128).
+        // This enforces the correct relationship between is_20xx, yy, and N.
+        let check = native.linear_combination(
+            layouter,
+            &[
+                (F::ONE, yy.clone()),
+                (-F::ONE, century_base.clone()),
+                (F::from(100u64), is_20xx_native.clone()),
+            ],
+            F::ZERO,
+        )?;
+        native.assert_lower_than_fixed(layouter, &check, &BigUint::from(128u64))?;
 
-        self.ascii_to_int(layouter, &bytes)
+        // Result: (1900 + YY + is_20xx * 100) * 10_000 + MMDD
+        native.linear_combination(
+            layouter,
+            &[
+                (F::from(10_000u64), yy),
+                (F::from(1_000_000u64), is_20xx_native),
+                (F::ONE, mmdd),
+            ],
+            F::from(19_000_000u64),
+        )
+    }
+}
+
+/// A calendar date with a full 4-digit year.
+#[derive(Clone, Copy, Debug)]
+pub struct Date {
+    /// Day of the month (1-31).
+    pub day: u8,
+    /// Month (1-12).
+    pub month: u8,
+    /// Four-digit year.
+    pub year: u16,
+}
+
+impl Date {
+    /// Encodes as YYYYMMDD integer: `year * 10_000 + month * 100 + day`.
+    pub fn as_yyyymmdd(&self) -> u64 {
+        self.year as u64 * 10_000 + self.month as u64 * 100 + self.day as u64
+    }
+}
+
+impl From<Date> for BigUint {
+    fn from(value: Date) -> Self {
+        value.as_yyyymmdd().into()
+    }
+}
+
+impl<F, N> ParserGadget<F, N>
+where
+    F: CircuitField,
+    N: NativeInstructions<F>,
+{
+    /// Asserts that a date (as assigned bytes in the given format) is
+    /// strictly before `limit_date`. Convenience wrapper around
+    /// [`date_to_int`](Self::date_to_int) + a range check.
+    pub fn assert_date_before_fixed(
+        &self,
+        layouter: &mut impl Layouter<F>,
+        date_bytes: &[AssignedByte<F>],
+        format: (DateFormat, Separator),
+        limit_date: Date,
+    ) -> Result<(), Error> {
+        let date = self.date_to_int(layouter, date_bytes, format, None)?;
+        self.native_gadget.assert_lower_than_fixed(layouter, &date, &limit_date.into())
     }
 }
 
@@ -178,16 +297,18 @@ mod tests {
     };
 
     #[derive(Clone, Copy, Debug)]
-    enum Operation {
-        ParseInt,
-        ParseDate((DateFormat, Separator)),
+    enum ParseTarget {
+        Int,
+        Date((DateFormat, Separator)),
+        /// Parse a short-year date with `century_base`.
+        DateShortYear((DateFormat, Separator), u64),
     }
 
     #[derive(Clone, Debug)]
     struct TestCircuit<F, N> {
         string: Vec<Value<F>>,
         expected: F,
-        operation: Operation,
+        operation: ParseTarget,
         _marker: PhantomData<N>,
     }
 
@@ -230,9 +351,14 @@ mod tests {
                 .collect::<Result<Vec<AssignedByte<F>>, Error>>()?;
 
             let res = match self.operation {
-                Operation::ParseInt => parser_gadget.ascii_to_int(&mut layouter, &bytes),
-                Operation::ParseDate(format) => {
-                    parser_gadget.date_to_int(&mut layouter, &bytes, format)
+                ParseTarget::Int => parser_gadget.ascii_to_int(&mut layouter, &bytes),
+                ParseTarget::Date(format) => {
+                    parser_gadget.date_to_int(&mut layouter, &bytes, format, None)
+                }
+                ParseTarget::DateShortYear(format, n) => {
+                    let century_base =
+                        native_gadget.assign(&mut layouter, Value::known(F::from(n)))?;
+                    parser_gadget.date_to_int(&mut layouter, &bytes, format, Some(&century_base))
                 }
             }?;
 
@@ -242,7 +368,7 @@ mod tests {
         }
     }
 
-    fn run<F>(string: &[u8], expected: u64, operation: Operation, must_pass: bool)
+    fn run<F>(string: &[u8], expected: u64, operation: ParseTarget, must_pass: bool)
     where
         F: CircuitField + FromUniformBytes<64> + Ord,
     {
@@ -277,7 +403,7 @@ mod tests {
             (b"54321", 0, false),
         ];
         test_vecs.iter().for_each(|(input, expected, must_pass)| {
-            run::<F>(input, *expected, Operation::ParseInt, *must_pass)
+            run::<F>(input, *expected, ParseTarget::Int, *must_pass)
         });
     }
 
@@ -310,7 +436,39 @@ mod tests {
             (b"19701225", format4, 19701225, true),
         ];
         test_vecs.iter().for_each(|(input, format, expected, must_pass)| {
-            run::<F>(input, *expected, Operation::ParseDate(*format), *must_pass)
+            run::<F>(input, *expected, ParseTarget::Date(*format), *must_pass)
+        });
+    }
+
+    #[test]
+    fn test_parse_date_short_year() {
+        type F = midnight_curves::Fq;
+        let yymmdd = (DateFormat::YYMMDD, Separator::NoSep);
+
+        // N = 26: window [1926, 2026). YY >= 26 → 19xx, YY < 26 → 20xx.
+        let test_vecs: Vec<(&[u8], _, u64, _, _)> = vec![
+            (b"000101", yymmdd, 26, 20000101, true),  // YY=0 < 26 → 2000
+            (b"251231", yymmdd, 26, 20251231, true),  // YY=25 < 26 → 2025
+            (b"260101", yymmdd, 26, 19260101, true),  // YY=26 >= 26 → 1926
+            (b"911214", yymmdd, 26, 19911214, true),  // YY=91 >= 26 → 1991
+            (b"991231", yymmdd, 26, 19991231, true),  // YY=99 >= 26 → 1999
+            (b"100812", yymmdd, 26, 20100812, true),  // YY=10 < 26 → 2010
+            (b"911214", yymmdd, 26, 20171214, false), // wrong century
+            // N = 0: window [1900, 2000). All YY → 19xx.
+            (b"000101", yymmdd, 0, 19000101, true),
+            (b"991231", yymmdd, 0, 19991231, true),
+            // N = 99: window [1999, 2099). YY=99 → 1999, YY=0..98 → 20xx.
+            (b"990101", yymmdd, 99, 19990101, true),
+            (b"000101", yymmdd, 99, 20000101, true),
+            (b"980101", yymmdd, 99, 20980101, true),
+        ];
+        test_vecs.iter().for_each(|(input, format, n, expected, must_pass)| {
+            run::<F>(
+                input,
+                *expected,
+                ParseTarget::DateShortYear(*format, *n),
+                *must_pass,
+            )
         });
     }
 }

--- a/circuits/src/parsing/mod.rs
+++ b/circuits/src/parsing/mod.rs
@@ -23,6 +23,6 @@ pub mod scanner;
 mod table;
 
 pub use base64_chip::*;
-pub use data_types::{DateFormat, Separator};
+pub use data_types::{Date, DateFormat, Separator};
 pub use parser_gadget::*;
 pub use scanner::{regex, static_specs::spec_library, StdLibParser};

--- a/circuits/src/vec/vector.rs
+++ b/circuits/src/vec/vector.rs
@@ -32,12 +32,21 @@ use crate::{
 /// over this type. As a result of this alignment, the data may contain filler
 /// values before and after the effective payload. The padding in front of
 /// the payload will always be 0 mod A, so that the payload begins aligned in A
-/// sized chunks. The padding at the end of the payload will be have a size in
+/// sized chunks. The padding at the end of the payload will have a size in
 /// [0, A) such that | front_pad | + | payload | + | back_pad | = M.
+///
+/// **Invariant: `M` must be a multiple of `A`** (and `A > 0`, `M >= A`).
+/// Several operations (`padding_flag`, `get_limits`, hashing, …) rely on this
+/// to guarantee that the buffer decomposes into exactly `M / A` full chunks
+/// and that a full-capacity vector (`len == M`) can always be placed without
+/// overflow. This is enforced by the entry points
+/// [`assign_with_filler`](`VectorInstructions::assign_with_filler`) and
+/// [`assign`](`AssignmentInstructions::assign`).
 #[derive(Clone, Debug)]
 pub struct AssignedVector<F: CircuitField, T: Vectorizable, const M: usize, const A: usize> {
-    /// Padded payload of the vector.
-    pub(crate) buffer: [T; M],
+    /// Padded payload of the vector. Boxed to keep large buffers
+    /// off the stack.
+    pub(crate) buffer: Box<[T; M]>,
 
     /// Effective length of the vector.
     pub(crate) len: AssignedNative<F>,

--- a/circuits/src/vec/vector.rs
+++ b/circuits/src/vec/vector.rs
@@ -40,8 +40,8 @@ use crate::{
 /// to guarantee that the buffer decomposes into exactly `M / A` full chunks
 /// and that a full-capacity vector (`len == M`) can always be placed without
 /// overflow. This is enforced by the entry points
-/// [`assign_with_filler`](`VectorInstructions::assign_with_filler`) and
-/// [`assign`](`AssignmentInstructions::assign`).
+/// [`assign_with_filler`](crate::instructions::VectorInstructions::assign_with_filler) and
+/// [`assign`](crate::instructions::AssignmentInstructions::assign).
 #[derive(Clone, Debug)]
 pub struct AssignedVector<F: CircuitField, T: Vectorizable, const M: usize, const A: usize> {
     /// Padded payload of the vector. Boxed to keep large buffers

--- a/circuits/src/vec/vector_gadget.rs
+++ b/circuits/src/vec/vector_gadget.rs
@@ -25,9 +25,9 @@ use crate::{
     instructions::{
         division::DivisionInstructions,
         vector::{VectorBounds, VectorInstructions},
-        ArithInstructions,
-        AssertionInstructions, AssignmentInstructions, BinaryInstructions, ComparisonInstructions,
-        ControlFlowInstructions, EqualityInstructions, RangeCheckInstructions,
+        ArithInstructions, AssertionInstructions, AssignmentInstructions, BinaryInstructions,
+        ComparisonInstructions, ControlFlowInstructions, EqualityInstructions,
+        RangeCheckInstructions,
     },
     types::{AssignedBit, AssignedVector, InnerValue, Vectorizable},
     vec::get_lims,

--- a/circuits/src/vec/vector_gadget.rs
+++ b/circuits/src/vec/vector_gadget.rs
@@ -23,7 +23,9 @@ use crate::{
         NativeGadget,
     },
     instructions::{
-        division::DivisionInstructions, vector::VectorInstructions, ArithInstructions,
+        division::DivisionInstructions,
+        vector::{VectorBounds, VectorInstructions},
+        ArithInstructions,
         AssertionInstructions, AssignmentInstructions, BinaryInstructions, ComparisonInstructions,
         ControlFlowInstructions, EqualityInstructions, RangeCheckInstructions,
     },
@@ -82,8 +84,8 @@ where
             .native_gadget
             .assign_many(layouter, &vec![Value::known(T::FILLER); L - M])?;
 
-        let buffer: [T; L] =
-            [extra_pad.as_slice(), input.buffer.as_slice()].concat().try_into().unwrap();
+        let buffer: Box<[T; L]> =
+            Box::new([extra_pad.as_slice(), input.buffer.as_slice()].concat().try_into().unwrap());
 
         Ok(AssignedVector {
             buffer,
@@ -97,10 +99,18 @@ where
         value: Value<Vec<T::Element>>,
         filler: Option<T::Element>,
     ) -> Result<AssignedVector<F, T, M, A>, Error> {
+        assert!(M >= A, "AssignedVector requires M >= A (got M={M}, A={A})");
+        assert!(A > 0, "AssignedVector requires A positive (A={A})");
+        assert!(
+            M.is_multiple_of(A),
+            "AssignedVector requires M % A == 0 (got M={M}, A={A})"
+        );
         let ng = &self.native_gadget;
         let filler = filler.unwrap_or(T::FILLER);
         let (data_val, len_val) = value
             .map(|v| {
+                // `v` needs to be at most `M - M % A`, i.e., `M` since we require above that it
+                // is a multiple of `A`.
                 assert!(v.len() <= M);
                 let len = F::from(v.len() as u64);
                 let mut buffer = [filler; M];
@@ -109,10 +119,11 @@ where
             })
             .unzip();
 
-        let data = ng
-            .assign_many(layouter, &data_val.transpose_array())?
-            .try_into()
-            .expect("Length mismatch in AssignedVector.");
+        let data: Box<[T; M]> = Box::new(
+            ng.assign_many(layouter, &data_val.transpose_array())?
+                .try_into()
+                .expect("Length mismatch in AssignedVector."),
+        );
         let len = ng.assign_lower_than_fixed(layouter, len_val, &(M + 1).into())?;
         Ok(AssignedVector { buffer: data, len })
     }
@@ -121,28 +132,31 @@ where
         &self,
         layouter: &mut impl Layouter<F>,
         input: &AssignedVector<F, T, M, A>,
-    ) -> Result<[AssignedBit<F>; M], Error> {
+    ) -> Result<(Box<[AssignedBit<F>; M]>, VectorBounds<F>), Error> {
         let ng = &self.native_gadget;
-        let (start, end) = self.get_limits(layouter, input)?;
+        let limits = self.get_limits(layouter, input)?;
+        let (start, end) = &limits;
         let mut is_data: AssignedBit<F> = ng.assign_fixed(layouter, true)?;
 
-        let result = (0..M - A)
+        let result = (0..M - A + 1)
             .map(|i| {
-                let is_start = ng.is_equal_to_fixed(layouter, &start, F::from(i as u64))?;
+                let is_start = ng.is_equal_to_fixed(layouter, start, F::from(i as u64))?;
                 is_data = ng.xor(layouter, &[is_data.clone(), is_start])?;
                 Ok(is_data.clone())
             })
             .collect::<Result<Vec<_>, Error>>()?;
 
-        let last_chunk = (M - A..M)
+        let last_chunk = (M - A + 1..M)
             .map(|i| {
-                let is_end = ng.is_equal_to_fixed(layouter, &end, F::from(i as u64))?;
+                let is_end = ng.is_equal_to_fixed(layouter, end, F::from(i as u64))?;
                 is_data = ng.xor(layouter, &[is_data.clone(), is_end])?;
                 Ok(is_data.clone())
             })
             .collect::<Result<Vec<_>, Error>>()?;
 
-        Ok([result, last_chunk].concat().try_into().expect("Mismatch in vector lengths"))
+        let flags: Box<[AssignedBit<F>; M]> =
+            Box::new([result, last_chunk].concat().try_into().expect("Mismatch in vector lengths"));
+        Ok((flags, limits))
     }
 
     fn get_limits(
@@ -224,11 +238,13 @@ where
         };
         debug_assert_eq!(buffer.len(), M + A);
 
-        let buffer: [_; M] = (0..M)
-            .map(|i| ng.select(layouter, &needs_adjust, &buffer[i], &buffer[A + i]))
-            .collect::<Result<Vec<_>, Error>>()?
-            .try_into()
-            .unwrap();
+        let buffer: Box<[_; M]> = Box::new(
+            (0..M)
+                .map(|i| ng.select(layouter, &needs_adjust, &buffer[i], &buffer[A + i]))
+                .collect::<Result<Vec<_>, Error>>()?
+                .try_into()
+                .unwrap(),
+        );
 
         // Compute final length.
         let len = ng.add_constant(layouter, &input.len, -F::from(n_elems as u64))?;
@@ -284,6 +300,7 @@ where
         // Check all data values are equal.
         let val_checks = self
             .padding_flag(layouter, x)?
+            .0
             .into_iter()
             .zip(x.buffer.iter().zip(y.buffer.iter()))
             .map(|(is_padding, (a, b))| {
@@ -569,7 +586,7 @@ mod tests {
                         })
                         .transpose_array();
 
-                    let result = vg.padding_flag(&mut layouter, &vec_1)?;
+                    let (result, _limits) = vg.padding_flag(&mut layouter, &vec_1)?;
 
                     for (r, e) in result.iter().zip(expected.iter()) {
                         let e: AssignedBit<F> = ng.assign(&mut layouter, *e)?;
@@ -699,7 +716,7 @@ mod tests {
 
         // Equal vectors, different padding.
         run_eq_vec_test::<_, 128, 2>(&inputs, &inputs, true, true, true);
-        run_eq_vec_test::<_, 128, 3>(&inputs, &inputs, true, true, false);
+        run_eq_vec_test::<_, 126, 3>(&inputs, &inputs, true, true, false);
 
         // Equal vectors, equal padding.
         run_eq_vec_test::<_, 128, 2>(&inputs, &inputs, true, false, false);
@@ -728,9 +745,9 @@ mod tests {
         // Test different alignments.
         run_limit_vec_test::<_, 128, 1>(&inputs, true);
         run_limit_vec_test::<_, 128, 2>(&inputs, false);
-        run_limit_vec_test::<_, 128, 3>(&inputs, false);
+        run_limit_vec_test::<_, 126, 3>(&inputs, false);
         run_limit_vec_test::<_, 128, 4>(&inputs, false);
-        run_limit_vec_test::<_, 128, 5>(&inputs, false);
+        run_limit_vec_test::<_, 130, 5>(&inputs, false);
 
         // Test edge cases.
         run_limit_vec_test::<_, 64, 2>(&inputs[..64], false);
@@ -747,7 +764,7 @@ mod tests {
 
         run_padding_flags_test::<_, 128, 1>(&inputs, true);
         run_padding_flags_test::<_, 128, 2>(&inputs, false);
-        run_padding_flags_test::<_, 128, 3>(&inputs, false);
+        run_padding_flags_test::<_, 126, 3>(&inputs, false);
         run_padding_flags_test::<_, 128, 64>(&inputs, false);
         run_padding_flags_test::<F, 128, 64>(&[], false);
         run_padding_flags_test::<F, 64, 16>(&inputs[..64], false);
@@ -773,14 +790,14 @@ mod tests {
         run_trim_vec_test::<_, 128, 32>(&inputs, 31, false);
 
         // Above or equal to A.
-        run_trim_vec_test::<_, 128, 3>(&inputs, 3, false);
-        run_trim_vec_test::<_, 128, 3>(&inputs, 4, false);
-        run_trim_vec_test::<_, 128, 3>(&inputs, 5, false);
-        run_trim_vec_test::<_, 128, 3>(&inputs, 6, false);
-        run_trim_vec_test::<_, 128, 3>(&inputs, 10, false);
-        run_trim_vec_test::<_, 128, 3>(&inputs, 20, false);
-        run_trim_vec_test::<_, 128, 3>(&inputs, 30, false);
-        run_trim_vec_test::<_, 128, 3>(&inputs, 40, false);
+        run_trim_vec_test::<_, 126, 3>(&inputs, 3, false);
+        run_trim_vec_test::<_, 126, 3>(&inputs, 4, false);
+        run_trim_vec_test::<_, 126, 3>(&inputs, 5, false);
+        run_trim_vec_test::<_, 126, 3>(&inputs, 6, false);
+        run_trim_vec_test::<_, 126, 3>(&inputs, 10, false);
+        run_trim_vec_test::<_, 126, 3>(&inputs, 20, false);
+        run_trim_vec_test::<_, 126, 3>(&inputs, 30, false);
+        run_trim_vec_test::<_, 126, 3>(&inputs, 40, false);
 
         // Edge case: offset of original vector = 0;
         run_trim_vec_test::<_, 128, 32>(&inputs[..96], 23, false);

--- a/circuits/src/vec/vector_gadget.rs
+++ b/circuits/src/vec/vector_gadget.rs
@@ -138,7 +138,7 @@ where
         let (start, end) = &limits;
         let mut is_data: AssignedBit<F> = ng.assign_fixed(layouter, true)?;
 
-        let result = (0..M - A + 1)
+        let result = (0..=M - A)
             .map(|i| {
                 let is_start = ng.is_equal_to_fixed(layouter, start, F::from(i as u64))?;
                 is_data = ng.xor(layouter, &[is_data.clone(), is_start])?;

--- a/zk_stdlib/CHANGELOG.md
+++ b/zk_stdlib/CHANGELOG.md
@@ -16,6 +16,7 @@ verification keys break backwards compatibility.
 * Adapt `FromScratch` impls to new `configure_from_scratch` signature with shared column pools [#306](https://github.com/midnightntwrk/midnight-zk/pull/306)
 * Use `Blake2b256` transcript hash in the `bitcoin_signature` example [#322](https://github.com/midnightntwrk/midnight-zk/pull/322)
 * Removed outdated identity examples and restructured identity example crate [#330](https://github.com/midnightntwrk/midnight-zk/pull/330)
+* Exposing varlen hashes, and minor additional function exposure [#331](https://github.com/midnightntwrk/midnight-zk/pull/331)
 
 ### Added
 * Expose P-256 (secp256r1) chip via `ZkStdLib::p256_curve` and `ZkStdLib::p256_scalar` [#317](https://github.com/midnightntwrk/midnight-zk/pull/317)

--- a/zk_stdlib/examples/identity/jwt/full_credential.rs
+++ b/zk_stdlib/examples/identity/jwt/full_credential.rs
@@ -283,7 +283,7 @@ impl FullCredential {
         limit_date: Date,
     ) -> Result<(), Error> {
         let format = (DateFormat::YYYYMMDD, Separator::Sep('-'));
-        let date = std_lib.parser().date_to_int(layouter, date, format)?;
+        let date = std_lib.parser().date_to_int(layouter, date, format, None)?;
         std_lib.assert_lower_than_fixed(layouter, &date, &limit_date.into())
     }
 }

--- a/zk_stdlib/examples/identity/jwt/property_check.rs
+++ b/zk_stdlib/examples/identity/jwt/property_check.rs
@@ -294,7 +294,7 @@ impl CredentialProperty {
         limit_date: Date,
     ) -> Result<(), Error> {
         let format = (DateFormat::YYYYMMDD, Separator::Sep('-'));
-        let date = std_lib.parser().date_to_int(layouter, date, format)?;
+        let date = std_lib.parser().date_to_int(layouter, date, format, None)?;
         std_lib.assert_lower_than_fixed(layouter, &date, &limit_date.into())
     }
 

--- a/zk_stdlib/src/lib.rs
+++ b/zk_stdlib/src/lib.rs
@@ -66,10 +66,13 @@ use midnight_circuits::{
     },
     hash::{
         poseidon::{
-            PoseidonChip, PoseidonConfig, VarLenPoseidonGadget, NB_POSEIDON_ADVICE_COLS,
-            NB_POSEIDON_FIXED_COLS,
+            constants::RATE, PoseidonChip, PoseidonConfig, VarLenPoseidonGadget,
+            NB_POSEIDON_ADVICE_COLS, NB_POSEIDON_FIXED_COLS,
         },
-        sha256::{Sha256Chip, Sha256Config, NB_SHA256_ADVICE_COLS, NB_SHA256_FIXED_COLS},
+        sha256::{
+            Sha256Chip, Sha256Config, VarLenSha256Gadget, NB_SHA256_ADVICE_COLS,
+            NB_SHA256_FIXED_COLS,
+        },
         sha512::{Sha512Chip, Sha512Config, NB_SHA512_ADVICE_COLS, NB_SHA512_FIXED_COLS},
     },
     instructions::{
@@ -293,8 +296,10 @@ pub struct ZkStdLib {
     core_decomposition_chip: P2RDecompositionChip<F>,
     jubjub_chip: Option<EccChip<C>>,
     sha2_256_chip: Option<Sha256Chip<F>>,
+    varlen_sha2_256_chip: Option<VarLenSha256Gadget<F>>,
     sha2_512_chip: Option<Sha512Chip<F>>,
     poseidon_gadget: Option<PoseidonChip<F>>,
+    varlen_poseidon_gadget: Option<VarLenPoseidonGadget<F>>,
     htc_gadget: Option<HashToCurveGadget<F, C, AssignedNative<F>, PoseidonChip<F>, EccChip<C>>>,
     map_gadget: Option<MapGadget<F, NG, PoseidonChip<F>>>,
     biguint_gadget: BigUintGadget<F, NG>,
@@ -338,10 +343,13 @@ impl ZkStdLib {
             .map(|jubjub_config| EccChip::new(jubjub_config, &native_gadget));
         let sha2_256_chip = (config.sha2_256_config.as_ref())
             .map(|sha256_config| Sha256Chip::new(sha256_config, &native_gadget));
+        let varlen_sha2_256_chip = sha2_256_chip.as_ref().map(|sha256| sha256.varlen_gadget());
         let sha2_512_chip = (config.sha2_512_config.as_ref())
             .map(|sha512_config| Sha512Chip::new(sha512_config, &native_gadget));
         let poseidon_gadget = (config.poseidon_config.as_ref())
             .map(|poseidon_config| PoseidonChip::new(poseidon_config, &native_chip));
+        let varlen_poseidon_gadget = (poseidon_gadget.as_ref())
+            .map(|poseidon| VarLenPoseidonGadget::new(poseidon, &native_gadget));
         let htc_gadget = (jubjub_chip.as_ref())
             .zip(poseidon_gadget.as_ref())
             .map(|(ecc_chip, poseidon_gadget)| HashToCurveGadget::new(poseidon_gadget, ecc_chip));
@@ -402,8 +410,10 @@ impl ZkStdLib {
             core_decomposition_chip,
             jubjub_chip,
             sha2_256_chip,
+            varlen_sha2_256_chip,
             sha2_512_chip,
             poseidon_gadget,
+            varlen_poseidon_gadget,
             map_gadget,
             htc_gadget,
             biguint_gadget,
@@ -867,19 +877,21 @@ impl ZkStdLib {
     }
 
     /// Variable-length Poseidon hash. Takes an [`AssignedVector`] of native
-    /// field elements with chunk alignment 2 (Poseidon rate) and maximum
-    /// length `M`. `M` must be a multiple of 2.
+    /// field elements with chunk alignment RATE and maximum length `M`.
+    /// `M` must be a multiple of RATE.
     pub fn poseidon_varlen<const M: usize>(
         &self,
         layouter: &mut impl Layouter<F>,
-        input: &AssignedVector<F, AssignedNative<F>, M, 2>,
+        input: &AssignedVector<F, AssignedNative<F>, M, RATE>,
     ) -> Result<AssignedNative<F>, Error> {
-        let poseidon_chip = self
-            .poseidon_gadget
+        assert!(
+            M.is_multiple_of(RATE),
+            "poseidon_varlen only supports assigned vector whose maxlen M is a multiple of {RATE} (here M = {M})"
+        );
+        self.varlen_poseidon_gadget
             .as_ref()
-            .unwrap_or_else(|| panic!("ZkStdLibArch must enable poseidon"));
-        let gadget = VarLenPoseidonGadget::new(poseidon_chip, &self.native_gadget);
-        gadget.poseidon_varlen(layouter, input)
+            .unwrap_or_else(|| panic!("ZkStdLibArch must enable poseidon"))
+            .poseidon_varlen(layouter, input)
     }
 
     /// Hashes a slice of assigned values into `(x, y)` coordinates which are
@@ -934,10 +946,9 @@ impl ZkStdLib {
         input: &AssignedVector<F, AssignedByte<F>, M, 64>,
     ) -> Result<[AssignedByte<F>; 32], Error> {
         *self.used_sha2_256.borrow_mut() = true;
-        self.sha2_256_chip
+        self.varlen_sha2_256_chip
             .as_ref()
             .expect("ZkStdLibArch must enable sha256")
-            .varlen_gadget()
             .varhash(layouter, input)
     }
 

--- a/zk_stdlib/src/lib.rs
+++ b/zk_stdlib/src/lib.rs
@@ -343,8 +343,7 @@ impl ZkStdLib {
             .map(|jubjub_config| EccChip::new(jubjub_config, &native_gadget));
         let sha2_256_chip = (config.sha2_256_config.as_ref())
             .map(|sha256_config| Sha256Chip::new(sha256_config, &native_gadget));
-        let varlen_sha2_256_gadget =
-            sha2_256_chip.as_ref().map(|sha256_chip| VarLenSha256Gadget::new(sha256_chip));
+        let varlen_sha2_256_gadget = sha2_256_chip.as_ref().map(VarLenSha256Gadget::new);
         let sha2_512_chip = (config.sha2_512_config.as_ref())
             .map(|sha512_config| Sha512Chip::new(sha512_config, &native_gadget));
         let poseidon_gadget = (config.poseidon_config.as_ref())

--- a/zk_stdlib/src/lib.rs
+++ b/zk_stdlib/src/lib.rs
@@ -1390,7 +1390,7 @@ where
         &self,
         layouter: &mut impl Layouter<F>,
         input: &AssignedVector<F, T, M, A>,
-    ) -> Result<[AssignedBit<F>; M], Error> {
+    ) -> Result<(Box<[AssignedBit<F>; M]>, VectorBounds<F>), Error> {
         self.vector_gadget.padding_flag(layouter, input)
     }
 
@@ -1398,7 +1398,7 @@ where
         &self,
         layouter: &mut impl Layouter<F>,
         input: &AssignedVector<F, T, M, A>,
-    ) -> Result<(AssignedNative<F>, AssignedNative<F>), Error> {
+    ) -> Result<VectorBounds<F>, Error> {
         self.vector_gadget.get_limits(layouter, input)
     }
 

--- a/zk_stdlib/src/lib.rs
+++ b/zk_stdlib/src/lib.rs
@@ -65,11 +65,17 @@ use midnight_circuits::{
         NativeChip, NativeConfig, NativeGadget,
     },
     hash::{
-        poseidon::{PoseidonChip, PoseidonConfig, NB_POSEIDON_ADVICE_COLS, NB_POSEIDON_FIXED_COLS},
+        poseidon::{
+            PoseidonChip, PoseidonConfig, VarLenPoseidonGadget, NB_POSEIDON_ADVICE_COLS,
+            NB_POSEIDON_FIXED_COLS,
+        },
         sha256::{Sha256Chip, Sha256Config, NB_SHA256_ADVICE_COLS, NB_SHA256_FIXED_COLS},
         sha512::{Sha512Chip, Sha512Config, NB_SHA512_ADVICE_COLS, NB_SHA512_FIXED_COLS},
     },
-    instructions::{public_input::CommittedInstanceInstructions, *},
+    instructions::{
+        hash::VarHashInstructions, public_input::CommittedInstanceInstructions,
+        vector::VectorBounds, *,
+    },
     map::map_gadget::MapGadget,
     parsing::{
         self,
@@ -860,6 +866,22 @@ impl ZkStdLib {
             .hash(layouter, input)
     }
 
+    /// Variable-length Poseidon hash. Takes an [`AssignedVector`] of native
+    /// field elements with chunk alignment 2 (Poseidon rate) and maximum
+    /// length `M`. `M` must be a multiple of 2.
+    pub fn poseidon_varlen<const M: usize>(
+        &self,
+        layouter: &mut impl Layouter<F>,
+        input: &AssignedVector<F, AssignedNative<F>, M, 2>,
+    ) -> Result<AssignedNative<F>, Error> {
+        let poseidon_chip = self
+            .poseidon_gadget
+            .as_ref()
+            .unwrap_or_else(|| panic!("ZkStdLibArch must enable poseidon"));
+        let gadget = VarLenPoseidonGadget::new(poseidon_chip, &self.native_gadget);
+        gadget.poseidon_varlen(layouter, input)
+    }
+
     /// Hashes a slice of assigned values into `(x, y)` coordinates which are
     /// guaranteed to be in the curve `C`. For usage, see [HashToCurveGadget].
     pub fn hash_to_curve(
@@ -902,6 +924,21 @@ impl ZkStdLib {
             .as_ref()
             .expect("ZkStdLibArch must enable sha256")
             .hash(layouter, input)
+    }
+
+    /// Variable-length SHA-256 hash. Takes an [`AssignedVector`] of bytes
+    /// with chunk alignment 64 (SHA-256 block size) and maximum length `M`.
+    pub fn sha2_256_varlen<const M: usize>(
+        &self,
+        layouter: &mut impl Layouter<F>,
+        input: &AssignedVector<F, AssignedByte<F>, M, 64>,
+    ) -> Result<[AssignedByte<F>; 32], Error> {
+        *self.used_sha2_256.borrow_mut() = true;
+        self.sha2_256_chip
+            .as_ref()
+            .expect("ZkStdLibArch must enable sha256")
+            .varlen_gadget()
+            .varhash(layouter, input)
     }
 
     /// Sha2_512 hash.

--- a/zk_stdlib/src/lib.rs
+++ b/zk_stdlib/src/lib.rs
@@ -296,7 +296,7 @@ pub struct ZkStdLib {
     core_decomposition_chip: P2RDecompositionChip<F>,
     jubjub_chip: Option<EccChip<C>>,
     sha2_256_chip: Option<Sha256Chip<F>>,
-    varlen_sha2_256_chip: Option<VarLenSha256Gadget<F>>,
+    varlen_sha2_256_gadget: Option<VarLenSha256Gadget<F>>,
     sha2_512_chip: Option<Sha512Chip<F>>,
     poseidon_gadget: Option<PoseidonChip<F>>,
     varlen_poseidon_gadget: Option<VarLenPoseidonGadget<F>>,
@@ -343,7 +343,8 @@ impl ZkStdLib {
             .map(|jubjub_config| EccChip::new(jubjub_config, &native_gadget));
         let sha2_256_chip = (config.sha2_256_config.as_ref())
             .map(|sha256_config| Sha256Chip::new(sha256_config, &native_gadget));
-        let varlen_sha2_256_chip = sha2_256_chip.as_ref().map(|sha256| sha256.varlen_gadget());
+        let varlen_sha2_256_gadget =
+            sha2_256_chip.as_ref().map(|sha256_chip| VarLenSha256Gadget::new(sha256_chip));
         let sha2_512_chip = (config.sha2_512_config.as_ref())
             .map(|sha512_config| Sha512Chip::new(sha512_config, &native_gadget));
         let poseidon_gadget = (config.poseidon_config.as_ref())
@@ -410,7 +411,7 @@ impl ZkStdLib {
             core_decomposition_chip,
             jubjub_chip,
             sha2_256_chip,
-            varlen_sha2_256_chip,
+            varlen_sha2_256_gadget,
             sha2_512_chip,
             poseidon_gadget,
             varlen_poseidon_gadget,
@@ -876,9 +877,16 @@ impl ZkStdLib {
             .hash(layouter, input)
     }
 
-    /// Variable-length Poseidon hash. Takes an [`AssignedVector`] of native
-    /// field elements with chunk alignment RATE and maximum length `M`.
-    /// `M` must be a multiple of RATE.
+    /// Poseidon hash over a payload whose element count can vary between
+    /// proofs.
+    ///
+    /// Unlike [`poseidon`](Self::poseidon), which takes a plain slice whose
+    /// length is structurally fixed in the circuit (the same for every proof),
+    /// this variant takes an [`AssignedVector`]: a specialized structure for
+    /// carrying data of varying length, up to a maximum capacity of `M`
+    /// elements.
+    ///
+    /// `M` must be a multiple of 2 (the Poseidon absorption rate).
     pub fn poseidon_varlen<const M: usize>(
         &self,
         layouter: &mut impl Layouter<F>,
@@ -907,7 +915,7 @@ impl ZkStdLib {
             .hash_to_curve(layouter, inputs)
     }
 
-    /// Sha2_256.
+    /// SHA2-256.
     /// Takes as input a slice of assigned bytes and returns the assigned
     /// input/output in bytes.
     /// We assume the field uses little endian encoding.
@@ -938,21 +946,31 @@ impl ZkStdLib {
             .hash(layouter, input)
     }
 
-    /// Variable-length SHA-256 hash. Takes an [`AssignedVector`] of bytes
-    /// with chunk alignment 64 (SHA-256 block size) and maximum length `M`.
+    /// SHA-256 hash over a payload whose byte count can vary between proofs.
+    ///
+    /// Unlike [`sha2_256`](Self::sha2_256), which takes a plain slice whose
+    /// length is structurally fixed in the circuit (the same for every proof),
+    /// this variant takes an [`AssignedVector`]: a specialized structure for
+    /// carrying data of varying length, up to a maximum capacity of `M` bytes.
+    ///
+    /// `M` must be a multiple of 64 (the SHA-256 block size).
     pub fn sha2_256_varlen<const M: usize>(
         &self,
         layouter: &mut impl Layouter<F>,
         input: &AssignedVector<F, AssignedByte<F>, M, 64>,
     ) -> Result<[AssignedByte<F>; 32], Error> {
         *self.used_sha2_256.borrow_mut() = true;
-        self.varlen_sha2_256_chip
+        assert!(
+            M.is_multiple_of(64),
+            "sha2_256_varlen only supports assigned vector whose maxlen M is a multiple of 64 (here M = {M})"
+        );
+        self.varlen_sha2_256_gadget
             .as_ref()
             .expect("ZkStdLibArch must enable sha256")
             .varhash(layouter, input)
     }
 
-    /// Sha2_512 hash.
+    /// SHA2-512 hash.
     pub fn sha2_512(
         &self,
         layouter: &mut impl Layouter<F>,
@@ -965,7 +983,7 @@ impl ZkStdLib {
             .hash(layouter, input)
     }
 
-    /// Sha3_256 hash (third-party implementation).
+    /// SHA3-256 hash (third-party implementation).
     pub fn sha3_256(
         &self,
         layouter: &mut impl Layouter<F>,
@@ -979,7 +997,7 @@ impl ZkStdLib {
         chip.sha3_256_digest(layouter, input)
     }
 
-    /// keccak_256 hash (third-party implementation).
+    /// Keccak-256 hash (third-party implementation).
     pub fn keccak_256(
         &self,
         layouter: &mut impl Layouter<F>,


### PR DESCRIPTION
Small PR to add missing features required for the passport verification.
1. Adding big endian conversions for biguint
2. Exposing varlen hash gadgets (not available before for, e.g., Poseidon)
3. Solve VectorGadget StackOverflow issue by boxing the buffer