### PR TITLE
Prover Optimization: affine SRS 

### DIFF
--- a/aggregation/src/light_aggregator/mod.rs
+++ b/aggregation/src/light_aggregator/mod.rs
@@ -272,7 +272,10 @@ impl<const NB_PROOFS: usize> LightAggregator<NB_PROOFS> {
             inner_vk: inner_vk.clone(),
             aggregator_vk,
             aggregator_pk,
-            lagrange_commitments: srs.g_lagrange()[..(nb_coms_per_proof * NB_PROOFS)].to_vec(),
+            lagrange_commitments: srs.g_lagrange()[..(nb_coms_per_proof * NB_PROOFS)]
+                .iter()
+                .map(|p| (*p).into())
+                .collect(),
         })
     }
 

--- a/curves/src/bls12_381/g1.rs
+++ b/curves/src/bls12_381/g1.rs
@@ -422,8 +422,11 @@ impl G1Affine {
 impl G1Affine {
     /// Perform a multi-exponentiation on affine points.
     ///
-    /// `nbits` is the maximum number of significant bits across all scalars.
-    pub fn multi_exp_affine(points: &[Self], scalars: &[Fq], nbits: usize) -> G1Projective {
+    /// # Panics
+    ///
+    /// If |points| != |scalars|.
+    /// If |scalars| == 0 due to internal blst `mult` call.
+    pub fn multi_exp_affine(points: &[Self], scalars: &[Fq]) -> G1Projective {
         use blst::MultiPoint;
 
         let n = points.len();
@@ -439,7 +442,7 @@ impl G1Affine {
         }
 
         // Blst Pippenger MSM over affine points.
-        let res = affine_slice.mult(scalar_bytes.as_slice(), nbits);
+        let res = affine_slice.mult(scalar_bytes.as_slice(), 255);
         G1Projective(res)
     }
 }
@@ -650,11 +653,8 @@ impl G1Projective {
     /// using `blst`'s implementation of Pippenger's algorithm.
     /// Note: `scalars` is cloned in this method.
     pub fn multi_exp(points: &[Self], scalars: &[Fq]) -> Self {
-        let n = if points.len() < scalars.len() {
-            points.len()
-        } else {
-            scalars.len()
-        };
+        let n = points.len();
+        assert_eq!(n, scalars.len());
         let points =
             unsafe { std::slice::from_raw_parts(points.as_ptr() as *const blst_p1, points.len()) };
 

--- a/curves/src/bls12_381/g1.rs
+++ b/curves/src/bls12_381/g1.rs
@@ -419,6 +419,31 @@ impl G1Affine {
     }
 }
 
+impl G1Affine {
+    /// Perform a multi-exponentiation on affine points.
+    ///
+    /// `nbits` is the maximum number of significant bits across all scalars.
+    pub fn multi_exp_affine(points: &[Self], scalars: &[Fq], nbits: usize) -> G1Projective {
+        use blst::MultiPoint;
+
+        let n = points.len();
+        assert_eq!(n, scalars.len());
+
+        // G1Affine is #[repr(transparent)] over blst_p1_affine.
+        let affine_slice =
+            unsafe { std::slice::from_raw_parts(points.as_ptr() as *const blst_p1_affine, n) };
+
+        let mut scalar_bytes: Vec<u8> = Vec::with_capacity(n * 32);
+        for a in scalars.iter().map(|s| s.to_bytes_le()) {
+            scalar_bytes.extend_from_slice(&a);
+        }
+
+        // Blst Pippenger MSM over affine points.
+        let res = affine_slice.mult(scalar_bytes.as_slice(), nbits);
+        G1Projective(res)
+    }
+}
+
 impl SerdeObject for G1Affine {
     fn from_raw_bytes_unchecked(bytes: &[u8]) -> Self {
         debug_assert_eq!(bytes.len(), UNCOMPRESSED_SIZE);

--- a/proofs/src/poly/kzg/msm.rs
+++ b/proofs/src/poly/kzg/msm.rs
@@ -1,12 +1,12 @@
 use std::{any::TypeId, fmt::Debug};
 
 use ff::Field;
-use group::{Curve, Group};
+use group::{prime::PrimeCurveAffine, Curve, Group};
 use itertools::izip;
 use midnight_curves::{
     msm::msm_best,
     pairing::{Engine, MillerLoopResult, MultiMillerLoop},
-    CurveAffine, Fq, G1Projective,
+    CurveAffine, Fq, G1Affine,
 };
 use rayon::iter::{IntoParallelRefMutIterator, ParallelIterator};
 
@@ -22,7 +22,6 @@ use crate::{
         helpers::ProcessedSerdeObject,
     },
 };
-
 
 /// A multi-scalar multiplication in the polynomial commitment scheme.
 /// For every i, term (bases_i, scalars_i) may be have an optional
@@ -142,7 +141,9 @@ where
         if self.scalars == vec![E::Fr::ONE] {
             self.bases[0]
         } else {
-            msm_specific::<E::G1Affine>(&self.scalars, &self.bases)
+            let mut affine = vec![E::G1Affine::identity(); self.bases.len()];
+            E::G1::batch_normalize(&self.bases, &mut affine);
+            msm_specific::<E::G1Affine>(&self.scalars, &affine)
         }
     }
 
@@ -161,9 +162,10 @@ where
 
 #[allow(unsafe_code)]
 /// Wrapper over the MSM function to use the blstrs underlying function.
-pub fn msm_specific<C: CurveAffine>(coeffs: &[C::Scalar], bases: &[C::Curve]) -> C::Curve {
+/// Bases are passed as affine points.
+pub fn msm_specific<C: CurveAffine>(coeffs: &[C::Scalar], bases: &[C]) -> C::Curve {
     // We remove zeros (keep only non-zero coefficients).
-    let (coeffs, bases): (Vec<C::Scalar>, Vec<C::Curve>) = coeffs
+    let (coeffs, bases): (Vec<C::Scalar>, Vec<C>) = coeffs
         .iter()
         .zip(bases)
         .filter(|(s, _)| !s.is_zero_vartime())
@@ -174,22 +176,19 @@ pub fn msm_specific<C: CurveAffine>(coeffs: &[C::Scalar], bases: &[C::Curve]) ->
         return C::Curve::identity();
     }
 
-    // We empirically checked that for MSMs larger than 2**18, the blstrs
+    // NOTE: Empirically checked that for MSMs larger than 2**18, the blstrs
     // implementation regresses.
-    if coeffs.len() <= (2 << 18)
-        && TypeId::of::<C>() == TypeId::of::<midnight_curves::G1Affine>()
-    {
-        // Safe: we just checked type.
-        let coeffs_slice = coeffs.as_slice();
-        let bases_slice = bases.as_slice();
-        let coeffs = unsafe { &*(coeffs_slice as *const _ as *const [Fq]) };
-        let bases = unsafe { &*(bases_slice as *const _ as *const [G1Projective]) };
-        let res = G1Projective::multi_exp(bases, coeffs);
+    // TODO: Review this threshold after optimizations.
+    if coeffs.len() <= (2 << 18) && TypeId::of::<C>() == TypeId::of::<G1Affine>() {
+        // Safe: we just checked the type.
+        let coeffs = unsafe { &*(coeffs.as_slice() as *const _ as *const [Fq]) };
+        let bases = unsafe { &*(bases.as_slice() as *const _ as *const [G1Affine]) };
+        // TODO: 255 is fine because type is checked. Another option is propagating
+        // nbits as an input of msm_specific.
+        let res = G1Affine::multi_exp_affine(bases, coeffs, 255);
         unsafe { std::mem::transmute_copy(&res) }
     } else {
-        let mut affine_bases = vec![C::identity(); coeffs.len()];
-        C::Curve::batch_normalize(&bases, &mut affine_bases);
-        msm_best(&coeffs, &affine_bases)
+        msm_best(&coeffs, &bases)
     }
 }
 

--- a/proofs/src/poly/kzg/msm.rs
+++ b/proofs/src/poly/kzg/msm.rs
@@ -185,7 +185,7 @@ pub fn msm_specific<C: CurveAffine>(coeffs: &[C::Scalar], bases: &[C]) -> C::Cur
         let bases = unsafe { &*(bases.as_slice() as *const _ as *const [G1Affine]) };
         // TODO: 255 is fine because type is checked. Another option is propagating
         // nbits as an input of msm_specific.
-        let res = G1Affine::multi_exp_affine(bases, coeffs, 255);
+        let res = G1Affine::multi_exp_affine(bases, coeffs);
         unsafe { std::mem::transmute_copy(&res) }
     } else {
         msm_best(&coeffs, &bases)

--- a/proofs/src/poly/kzg/params.rs
+++ b/proofs/src/poly/kzg/params.rs
@@ -1,14 +1,17 @@
 use std::{fmt::Debug, io};
 
 use ff::{Field, PrimeField};
-use group::{prime::PrimeCurveAffine, Curve, Group};
-use midnight_curves::pairing::{Engine, MultiMillerLoop};
+use group::{prime::PrimeCurveAffine, Curve, Group, GroupEncoding};
+use midnight_curves::{
+    pairing::{Engine, MultiMillerLoop},
+    serde::SerdeObject,
+};
 use rand_core::RngCore;
 
 use crate::{
     poly::commitment::Params,
     utils::{
-        arithmetic::{g_to_lagrange, parallelize},
+        arithmetic::{g_to_lagrange, parallelize, CurveAffine},
         helpers::ProcessedSerdeObject,
         SerdeFormat,
     },
@@ -17,13 +20,16 @@ use crate::{
 /// These are the public parameters for the polynomial commitment scheme.
 #[derive(Debug, Clone)]
 pub struct ParamsKZG<E: Engine> {
-    pub(crate) g: Vec<E::G1>,
-    pub(crate) g_lagrange: Vec<E::G1>,
+    pub(crate) g: Vec<E::G1Affine>,
+    pub(crate) g_lagrange: Vec<E::G1Affine>,
     pub(crate) g2: E::G2,
     pub(crate) s_g2: E::G2,
 }
 
-impl<E: Engine> Params for ParamsKZG<E> {
+impl<E: Engine> Params for ParamsKZG<E>
+where
+    E::G1Affine: CurveAffine,
+{
     fn max_k(&self) -> u32 {
         #[cfg(not(feature = "single-h-commitment"))]
         assert_eq!(self.g.len(), self.g_lagrange.len());
@@ -39,7 +45,10 @@ impl<E: Engine> Params for ParamsKZG<E> {
     }
 }
 
-impl<E: Engine + Debug> ParamsKZG<E> {
+impl<E: Engine + Debug> ParamsKZG<E>
+where
+    E::G1Affine: CurveAffine,
+{
     /// Downsize the current parameters to match a smaller `k`.
     pub fn downsize(&mut self, new_k: u32) {
         if self.max_k() == new_k {
@@ -131,12 +140,18 @@ impl<E: Engine + Debug> ParamsKZG<E> {
             }
         });
 
+        let mut g_affine = vec![E::G1Affine::identity(); n as usize];
+        E::G1::batch_normalize(&g, &mut g_affine);
+
+        let mut g_lagrange_affine = vec![E::G1Affine::identity(); n as usize];
+        E::G1::batch_normalize(&g_lagrange, &mut g_lagrange_affine);
+
         let g2 = E::G2::generator();
         let s_g2 = g2 * s;
 
         Self {
-            g,
-            g_lagrange,
+            g: g_affine,
+            g_lagrange: g_lagrange_affine,
             g2,
             s_g2,
         }
@@ -151,19 +166,27 @@ impl<E: Engine + Debug> ParamsKZG<E> {
         g2: E::G2,
         s_g2: E::G2,
     ) -> Self {
+        let n = g.len();
+        let mut g_affine = vec![E::G1Affine::identity(); n];
+        E::G1::batch_normalize(&g, &mut g_affine);
+        let g_lagrange_affine = match g_lagrange {
+            Some(g_l) => {
+                let mut aff = vec![E::G1Affine::identity(); g_l.len()];
+                E::G1::batch_normalize(&g_l, &mut aff);
+                aff
+            }
+            None => g_to_lagrange(&g_affine, k),
+        };
         Self {
-            g_lagrange: match g_lagrange {
-                Some(g_l) => g_l,
-                None => g_to_lagrange(&g, k),
-            },
-            g,
+            g: g_affine,
+            g_lagrange: g_lagrange_affine,
             g2,
             s_g2,
         }
     }
 
     /// Returns the committed lagrange polynomials of these KZG params.
-    pub fn g_lagrange(&self) -> &[E::G1] {
+    pub fn g_lagrange(&self) -> &[E::G1Affine] {
         &self.g_lagrange
     }
 
@@ -180,15 +203,21 @@ impl<E: Engine + Debug> ParamsKZG<E> {
     /// Writes parameters to buffer
     pub fn write_custom<W: io::Write>(&self, writer: &mut W, format: SerdeFormat) -> io::Result<()>
     where
-        E::G1: Curve + ProcessedSerdeObject,
-        E::G2: Curve + ProcessedSerdeObject,
+        E::G1Affine: SerdeObject,
+        E::G2: ProcessedSerdeObject,
     {
         writer.write_all(&self.g.len().ilog2().to_le_bytes())?;
         for el in self.g.iter() {
-            el.write(writer, format)?;
+            match format {
+                SerdeFormat::Processed => writer.write_all(el.to_bytes().as_ref())?,
+                _ => el.write_raw(writer)?,
+            }
         }
         for el in self.g_lagrange.iter() {
-            el.write(writer, format)?;
+            match format {
+                SerdeFormat::Processed => writer.write_all(el.to_bytes().as_ref())?,
+                _ => el.write_raw(writer)?,
+            }
         }
         self.g2.write(writer, format)?;
         self.s_g2.write(writer, format)?;
@@ -198,8 +227,8 @@ impl<E: Engine + Debug> ParamsKZG<E> {
     /// Reads params from a buffer.
     pub fn read_custom<R: io::Read>(reader: &mut R, format: SerdeFormat) -> io::Result<Self>
     where
-        E::G1: Curve + ProcessedSerdeObject,
-        E::G2: Curve + ProcessedSerdeObject,
+        E::G1Affine: SerdeObject,
+        E::G2: ProcessedSerdeObject,
     {
         let mut k = [0u8; 4];
         reader.read_exact(&mut k[..])?;
@@ -208,54 +237,42 @@ impl<E: Engine + Debug> ParamsKZG<E> {
 
         let (g, g_lagrange) = match format {
             SerdeFormat::Processed => {
-                use group::GroupEncoding;
                 let load_points_from_file_parallelly =
-                    |reader: &mut R| -> io::Result<Vec<Option<E::G1>>> {
+                    |reader: &mut R| -> io::Result<Vec<E::G1Affine>> {
                         let mut points_compressed =
-                            vec![<<E as Engine>::G1 as GroupEncoding>::Repr::default(); n];
+                            vec![<E::G1Affine as GroupEncoding>::Repr::default(); n];
                         for points_compressed in points_compressed.iter_mut() {
                             reader.read_exact((*points_compressed).as_mut())?;
                         }
-
-                        let mut points = vec![Option::<E::G1>::None; n];
+                        let mut points = vec![Option::<E::G1Affine>::None; n];
                         parallelize(&mut points, |points, chunks| {
                             for (i, point) in points.iter_mut().enumerate() {
-                                *point =
-                                    Option::from(E::G1::from_bytes(&points_compressed[chunks + i]));
+                                *point = Option::from(E::G1Affine::from_bytes(
+                                    &points_compressed[chunks + i],
+                                ));
                             }
                         });
-                        Ok(points)
+                        points
+                            .into_iter()
+                            .map(|p| p.ok_or_else(|| io::Error::other("invalid point encoding")))
+                            .collect()
                     };
 
                 let g = load_points_from_file_parallelly(reader)?;
-                let g: Vec<<E as Engine>::G1> = g
-                    .iter()
-                    .map(|point| point.ok_or_else(|| io::Error::other("invalid point encoding")))
-                    .collect::<Result<_, _>>()?;
                 let g_lagrange = load_points_from_file_parallelly(reader)?;
-                let g_lagrange: Vec<<E as Engine>::G1> = g_lagrange
-                    .iter()
-                    .map(|point| point.ok_or_else(|| io::Error::other("invalid point encoding")))
-                    .collect::<Result<_, _>>()?;
                 (g, g_lagrange)
             }
             SerdeFormat::RawBytes => {
-                let g = (0..n)
-                    .map(|_| <E::G1 as ProcessedSerdeObject>::read(reader, format))
-                    .collect::<Result<Vec<_>, _>>()?;
-                let g_lagrange = (0..n)
-                    .map(|_| <E::G1 as ProcessedSerdeObject>::read(reader, format))
-                    .collect::<Result<Vec<_>, _>>()?;
+                let g =
+                    (0..n).map(|_| E::G1Affine::read_raw(reader)).collect::<Result<Vec<_>, _>>()?;
+                let g_lagrange =
+                    (0..n).map(|_| E::G1Affine::read_raw(reader)).collect::<Result<Vec<_>, _>>()?;
                 (g, g_lagrange)
             }
             SerdeFormat::RawBytesUnchecked => {
-                // avoid try branching for performance
-                let g = (0..n)
-                    .map(|_| <E::G1 as ProcessedSerdeObject>::read(reader, format).unwrap())
-                    .collect::<Vec<_>>();
-                let g_lagrange = (0..n)
-                    .map(|_| <E::G1 as ProcessedSerdeObject>::read(reader, format).unwrap())
-                    .collect::<Vec<_>>();
+                let g = (0..n).map(|_| E::G1Affine::read_raw_unchecked(reader)).collect::<Vec<_>>();
+                let g_lagrange =
+                    (0..n).map(|_| E::G1Affine::read_raw_unchecked(reader)).collect::<Vec<_>>();
                 (g, g_lagrange)
             }
         };

--- a/proofs/src/utils/arithmetic.rs
+++ b/proofs/src/utils/arithmetic.rs
@@ -9,8 +9,8 @@ use std::{
 pub use ff::Field;
 use group::{
     ff::{BatchInvert, PrimeField},
-    prime::{PrimeCurve, PrimeCurveAffine},
-    GroupOpsOwned, ScalarMulOwned,
+    prime::PrimeCurveAffine,
+    Curve, GroupOpsOwned, ScalarMulOwned,
 };
 use midnight_curves::{fft::best_fft, pairing::MultiMillerLoop};
 pub use midnight_curves::{CurveAffine, CurveExt};
@@ -31,22 +31,26 @@ where
 }
 
 /// Convert coefficient bases group elements to lagrange basis by inverse FFT.
-pub fn g_to_lagrange<C: PrimeCurve>(g_projective: &[C], k: u32) -> Vec<C> {
-    let n_inv = C::Scalar::TWO_INV.pow_vartime([k as u64, 0, 0, 0]);
-    let mut omega_inv = C::Scalar::ROOT_OF_UNITY_INV;
-    for _ in k..C::Scalar::S {
+pub fn g_to_lagrange<C: CurveAffine>(g_affine: &[C], k: u32) -> Vec<C> {
+    let n_inv = C::ScalarExt::TWO_INV.pow_vartime([k as u64, 0, 0, 0]);
+    let mut omega_inv = C::ScalarExt::ROOT_OF_UNITY_INV;
+    for _ in k..C::ScalarExt::S {
         omega_inv = omega_inv.square();
     }
 
-    let mut g_lagrange = g_projective.to_vec();
-    best_fft(&mut g_lagrange, omega_inv, k);
-    parallelize(&mut g_lagrange, |g, _| {
+    // The FFT operates in projective coordinates (G1Affine is not closed
+    // under addition), so convert on entry and normalize back on exit.
+    let mut g_proj: Vec<C::CurveExt> = g_affine.iter().map(|p| (*p).into()).collect();
+    best_fft(&mut g_proj, omega_inv, k);
+    parallelize(&mut g_proj, |g, _| {
         for g in g.iter_mut() {
             *g *= n_inv;
         }
     });
 
-    g_lagrange.to_vec()
+    let mut g_lagrange = vec![C::identity(); g_proj.len()];
+    C::CurveExt::batch_normalize(&g_proj, &mut g_lagrange);
+    g_lagrange
 }
 
 /// This evaluates a provided polynomial (in coefficient form) at `point`.


### PR DESCRIPTION
Merges into  #349 

  ## Summary

  - Store the SRS points (`g`, `g_lagrange`) as `Vec<G1Affine>` instead of  `Vec<G1Projective>`.
 This eliminates the projective→affine batch conversion     that blst's Pippenger performs internally on every MSM call.
  - Add `G1Affine::multi_exp_affine` that calls blst's Pippenger directly on  affine points, and route `msm_specific` through it for BLS12-381.
  - Change `g_to_lagrange` to accept and return affine points.
  The FFT still  runs in projective coordinates internally, but the conversion is now encapsulated inside `g_to_lagrange`. This cleans up the codebase and its fine since we call this on SRS points that should always be in affine form.
  - Simplify SRS serialization: read/write `G1Affine` directly via `SerdeObject`, removing the `ProcessedSerdeObject` indirection for `G1` points. Format is unchanged (both old and new code serialize the compressed/uncompressed affine representation).
The serialization could still be cleaned up further, but that needs a deeper refactor in `proofs` and `curves`.
  - The `light_aggregator` stores its `lagrange_commitments` as projective (needed by the IPA). An affine→projective conversion is added at load time (not the hot path, so it does not hurt performance).

## Peformance improvement
| Optimization | k=15 (ms) | delta | k=17 (ms) | delta |
  | :--- | :-------: | :-----: | :-------: | :-----: |
  | Baseline  | 3214 | — | 13434 | — |
  | Affine SRS | 3149 | -2.0% | 13224 | -1.6% |

 **CPU**: Intel i5-11400H (6C/12T, 12 MB L3)
 Turbo disabled for stability