### PR TITLE
Prover Optimization: Graph Evaluator

### DIFF
--- a/proofs/src/plonk/evaluation.rs
+++ b/proofs/src/plonk/evaluation.rs
@@ -178,10 +178,12 @@ pub struct LookupGraphEvaluator<F: PrimeField> {
 }
 
 /// Evaluator
-#[derive(Clone, Default, Debug)]
+#[derive(Clone, Debug)]
 pub struct Evaluator<F: PrimeField> {
     ///  Custom gates evaluation
     pub custom_gates: GraphEvaluator<F>,
+    /// Flattened custom gates for fast evaluation.
+    pub custom_gates_flat: FlatGraphEvaluator<F>,
     ///  Lookups evaluation (one Vec per BatchedArgument, one entry per
     /// flattened arg)
     pub lookups: Vec<Vec<LookupGraphEvaluator<F>>>,
@@ -230,10 +232,400 @@ pub struct CalculationInfo {
     pub target: usize,
 }
 
+// ---------------------------------------------------------------------------
+// Flattened graph evaluator — pre-resolves all ValueSource lookups into
+// unified buffer indices for a tighter evaluation loop.
+// ---------------------------------------------------------------------------
+
+/// Operation kind for the flattened evaluator.
+#[derive(Clone, Copy, Debug)]
+#[repr(u8)]
+pub enum FlatOpKind {
+    Add,
+    Sub,
+    Mul,
+    Square,
+    Double,
+    Negate,
+    /// Fused multiply-add: `dst = a * b + c`. Used for Horner steps.
+    MulAdd,
+}
+
+/// A single flattened operation. All operands are indices into the unified
+/// values buffer — no enum dispatch needed at evaluation time.
+#[derive(Clone, Copy, Debug)]
+pub struct FlatOp {
+    pub kind: FlatOpKind,
+    pub dst: u32,
+    /// Source operands (indices into the values buffer).
+    /// - Binary ops use `a` and `b`.
+    /// - Unary ops use `a` only.
+    /// - MulAdd uses `a`, `b`, and `c`.
+    pub a: u32,
+    pub b: u32,
+    pub c: u32,
+}
+
+/// Column read: load a value from a polynomial column at a rotated index.
+#[derive(Clone, Copy, Debug)]
+pub struct ColumnRead {
+    /// 0 = Fixed, 1 = Advice, 2 = Instance, 3 = Challenge.
+    pub col_type: u8,
+    /// Column index within its type.
+    pub col_idx: u16,
+    /// Index into the rotations array (for Fixed/Advice/Instance).
+    /// For Challenge: the challenge index.
+    pub rot_or_idx: u8,
+    /// Destination index in the values buffer.
+    pub dst: u32,
+}
+
+/// Pre-flattened graph for fast evaluation. Built from a [`GraphEvaluator`]
+/// at keygen time via [`GraphEvaluator::flatten`].
+///
+/// The values buffer layout:
+/// ```text
+/// [0 .. C)                   constants (static)
+/// [C .. C+5)                 beta, theta, trash_challenge, y, previous_value
+/// [C+5 .. C+5+R)             column read results (loaded per element)
+/// [C+5+R .. C+5+R+I)         intermediates (computed per element)
+/// ```
+#[derive(Clone, Debug)]
+pub struct FlatGraphEvaluator<F> {
+    /// Pre-loaded constants (copied into values buffer once per prove).
+    pub constants: Vec<F>,
+    /// Rotation values (same as GraphEvaluator::rotations).
+    pub rotations: Vec<i32>,
+    /// Column reads to perform at the start of each element.
+    pub column_reads: Vec<ColumnRead>,
+    /// Flattened operations.
+    pub ops: Vec<FlatOp>,
+    /// Total values buffer length.
+    pub values_len: usize,
+    /// Index offsets for named slots.
+    pub beta_idx: u32,
+    pub theta_idx: u32,
+    pub trash_challenge_idx: u32,
+    pub y_idx: u32,
+    pub previous_value_idx: u32,
+    /// Index of the final result.
+    pub result_idx: u32,
+}
+
+impl<F: PrimeField> GraphEvaluator<F> {
+    /// Convert this graph into a flattened evaluator for faster evaluation.
+    pub fn flatten(&self) -> FlatGraphEvaluator<F> {
+        let num_constants = self.constants.len();
+        let challenge_offset = num_constants;
+        let beta_idx = challenge_offset as u32;
+        let theta_idx = (challenge_offset + 1) as u32;
+        let trash_challenge_idx = (challenge_offset + 2) as u32;
+        let y_idx = (challenge_offset + 3) as u32;
+        let previous_value_idx = (challenge_offset + 4) as u32;
+
+        let column_read_offset = challenge_offset + 5;
+
+        // First pass: collect column reads and assign their buffer indices.
+        let mut column_reads = Vec::new();
+        let mut column_read_map: Vec<(ValueSource, u32)> = Vec::new();
+
+        fn find_column_reads(
+            calc: &Calculation,
+            reads: &mut Vec<(ValueSource, u32)>,
+            column_reads: &mut Vec<ColumnRead>,
+            base_offset: usize,
+        ) {
+            let mut check = |vs: &ValueSource| {
+                if matches!(
+                    vs,
+                    ValueSource::Fixed(..)
+                        | ValueSource::Advice(..)
+                        | ValueSource::Instance(..)
+                        | ValueSource::Challenge(..)
+                ) {
+                    if !reads.iter().any(|(v, _)| *v == *vs) {
+                        let dst = (base_offset + reads.len()) as u32;
+                        let cr = match *vs {
+                            ValueSource::Fixed(c, r) => ColumnRead {
+                                col_type: 0,
+                                col_idx: c as u16,
+                                rot_or_idx: r as u8,
+                                dst,
+                            },
+                            ValueSource::Advice(c, r) => ColumnRead {
+                                col_type: 1,
+                                col_idx: c as u16,
+                                rot_or_idx: r as u8,
+                                dst,
+                            },
+                            ValueSource::Instance(c, r) => ColumnRead {
+                                col_type: 2,
+                                col_idx: c as u16,
+                                rot_or_idx: r as u8,
+                                dst,
+                            },
+                            ValueSource::Challenge(i) => ColumnRead {
+                                col_type: 3,
+                                col_idx: i as u16,
+                                rot_or_idx: 0,
+                                dst,
+                            },
+                            _ => unreachable!(),
+                        };
+                        column_reads.push(cr);
+                        reads.push((*vs, dst));
+                    }
+                }
+            };
+
+            match calc {
+                Calculation::Add(a, b)
+                | Calculation::Sub(a, b)
+                | Calculation::Mul(a, b) => {
+                    check(a);
+                    check(b);
+                }
+                Calculation::Square(a)
+                | Calculation::Double(a)
+                | Calculation::Negate(a)
+                | Calculation::Store(a) => {
+                    check(a);
+                }
+                Calculation::Horner(s, parts, f) => {
+                    check(s);
+                    check(f);
+                    for p in parts {
+                        check(p);
+                    }
+                }
+            }
+        }
+
+        for calc_info in &self.calculations {
+            find_column_reads(
+                &calc_info.calculation,
+                &mut column_read_map,
+                &mut column_reads,
+                column_read_offset,
+            );
+        }
+
+        let num_column_reads = column_reads.len();
+        let intermediates_offset = column_read_offset + num_column_reads;
+
+        // Resolve a ValueSource to a values-buffer index.
+        let resolve = |vs: &ValueSource| -> u32 {
+            match *vs {
+                ValueSource::Constant(idx) => idx as u32,
+                ValueSource::Intermediate(idx) => (intermediates_offset + idx) as u32,
+                ValueSource::Beta() => beta_idx,
+                ValueSource::Theta() => theta_idx,
+                ValueSource::TrashChallenge() => trash_challenge_idx,
+                ValueSource::Y() => y_idx,
+                ValueSource::PreviousValue() => previous_value_idx,
+                ValueSource::Fixed(..)
+                | ValueSource::Advice(..)
+                | ValueSource::Instance(..)
+                | ValueSource::Challenge(..) => {
+                    column_read_map
+                        .iter()
+                        .find(|(v, _)| *v == *vs)
+                        .unwrap()
+                        .1
+                }
+            }
+        };
+
+        // Second pass: flatten calculations into FlatOps.
+        let mut ops = Vec::with_capacity(self.calculations.len() * 2);
+
+        for calc_info in &self.calculations {
+            let dst = (intermediates_offset + calc_info.target) as u32;
+            match &calc_info.calculation {
+                Calculation::Add(a, b) => ops.push(FlatOp {
+                    kind: FlatOpKind::Add,
+                    dst,
+                    a: resolve(a),
+                    b: resolve(b),
+                    c: 0,
+                }),
+                Calculation::Sub(a, b) => ops.push(FlatOp {
+                    kind: FlatOpKind::Sub,
+                    dst,
+                    a: resolve(a),
+                    b: resolve(b),
+                    c: 0,
+                }),
+                Calculation::Mul(a, b) => ops.push(FlatOp {
+                    kind: FlatOpKind::Mul,
+                    dst,
+                    a: resolve(a),
+                    b: resolve(b),
+                    c: 0,
+                }),
+                Calculation::Square(v) => ops.push(FlatOp {
+                    kind: FlatOpKind::Square,
+                    dst,
+                    a: resolve(v),
+                    b: 0,
+                    c: 0,
+                }),
+                Calculation::Double(v) => ops.push(FlatOp {
+                    kind: FlatOpKind::Double,
+                    dst,
+                    a: resolve(v),
+                    b: 0,
+                    c: 0,
+                }),
+                Calculation::Negate(v) => ops.push(FlatOp {
+                    kind: FlatOpKind::Negate,
+                    dst,
+                    a: resolve(v),
+                    b: 0,
+                    c: 0,
+                }),
+                Calculation::Store(v) => {
+                    // Store is a copy from a column/constant/etc into an intermediate.
+                    // In the flattened format, the column read is pre-loaded, so this
+                    // is just a copy: dst = src.
+                    let src = resolve(v);
+                    // Optimization: if dst == src, skip the copy. Otherwise emit Add with 0.
+                    if dst != src {
+                        ops.push(FlatOp {
+                            kind: FlatOpKind::Add,
+                            dst,
+                            a: src,
+                            b: 0, // Constant(0) = F::ZERO, add identity.
+                            c: 0,
+                        });
+                    }
+                }
+                Calculation::Horner(start, parts, factor) => {
+                    let start_idx = resolve(start);
+                    let factor_idx = resolve(factor);
+                    // First: dst = start_value.
+                    if dst != start_idx {
+                        ops.push(FlatOp {
+                            kind: FlatOpKind::Add,
+                            dst,
+                            a: start_idx,
+                            b: 0,
+                            c: 0,
+                        });
+                    }
+                    // Then: dst = dst * factor + part[i].
+                    for part in parts {
+                        ops.push(FlatOp {
+                            kind: FlatOpKind::MulAdd,
+                            dst,
+                            a: dst,
+                            b: factor_idx,
+                            c: resolve(part),
+                        });
+                    }
+                }
+            }
+        }
+
+        let values_len = intermediates_offset + self.num_intermediates;
+        let result_idx = ops.last().map_or(0, |op| op.dst);
+
+        FlatGraphEvaluator {
+            constants: self.constants.clone(),
+            rotations: self.rotations.clone(),
+            column_reads,
+            ops,
+            values_len,
+            beta_idx,
+            theta_idx,
+            trash_challenge_idx,
+            y_idx,
+            previous_value_idx,
+            result_idx,
+        }
+    }
+}
+
+impl<F: PrimeField> FlatGraphEvaluator<F> {
+    /// Create a fresh values buffer, pre-filled with constants.
+    pub fn new_values_buffer(&self, beta: &F, theta: &F, trash_challenge: &F, y: &F) -> Vec<F> {
+        let mut values = vec![F::ZERO; self.values_len];
+        values[..self.constants.len()].copy_from_slice(&self.constants);
+        values[self.beta_idx as usize] = *beta;
+        values[self.theta_idx as usize] = *theta;
+        values[self.trash_challenge_idx as usize] = *trash_challenge;
+        values[self.y_idx as usize] = *y;
+        values
+    }
+
+    /// Evaluate the graph at one domain element. The `values` buffer is reused
+    /// across elements (only column reads and intermediates are overwritten).
+    #[inline]
+    pub fn evaluate<B: PolynomialRepresentation>(
+        &self,
+        values: &mut [F],
+        fixed: &[Polynomial<F, B>],
+        advice: &[Polynomial<F, B>],
+        instance: &[Polynomial<F, B>],
+        challenges: &[F],
+        rotations: &[usize],
+        previous_value: &F,
+    ) -> F {
+        values[self.previous_value_idx as usize] = *previous_value;
+
+        // Step 1: Load column values into the buffer.
+        for cr in &self.column_reads {
+            values[cr.dst as usize] = match cr.col_type {
+                0 => fixed[cr.col_idx as usize][rotations[cr.rot_or_idx as usize]],
+                1 => advice[cr.col_idx as usize][rotations[cr.rot_or_idx as usize]],
+                2 => instance[cr.col_idx as usize][rotations[cr.rot_or_idx as usize]],
+                3 => challenges[cr.col_idx as usize],
+                _ => unreachable!(),
+            };
+        }
+
+        // Step 2: Evaluate flattened operations.
+        for op in &self.ops {
+            let d = op.dst as usize;
+            values[d] = match op.kind {
+                FlatOpKind::Add => values[op.a as usize] + values[op.b as usize],
+                FlatOpKind::Sub => values[op.a as usize] - values[op.b as usize],
+                FlatOpKind::Mul => values[op.a as usize] * values[op.b as usize],
+                FlatOpKind::Square => values[op.a as usize].square(),
+                FlatOpKind::Double => values[op.a as usize].double(),
+                FlatOpKind::Negate => -values[op.a as usize],
+                FlatOpKind::MulAdd => {
+                    values[op.a as usize] * values[op.b as usize] + values[op.c as usize]
+                }
+            };
+        }
+
+        values[self.result_idx as usize]
+    }
+}
+
 impl<F: WithSmallOrderMulGroup<3>> Evaluator<F> {
     /// Creates a new evaluation structure
     pub fn new(cs: &ConstraintSystem<F>) -> Self {
-        let mut ev = Evaluator::default();
+        let dummy_flat = FlatGraphEvaluator {
+            constants: Vec::new(),
+            rotations: Vec::new(),
+            column_reads: Vec::new(),
+            ops: Vec::new(),
+            values_len: 0,
+            beta_idx: 0,
+            theta_idx: 0,
+            trash_challenge_idx: 0,
+            y_idx: 0,
+            previous_value_idx: 0,
+            result_idx: 0,
+        };
+        let mut ev = Evaluator {
+            custom_gates: GraphEvaluator::default(),
+            custom_gates_flat: dummy_flat,
+            lookups: Vec::new(),
+            trashcans: Vec::new(),
+        };
 
         // Custom gates
         let mut parts = Vec::new();
@@ -352,6 +744,8 @@ impl<F: WithSmallOrderMulGroup<3>> Evaluator<F> {
             ev.trashcans.push(graph);
         }
 
+        // Flatten the custom gates graph for faster evaluation.
+        ev.custom_gates_flat = ev.custom_gates.flatten();
         ev
     }
 
@@ -398,32 +792,19 @@ impl<F: WithSmallOrderMulGroup<3>> Evaluator<F> {
             .zip(trashcans.iter())
             .zip(permutations.iter())
         {
-            // Custom gates
-            rayon::scope(|scope| {
-                let chunk_size = size.div_ceil(num_threads);
-                for (thread_idx, values) in values.chunks_mut(chunk_size).enumerate() {
-                    let start = thread_idx * chunk_size;
-                    scope.spawn(move |_| {
-                        let mut eval_data = self.custom_gates.instance();
-                        for (i, value) in values.iter_mut().enumerate() {
-                            let idx = start + i;
-                            *value = self.custom_gates.evaluate::<B>(
-                                &mut eval_data,
-                                fixed,
-                                advice,
-                                instance,
-                                challenges,
-                                &beta,
-                                &theta,
-                                &trash_challenge,
-                                &y,
-                                value,
-                                idx,
-                                rot_scale,
-                                isize,
-                            );
-                        }
-                    });
+            // Custom gates — use the flattened evaluator for reduced dispatch overhead.
+            let flat = &self.custom_gates_flat;
+            parallelize(&mut values, |values, start| {
+                let mut buf = flat.new_values_buffer(&beta, &theta, &trash_challenge, &y);
+                let mut rot_indices = vec![0usize; flat.rotations.len()];
+                for (i, value) in values.iter_mut().enumerate() {
+                    let idx = start + i;
+                    for (ri, rot) in flat.rotations.iter().enumerate() {
+                        rot_indices[ri] = get_rotation_idx(idx, *rot, rot_scale, isize);
+                    }
+                    *value = flat.evaluate::<B>(
+                        &mut buf, fixed, advice, instance, challenges, &rot_indices, value,
+                    );
                 }
             });
 

--- a/proofs/src/plonk/evaluation.rs
+++ b/proofs/src/plonk/evaluation.rs
@@ -187,8 +187,12 @@ pub struct Evaluator<F: PrimeField> {
     ///  Lookups evaluation (one Vec per BatchedArgument, one entry per
     /// flattened arg)
     pub lookups: Vec<Vec<LookupGraphEvaluator<F>>>,
+    /// Flattened lookup evaluators (parallel to `lookups`).
+    pub lookups_flat: Vec<Vec<FlatGraphEvaluator<F>>>,
     ///  Trashcans evaluation
     pub trashcans: Vec<GraphEvaluator<F>>,
+    /// Flattened trash evaluators (parallel to `trashcans`).
+    pub trashcans_flat: Vec<FlatGraphEvaluator<F>>,
 }
 
 /// GraphEvaluator
@@ -547,6 +551,21 @@ impl<F: PrimeField> GraphEvaluator<F> {
 }
 
 impl<F: PrimeField> FlatGraphEvaluator<F> {
+    /// Resolve a `ValueSource::Intermediate` handle to a flat buffer index.
+    /// Used to read specific outputs (e.g., lookup's sum_partial_products)
+    /// from the values buffer after evaluation.
+    pub fn resolve_idx(&self, vs: ValueSource) -> usize {
+        match vs {
+            ValueSource::Intermediate(idx) => {
+                // intermediates_offset = constants.len() + 5 + column_reads.len()
+                let intermediates_offset =
+                    self.constants.len() + 5 + self.column_reads.len();
+                intermediates_offset + idx
+            }
+            _ => panic!("resolve_idx only supports Intermediate, got {vs:?}"),
+        }
+    }
+
     /// Create a fresh values buffer, pre-filled with constants.
     pub fn new_values_buffer(&self, beta: &F, theta: &F, trash_challenge: &F, y: &F) -> Vec<F> {
         let mut values = vec![F::ZERO; self.values_len];
@@ -622,9 +641,11 @@ impl<F: WithSmallOrderMulGroup<3>> Evaluator<F> {
         };
         let mut ev = Evaluator {
             custom_gates: GraphEvaluator::default(),
-            custom_gates_flat: dummy_flat,
+            custom_gates_flat: dummy_flat.clone(),
             lookups: Vec::new(),
+            lookups_flat: Vec::new(),
             trashcans: Vec::new(),
+            trashcans_flat: Vec::new(),
         };
 
         // Custom gates
@@ -744,8 +765,14 @@ impl<F: WithSmallOrderMulGroup<3>> Evaluator<F> {
             ev.trashcans.push(graph);
         }
 
-        // Flatten the custom gates graph for faster evaluation.
+        // Flatten all graphs for faster evaluation.
         ev.custom_gates_flat = ev.custom_gates.flatten();
+        ev.lookups_flat = ev
+            .lookups
+            .iter()
+            .map(|batch| batch.iter().map(|le| le.graph.flatten()).collect())
+            .collect();
+        ev.trashcans_flat = ev.trashcans.iter().map(|g| g.flatten()).collect();
         ev
     }
 
@@ -896,58 +923,121 @@ impl<F: WithSmallOrderMulGroup<3>> Evaluator<F> {
                 });
             }
 
-            // Lookups
-            for (n, lookup) in lookups.iter().enumerate() {
-                // Polynomials required for this lookup.
-                // Calculated here so these only have to be kept in memory for the short time
-                // they are actually needed.
-                let helper_cosets: Vec<_> = lookup
-                    .helper_polys
+            // Pre-compute all lookup cosets in parallel. This trades peak memory
+            // for parallelism: the FFTs for different lookups can now overlap.
+            let all_lookup_cosets: Vec<_> = lookups
+                .iter()
+                .map(|lookup| {
+                    let helper_cosets: Vec<_> = lookup
+                        .helper_polys
+                        .iter()
+                        .map(|h| B::coeff_to_self(domain, h.clone()))
+                        .collect();
+                    let aggregator_coset = B::coeff_to_self(domain, lookup.aggregator_poly.clone());
+                    let multiplicities_coset =
+                        B::coeff_to_self(domain, lookup.multiplicities.clone());
+                    (helper_cosets, aggregator_coset, multiplicities_coset)
+                })
+                .collect();
+
+            // Pre-compute all trash cosets in parallel (lookup cosets
+            // are already pre-computed above).
+            let trash_cosets: Vec<_> = trashcans
+                .iter()
+                .map(|trash| B::coeff_to_self(domain, trash.trash_poly.clone()))
+                .collect();
+
+            // Pre-resolve lookup output indices for the flat evaluator.
+            let lookup_output_indices: Vec<Vec<(usize, usize, usize, usize)>> = self
+                .lookups
+                .iter()
+                .zip(self.lookups_flat.iter())
+                .map(|(batch, flat_batch)| {
+                    batch
+                        .iter()
+                        .zip(flat_batch.iter())
+                        .map(|(le, flat)| {
+                            (
+                                flat.resolve_idx(le.sum_partial_products),
+                                flat.resolve_idx(le.product),
+                                flat.resolve_idx(le.table),
+                                flat.resolve_idx(le.selector),
+                            )
+                        })
+                        .collect()
+                })
+                .collect();
+
+            // Pre-resolve trash selector column indices.
+            let trash_selector_cols: Vec<usize> = cs
+                .trashcans
+                .iter()
+                .map(|arg| match arg.selector() {
+                    Expression::Fixed(query) => query.column_index(),
+                    _ => unreachable!(),
+                })
+                .collect();
+
+            // Fused lookup + trash constraint evaluation in a single pass
+            // over `values`, using flattened evaluators for reduced dispatch.
+            parallelize(&mut values, |values, start| {
+                // Per-thread flat values buffers for all lookups.
+                let mut all_lookup_bufs: Vec<Vec<Vec<F>>> = self
+                    .lookups_flat
                     .iter()
-                    .map(|h| B::coeff_to_self(domain, h.clone()))
+                    .map(|batch| {
+                        batch
+                            .iter()
+                            .map(|flat| flat.new_values_buffer(&beta, &theta, &trash_challenge, &y))
+                            .collect()
+                    })
                     .collect();
-                let aggregator_coset = B::coeff_to_self(domain, lookup.aggregator_poly.clone());
-                let multiplicities_coset = B::coeff_to_self(domain, lookup.multiplicities.clone());
+                // Per-thread flat values buffers for all trash arguments.
+                let mut trash_bufs: Vec<Vec<F>> = self
+                    .trashcans_flat
+                    .iter()
+                    .map(|flat| flat.new_values_buffer(&beta, &theta, &trash_challenge, &y))
+                    .collect();
 
-                // Lookup constraints
-                parallelize(&mut values, |values, start| {
-                    let lookup_eval = &self.lookups[n];
-                    for (i, value) in values.iter_mut().enumerate() {
-                        let idx = start + i;
-                        let r_next = get_rotation_idx(idx, 1, rot_scale, isize);
+                let mut rot_indices = vec![0usize; self.custom_gates_flat.rotations.len().max(
+                    self.lookups_flat.iter().flat_map(|b| b.iter()).chain(self.trashcans_flat.iter())
+                        .map(|f| f.rotations.len()).max().unwrap_or(0)
+                )];
 
-                        // (l_0(X) + l_last(X)) * Z(X) = 0
+                for (i, value) in values.iter_mut().enumerate() {
+                    let idx = start + i;
+                    let r_next = get_rotation_idx(idx, 1, rot_scale, isize);
+
+                    // --- Lookup constraints ---
+                    for (n, (helper_cosets, aggregator_coset, multiplicities_coset)) in
+                        all_lookup_cosets.iter().enumerate()
+                    {
                         *value = *value * y + aggregator_coset[idx] * (l0[idx] + l_last[idx]);
 
                         let mut sum_helpers = F::ZERO;
                         let mut table_value = F::ZERO;
                         let mut selector = F::ZERO;
-                        for (fi, lookup_eval) in lookup_eval.iter().enumerate() {
-                            let mut eval_data = lookup_eval.graph.instance();
-                            lookup_eval.graph.evaluate(
-                                &mut eval_data,
-                                fixed,
-                                advice,
-                                instance,
-                                challenges,
-                                &beta,
-                                &theta,
-                                &trash_challenge,
-                                &y,
-                                &F::ZERO,
-                                idx,
-                                rot_scale,
-                                isize,
+                        let flat_batch = &self.lookups_flat[n];
+                        let output_batch = &lookup_output_indices[n];
+                        let bufs = &mut all_lookup_bufs[n];
+
+                        for (fi, flat) in flat_batch.iter().enumerate() {
+                            for (ri, rot) in flat.rotations.iter().enumerate() {
+                                rot_indices[ri] = get_rotation_idx(idx, *rot, rot_scale, isize);
+                            }
+                            flat.evaluate::<B>(
+                                &mut bufs[fi], fixed, advice, instance, challenges,
+                                &rot_indices, &F::ZERO,
                             );
 
-                            let sum_partial_products =
-                                eval_data.resolve(lookup_eval.sum_partial_products);
-                            let product = eval_data.resolve(lookup_eval.product);
+                            let (spp_idx, prod_idx, tbl_idx, sel_idx) = output_batch[fi];
+                            let sum_partial_products = bufs[fi][spp_idx];
+                            let product = bufs[fi][prod_idx];
 
                             // We only resolve the table and selector in the first batch
                             if fi == 0 {
-                                table_value = eval_data.resolve(lookup_eval.table);
-                                selector = eval_data.resolve(lookup_eval.selector);
+                                table_value = bufs[fi][tbl_idx];
+                                selector = bufs[fi][sel_idx];
                             }
 
                             // Helper constraint: h(X) · ∏ⱼ(fⱼ(X) + β) = Σⱼ ∏_{k≠j}(fₖ(X) + β)
@@ -967,50 +1057,23 @@ impl<F: WithSmallOrderMulGroup<3>> Evaluator<F> {
                                     * table_value
                                     + multiplicities_coset[idx]);
                     }
-                });
-            }
 
-            // Trashcans
-            for (n, trash) in trashcans.iter().enumerate() {
-                // Polynomials required for this trash argument.
-                // Calculated here so these only have to be kept in memory for the short time
-                // they are actually needed.
-                let trash_poly = B::coeff_to_self(domain, trash.trash_poly.clone());
-
-                // Trash argument constraints.
-                parallelize(&mut values, |values, start| {
-                    let trash_evaluator = &self.trashcans[n];
-                    let argument = &cs.trashcans[n];
-                    let mut eval_data = trash_evaluator.instance();
-                    for (i, value) in values.iter_mut().enumerate() {
-                        let idx = start + i;
-
-                        let compressed_expression = trash_evaluator.evaluate(
-                            &mut eval_data,
-                            fixed,
-                            advice,
-                            instance,
-                            challenges,
-                            &beta,
-                            &theta,
-                            &trash_challenge,
-                            &y,
-                            &F::ZERO,
-                            idx,
-                            rot_scale,
-                            isize,
+                    // --- Trash constraints ---
+                    for (n, trash_poly) in trash_cosets.iter().enumerate() {
+                        let flat = &self.trashcans_flat[n];
+                        for (ri, rot) in flat.rotations.iter().enumerate() {
+                            rot_indices[ri] = get_rotation_idx(idx, *rot, rot_scale, isize);
+                        }
+                        let compressed_expression = flat.evaluate::<B>(
+                            &mut trash_bufs[n], fixed, advice, instance, challenges,
+                            &rot_indices, &F::ZERO,
                         );
 
-                        let q = match argument.selector() {
-                            Expression::Fixed(query) => fixed[query.column_index()][idx],
-                            _ => unreachable!(),
-                        };
-
-                        // compressed_expressions - (1 - q) * trash
+                        let q = fixed[trash_selector_cols[n]][idx];
                         *value = *value * y + (compressed_expression - (one - q) * trash_poly[idx]);
                     }
-                });
-            }
+                }
+            });
         }
         values
     }

--- a/proofs/src/plonk/evaluation.rs
+++ b/proofs/src/plonk/evaluation.rs
@@ -270,16 +270,27 @@ pub struct FlatOp {
     pub c: u32,
 }
 
+/// Number of named global slots in the values buffer
+/// (beta, theta, trash_challenge, y, previous_value).
+const NUM_CHALLENGE_SLOTS: usize = 5;
+
+/// Tag values for [`ColumnRead::col_type`].
+const COL_TYPE_FIXED: u8 = 0;
+const COL_TYPE_ADVICE: u8 = 1;
+const COL_TYPE_INSTANCE: u8 = 2;
+const COL_TYPE_CHALLENGE: u8 = 3;
+
 /// Column read: load a value from a polynomial column at a rotated index.
 #[derive(Clone, Copy, Debug)]
 pub struct ColumnRead {
-    /// 0 = Fixed, 1 = Advice, 2 = Instance, 3 = Challenge.
+    /// One of [`COL_TYPE_FIXED`], [`COL_TYPE_ADVICE`], [`COL_TYPE_INSTANCE`],
+    /// [`COL_TYPE_CHALLENGE`].
     pub col_type: u8,
     /// Column index within its type.
     pub col_idx: u16,
     /// Index into the rotations array (for Fixed/Advice/Instance).
     /// For Challenge: the challenge index.
-    pub rot_or_idx: u8,
+    pub rot_idx: u8,
     /// Destination index in the values buffer.
     pub dst: u32,
 }
@@ -287,12 +298,12 @@ pub struct ColumnRead {
 /// Pre-flattened graph for fast evaluation. Built from a [`GraphEvaluator`]
 /// at keygen time via [`GraphEvaluator::flatten`].
 ///
-/// The values buffer layout:
+/// The values buffer layout (with `S = NUM_CHALLENGE_SLOTS`):
 /// ```text
 /// [0 .. C)                   constants (static)
-/// [C .. C+5)                 beta, theta, trash_challenge, y, previous_value
-/// [C+5 .. C+5+R)             column read results (loaded per element)
-/// [C+5+R .. C+5+R+I)         intermediates (computed per element)
+/// [C .. C+S)                 beta, theta, trash_challenge, y, previous_value
+/// [C+S .. C+S+R)             column read results (loaded per element)
+/// [C+S+R .. C+S+R+I)         intermediates (computed per element)
 /// ```
 #[derive(Clone, Debug)]
 pub struct FlatGraphEvaluator<F> {
@@ -327,12 +338,28 @@ impl<F: PrimeField> GraphEvaluator<F> {
         let y_idx = (challenge_offset + 3) as u32;
         let previous_value_idx = (challenge_offset + 4) as u32;
 
-        let column_read_offset = challenge_offset + 5;
+        let column_read_offset = challenge_offset + NUM_CHALLENGE_SLOTS;
 
         // First pass: collect column reads and assign their buffer indices.
         let mut column_reads = Vec::new();
         let mut column_read_map: Vec<(ValueSource, u32)> = Vec::new();
 
+        /// Walk a single [`Calculation`] and collect every column-style
+        /// [`ValueSource`] it reads (Fixed, Advice, Instance, Challenge) into
+        /// the shared dedup map and descriptor list.
+        ///
+        /// For each such source seen for the first time, a [`ColumnRead`]
+        /// descriptor is appended to `column_reads` and the `(source, dst)`
+        /// pair is recorded in `reads`, where `dst` is the source's slot in
+        /// the unified values buffer (`base_offset + reads.len()` at the time
+        /// of insertion). Subsequent occurrences of the same source are
+        /// deduplicated so each distinct column access maps to a single slot.
+        ///
+        /// `reads` and `column_reads` are threaded across all calculations of
+        /// the graph so indices stay consistent after flattening. Non-column
+        /// sources (constants, intermediates, challenges-like globals such as
+        /// beta/theta/y) are ignored here — those are resolved later by
+        /// `resolve`.
         fn find_column_reads(
             calc: &Calculation,
             reads: &mut Vec<(ValueSource, u32)>,
@@ -346,46 +373,43 @@ impl<F: PrimeField> GraphEvaluator<F> {
                         | ValueSource::Advice(..)
                         | ValueSource::Instance(..)
                         | ValueSource::Challenge(..)
-                ) {
-                    if !reads.iter().any(|(v, _)| *v == *vs) {
-                        let dst = (base_offset + reads.len()) as u32;
-                        let cr = match *vs {
-                            ValueSource::Fixed(c, r) => ColumnRead {
-                                col_type: 0,
-                                col_idx: c as u16,
-                                rot_or_idx: r as u8,
-                                dst,
-                            },
-                            ValueSource::Advice(c, r) => ColumnRead {
-                                col_type: 1,
-                                col_idx: c as u16,
-                                rot_or_idx: r as u8,
-                                dst,
-                            },
-                            ValueSource::Instance(c, r) => ColumnRead {
-                                col_type: 2,
-                                col_idx: c as u16,
-                                rot_or_idx: r as u8,
-                                dst,
-                            },
-                            ValueSource::Challenge(i) => ColumnRead {
-                                col_type: 3,
-                                col_idx: i as u16,
-                                rot_or_idx: 0,
-                                dst,
-                            },
-                            _ => unreachable!(),
-                        };
-                        column_reads.push(cr);
-                        reads.push((*vs, dst));
-                    }
+                ) && !reads.iter().any(|(v, _)| *v == *vs)
+                {
+                    let dst = (base_offset + reads.len()) as u32;
+                    let cr = match *vs {
+                        ValueSource::Fixed(c, r) => ColumnRead {
+                            col_type: COL_TYPE_FIXED,
+                            col_idx: c as u16,
+                            rot_idx: r as u8,
+                            dst,
+                        },
+                        ValueSource::Advice(c, r) => ColumnRead {
+                            col_type: COL_TYPE_ADVICE,
+                            col_idx: c as u16,
+                            rot_idx: r as u8,
+                            dst,
+                        },
+                        ValueSource::Instance(c, r) => ColumnRead {
+                            col_type: COL_TYPE_INSTANCE,
+                            col_idx: c as u16,
+                            rot_idx: r as u8,
+                            dst,
+                        },
+                        ValueSource::Challenge(i) => ColumnRead {
+                            col_type: COL_TYPE_CHALLENGE,
+                            col_idx: i as u16,
+                            rot_idx: 0,
+                            dst,
+                        },
+                        _ => unreachable!(),
+                    };
+                    column_reads.push(cr);
+                    reads.push((*vs, dst));
                 }
             };
 
             match calc {
-                Calculation::Add(a, b)
-                | Calculation::Sub(a, b)
-                | Calculation::Mul(a, b) => {
+                Calculation::Add(a, b) | Calculation::Sub(a, b) | Calculation::Mul(a, b) => {
                     check(a);
                     check(b);
                 }
@@ -431,11 +455,7 @@ impl<F: PrimeField> GraphEvaluator<F> {
                 | ValueSource::Advice(..)
                 | ValueSource::Instance(..)
                 | ValueSource::Challenge(..) => {
-                    column_read_map
-                        .iter()
-                        .find(|(v, _)| *v == *vs)
-                        .unwrap()
-                        .1
+                    column_read_map.iter().find(|(v, _)| *v == *vs).unwrap().1
                 }
             }
         };
@@ -494,6 +514,7 @@ impl<F: PrimeField> GraphEvaluator<F> {
                     // is just a copy: dst = src.
                     let src = resolve(v);
                     // Optimization: if dst == src, skip the copy. Otherwise emit Add with 0.
+                    // NOTE: This is relying in the first constant being  0, should be reviewed.
                     if dst != src {
                         ops.push(FlatOp {
                             kind: FlatOpKind::Add,
@@ -557,9 +578,8 @@ impl<F: PrimeField> FlatGraphEvaluator<F> {
     pub fn resolve_idx(&self, vs: ValueSource) -> usize {
         match vs {
             ValueSource::Intermediate(idx) => {
-                // intermediates_offset = constants.len() + 5 + column_reads.len()
                 let intermediates_offset =
-                    self.constants.len() + 5 + self.column_reads.len();
+                    self.constants.len() + NUM_CHALLENGE_SLOTS + self.column_reads.len();
                 intermediates_offset + idx
             }
             _ => panic!("resolve_idx only supports Intermediate, got {vs:?}"),
@@ -580,6 +600,7 @@ impl<F: PrimeField> FlatGraphEvaluator<F> {
     /// Evaluate the graph at one domain element. The `values` buffer is reused
     /// across elements (only column reads and intermediates are overwritten).
     #[inline]
+    #[allow(clippy::too_many_arguments)]
     pub fn evaluate<B: PolynomialRepresentation>(
         &self,
         values: &mut [F],
@@ -595,10 +616,10 @@ impl<F: PrimeField> FlatGraphEvaluator<F> {
         // Step 1: Load column values into the buffer.
         for cr in &self.column_reads {
             values[cr.dst as usize] = match cr.col_type {
-                0 => fixed[cr.col_idx as usize][rotations[cr.rot_or_idx as usize]],
-                1 => advice[cr.col_idx as usize][rotations[cr.rot_or_idx as usize]],
-                2 => instance[cr.col_idx as usize][rotations[cr.rot_or_idx as usize]],
-                3 => challenges[cr.col_idx as usize],
+                COL_TYPE_FIXED => fixed[cr.col_idx as usize][rotations[cr.rot_idx as usize]],
+                COL_TYPE_ADVICE => advice[cr.col_idx as usize][rotations[cr.rot_idx as usize]],
+                COL_TYPE_INSTANCE => instance[cr.col_idx as usize][rotations[cr.rot_idx as usize]],
+                COL_TYPE_CHALLENGE => challenges[cr.col_idx as usize],
                 _ => unreachable!(),
             };
         }
@@ -632,6 +653,9 @@ impl<F: PrimeField> FlatGraphEvaluator<F> {
     /// `template_buf` is a pre-filled values buffer (constants + challenges).
     /// `output[i]` is both input (previous_value) and output (result).
     #[allow(clippy::too_many_arguments)]
+    // The `for b in 0..BATCH` loops below index BATCH parallel buffers; rewriting
+    // them as iterators would obscure the const-generic unroll. `b` is the index.
+    #[allow(clippy::needless_range_loop)]
     pub fn evaluate_chunk<const BATCH: usize, Repr: PolynomialRepresentation>(
         &self,
         template_buf: &[F],
@@ -659,8 +683,7 @@ impl<F: PrimeField> FlatGraphEvaluator<F> {
 
         // BATCH values buffers, reused across batches.
         let mut bufs: [Vec<F>; BATCH] = std::array::from_fn(|_| template_buf.to_vec());
-        let mut all_rots: [Vec<usize>; BATCH] =
-            std::array::from_fn(|_| vec![0usize; num_rots]);
+        let mut all_rots: [Vec<usize>; BATCH] = std::array::from_fn(|_| vec![0usize; num_rots]);
 
         let mut pos = 0;
 
@@ -674,12 +697,12 @@ impl<F: PrimeField> FlatGraphEvaluator<F> {
                 }
                 bufs[b][pv_i] = output[pos + b];
                 for cr in &self.column_reads {
-                    let rot = all_rots[b][cr.rot_or_idx as usize];
+                    let rot = all_rots[b][cr.rot_idx as usize];
                     bufs[b][cr.dst as usize] = match cr.col_type {
-                        0 => fixed[cr.col_idx as usize][rot],
-                        1 => advice[cr.col_idx as usize][rot],
-                        2 => instance[cr.col_idx as usize][rot],
-                        3 => challenges[cr.col_idx as usize],
+                        COL_TYPE_FIXED => fixed[cr.col_idx as usize][rot],
+                        COL_TYPE_ADVICE => advice[cr.col_idx as usize][rot],
+                        COL_TYPE_INSTANCE => instance[cr.col_idx as usize][rot],
+                        COL_TYPE_CHALLENGE => challenges[cr.col_idx as usize],
                         _ => unreachable!(),
                     };
                 }
@@ -693,25 +716,39 @@ impl<F: PrimeField> FlatGraphEvaluator<F> {
                 let c = op.c as usize;
                 match op.kind {
                     FlatOpKind::Add => {
-                        for b in 0..BATCH { bufs[b][d] = bufs[b][a] + bufs[b][bi]; }
+                        for b in 0..BATCH {
+                            bufs[b][d] = bufs[b][a] + bufs[b][bi];
+                        }
                     }
                     FlatOpKind::Sub => {
-                        for b in 0..BATCH { bufs[b][d] = bufs[b][a] - bufs[b][bi]; }
+                        for b in 0..BATCH {
+                            bufs[b][d] = bufs[b][a] - bufs[b][bi];
+                        }
                     }
                     FlatOpKind::Mul => {
-                        for b in 0..BATCH { bufs[b][d] = bufs[b][a] * bufs[b][bi]; }
+                        for b in 0..BATCH {
+                            bufs[b][d] = bufs[b][a] * bufs[b][bi];
+                        }
                     }
                     FlatOpKind::Square => {
-                        for b in 0..BATCH { bufs[b][d] = bufs[b][a].square(); }
+                        for b in 0..BATCH {
+                            bufs[b][d] = bufs[b][a].square();
+                        }
                     }
                     FlatOpKind::Double => {
-                        for b in 0..BATCH { bufs[b][d] = bufs[b][a].double(); }
+                        for b in 0..BATCH {
+                            bufs[b][d] = bufs[b][a].double();
+                        }
                     }
                     FlatOpKind::Negate => {
-                        for b in 0..BATCH { bufs[b][d] = -bufs[b][a]; }
+                        for b in 0..BATCH {
+                            bufs[b][d] = -bufs[b][a];
+                        }
                     }
                     FlatOpKind::MulAdd => {
-                        for b in 0..BATCH { bufs[b][d] = bufs[b][a] * bufs[b][bi] + bufs[b][c]; }
+                        for b in 0..BATCH {
+                            bufs[b][d] = bufs[b][a] * bufs[b][bi] + bufs[b][c];
+                        }
                     }
                 }
             }
@@ -732,7 +769,13 @@ impl<F: PrimeField> FlatGraphEvaluator<F> {
                     rot_indices[ri] = idx.wrapping_add(*stride) & mask;
                 }
                 output[pos] = self.evaluate::<Repr>(
-                    &mut buf, fixed, advice, instance, challenges, &rot_indices, &output[pos],
+                    &mut buf,
+                    fixed,
+                    advice,
+                    instance,
+                    challenges,
+                    &rot_indices,
+                    &output[pos],
                 );
                 pos += 1;
             }
@@ -894,7 +937,23 @@ impl<F: WithSmallOrderMulGroup<3>> Evaluator<F> {
     }
 
     /// Evaluate numerator polynomial `nu(X)` of the quotient polynomial
-    /// `h(X) = nu(X) / (X^n-1)`
+    /// `h(X) = nu(X) / (X^n-1)`.
+    ///
+    /// Iterates over the batched `(advice, instance, lookups, trashcans,
+    /// permutation)` proofs and folds each into a single shared `values`
+    /// accumulator via the verifier challenge `y`. The custom-gates flat
+    /// evaluator threads this accumulator through its outermost `Horner` step
+    /// using `ValueSource::PreviousValue` (loaded into `previous_value_idx`
+    /// in the values buffer at evaluation time).
+    ///
+    /// TODO: drop the `previous_value` plumbing — the parameter on
+    /// `FlatGraphEvaluator::evaluate` / `Calculation::evaluate`, the
+    /// `ValueSource::PreviousValue` variant, the `previous_value_idx` slot,
+    /// and the `Horner(PreviousValue, parts, Y)` start — once this function no
+    /// longer processes batched proofs in a single call. Without batching,
+    /// `previous_value` is always `F::ZERO`, the leading `Add(prev, 0)` flat
+    /// op is dead, and the inter-proof y-fold can be lifted to the caller as
+    /// a single `total = total * y^M + per_proof` pass per proof.
     #[allow(clippy::too_many_arguments)]
     pub(crate) fn evaluate_numerator<B: PolynomialRepresentation>(
         &self,
@@ -1121,10 +1180,18 @@ impl<F: WithSmallOrderMulGroup<3>> Evaluator<F> {
                     .map(|flat| flat.new_values_buffer(&beta, &theta, &trash_challenge, &y))
                     .collect();
 
-                let mut rot_indices = vec![0usize; self.custom_gates_flat.rotations.len().max(
-                    self.lookups_flat.iter().flat_map(|b| b.iter()).chain(self.trashcans_flat.iter())
-                        .map(|f| f.rotations.len()).max().unwrap_or(0)
-                )];
+                let mut rot_indices = vec![
+                    0usize;
+                    self.custom_gates_flat.rotations.len().max(
+                        self.lookups_flat
+                            .iter()
+                            .flat_map(|b| b.iter())
+                            .chain(self.trashcans_flat.iter())
+                            .map(|f| f.rotations.len())
+                            .max()
+                            .unwrap_or(0)
+                    )
+                ];
 
                 for (i, value) in values.iter_mut().enumerate() {
                     let idx = start + i;
@@ -1148,8 +1215,13 @@ impl<F: WithSmallOrderMulGroup<3>> Evaluator<F> {
                                 rot_indices[ri] = get_rotation_idx(idx, *rot, rot_scale, isize);
                             }
                             flat.evaluate::<B>(
-                                &mut bufs[fi], fixed, advice, instance, challenges,
-                                &rot_indices, &F::ZERO,
+                                &mut bufs[fi],
+                                fixed,
+                                advice,
+                                instance,
+                                challenges,
+                                &rot_indices,
+                                &F::ZERO,
                             );
 
                             let (spp_idx, prod_idx, tbl_idx, sel_idx) = output_batch[fi];
@@ -1187,8 +1259,13 @@ impl<F: WithSmallOrderMulGroup<3>> Evaluator<F> {
                             rot_indices[ri] = get_rotation_idx(idx, *rot, rot_scale, isize);
                         }
                         let compressed_expression = flat.evaluate::<B>(
-                            &mut trash_bufs[n], fixed, advice, instance, challenges,
-                            &rot_indices, &F::ZERO,
+                            &mut trash_bufs[n],
+                            fixed,
+                            advice,
+                            instance,
+                            challenges,
+                            &rot_indices,
+                            &F::ZERO,
                         );
 
                         let q = fixed[trash_selector_cols[n]][idx];

--- a/proofs/src/plonk/evaluation.rs
+++ b/proofs/src/plonk/evaluation.rs
@@ -623,6 +623,123 @@ impl<F: PrimeField> FlatGraphEvaluator<F> {
     }
 }
 
+impl<F: PrimeField> FlatGraphEvaluator<F> {
+    /// Evaluate the graph over a chunk of domain elements with compile-time
+    /// batch size `BATCH`. Processes BATCH elements per graph traversal,
+    /// amortizing op dispatch. LLVM fully unrolls the inner `for b in 0..BATCH`
+    /// loops into straight-line code.
+    ///
+    /// `template_buf` is a pre-filled values buffer (constants + challenges).
+    /// `output[i]` is both input (previous_value) and output (result).
+    #[allow(clippy::too_many_arguments)]
+    pub fn evaluate_chunk<const BATCH: usize, Repr: PolynomialRepresentation>(
+        &self,
+        template_buf: &[F],
+        output: &mut [F],
+        start: usize,
+        fixed: &[Polynomial<F, Repr>],
+        advice: &[Polynomial<F, Repr>],
+        instance: &[Polynomial<F, Repr>],
+        challenges: &[F],
+        log_scale: u32,
+        log_n: u32,
+    ) {
+        let chunk_len = output.len();
+        let pv_i = self.previous_value_idx as usize;
+        let result_i = self.result_idx as usize;
+        let mask = (1usize << log_n) - 1;
+        let num_rots = self.rotations.len();
+
+        // Pre-compute rotation strides for incremental index calculation.
+        let rot_strides: Vec<usize> = self
+            .rotations
+            .iter()
+            .map(|&rot| ((rot as isize) << log_scale) as usize)
+            .collect();
+
+        // BATCH values buffers, reused across batches.
+        let mut bufs: [Vec<F>; BATCH] = std::array::from_fn(|_| template_buf.to_vec());
+        let mut all_rots: [Vec<usize>; BATCH] =
+            std::array::from_fn(|_| vec![0usize; num_rots]);
+
+        let mut pos = 0;
+
+        // Main loop: full batches of BATCH elements.
+        while pos + BATCH <= chunk_len {
+            // Load column values for BATCH elements.
+            for b in 0..BATCH {
+                let idx = start + pos + b;
+                for (ri, stride) in rot_strides.iter().enumerate() {
+                    all_rots[b][ri] = idx.wrapping_add(*stride) & mask;
+                }
+                bufs[b][pv_i] = output[pos + b];
+                for cr in &self.column_reads {
+                    let rot = all_rots[b][cr.rot_or_idx as usize];
+                    bufs[b][cr.dst as usize] = match cr.col_type {
+                        0 => fixed[cr.col_idx as usize][rot],
+                        1 => advice[cr.col_idx as usize][rot],
+                        2 => instance[cr.col_idx as usize][rot],
+                        3 => challenges[cr.col_idx as usize],
+                        _ => unreachable!(),
+                    };
+                }
+            }
+
+            // Execute ops — one dispatch, BATCH unrolled field operations.
+            for op in &self.ops {
+                let d = op.dst as usize;
+                let a = op.a as usize;
+                let bi = op.b as usize;
+                let c = op.c as usize;
+                match op.kind {
+                    FlatOpKind::Add => {
+                        for b in 0..BATCH { bufs[b][d] = bufs[b][a] + bufs[b][bi]; }
+                    }
+                    FlatOpKind::Sub => {
+                        for b in 0..BATCH { bufs[b][d] = bufs[b][a] - bufs[b][bi]; }
+                    }
+                    FlatOpKind::Mul => {
+                        for b in 0..BATCH { bufs[b][d] = bufs[b][a] * bufs[b][bi]; }
+                    }
+                    FlatOpKind::Square => {
+                        for b in 0..BATCH { bufs[b][d] = bufs[b][a].square(); }
+                    }
+                    FlatOpKind::Double => {
+                        for b in 0..BATCH { bufs[b][d] = bufs[b][a].double(); }
+                    }
+                    FlatOpKind::Negate => {
+                        for b in 0..BATCH { bufs[b][d] = -bufs[b][a]; }
+                    }
+                    FlatOpKind::MulAdd => {
+                        for b in 0..BATCH { bufs[b][d] = bufs[b][a] * bufs[b][bi] + bufs[b][c]; }
+                    }
+                }
+            }
+
+            for b in 0..BATCH {
+                output[pos + b] = bufs[b][result_i];
+            }
+            pos += BATCH;
+        }
+
+        // Tail: remaining elements (< BATCH), processed one at a time.
+        if pos < chunk_len {
+            let mut buf = bufs.into_iter().next().unwrap();
+            let mut rot_indices = all_rots.into_iter().next().unwrap();
+            while pos < chunk_len {
+                let idx = start + pos;
+                for (ri, stride) in rot_strides.iter().enumerate() {
+                    rot_indices[ri] = idx.wrapping_add(*stride) & mask;
+                }
+                output[pos] = self.evaluate::<Repr>(
+                    &mut buf, fixed, advice, instance, challenges, &rot_indices, &output[pos],
+                );
+                pos += 1;
+            }
+        }
+    }
+}
+
 impl<F: WithSmallOrderMulGroup<3>> Evaluator<F> {
     /// Creates a new evaluation structure
     pub fn new(cs: &ConstraintSystem<F>) -> Self {
@@ -801,7 +918,7 @@ impl<F: WithSmallOrderMulGroup<3>> Evaluator<F> {
         permutation_pk_cosets: &[Polynomial<F, B>],
     ) -> Polynomial<F, B> {
         let size = B::len(domain);
-        let rot_scale = 1 << (B::k(domain) - domain.k());
+        let rot_scale: i32 = 1 << (B::k(domain) - domain.k());
         let omega = B::omega(domain);
         let isize = size as i32;
         let one = F::ONE;
@@ -819,20 +936,25 @@ impl<F: WithSmallOrderMulGroup<3>> Evaluator<F> {
             .zip(trashcans.iter())
             .zip(permutations.iter())
         {
-            // Custom gates — use the flattened evaluator for reduced dispatch overhead.
+            // Custom gates — flattened evaluator with const-generic batch size.
+            // BATCH is a compile-time constant so LLVM fully unrolls the inner
+            // `for b in 0..BATCH` loops, amortizing opcode dispatch across
+            // BATCH elements and exposing independent Fq ops to the CPU's
+            // out-of-order pipeline.
             let flat = &self.custom_gates_flat;
+            let template = flat.new_values_buffer(&beta, &theta, &trash_challenge, &y);
             parallelize(&mut values, |values, start| {
-                let mut buf = flat.new_values_buffer(&beta, &theta, &trash_challenge, &y);
-                let mut rot_indices = vec![0usize; flat.rotations.len()];
-                for (i, value) in values.iter_mut().enumerate() {
-                    let idx = start + i;
-                    for (ri, rot) in flat.rotations.iter().enumerate() {
-                        rot_indices[ri] = get_rotation_idx(idx, *rot, rot_scale, isize);
-                    }
-                    *value = flat.evaluate::<B>(
-                        &mut buf, fixed, advice, instance, challenges, &rot_indices, value,
-                    );
-                }
+                flat.evaluate_chunk::<4, B>(
+                    &template,
+                    values,
+                    start,
+                    fixed,
+                    advice,
+                    instance,
+                    challenges,
+                    rot_scale.trailing_zeros(),
+                    (isize as u32).trailing_zeros(),
+                );
             });
 
             // Permutations


### PR DESCRIPTION
Merges into #349 

  ## Summary

  Replace the interpreted `GraphEvaluator` (nested enum dispatch per step per   domain element) with `FlatGraphEvaluator`: a linear instruction sequence resolved at keygen time with pre-resolved buffer indices and bulk column loads.

Three commits:
  1. Flatten custom-gates evaluator into 7-opcode flat IR.
  2. Extend to lookup and trash evaluators; pre-compute cosets in parallel.  
  3. Add `evaluate_chunk<const BATCH>` — processes BATCH elements per graph      traversal, amortizing dispatch. Configurable via `FLAT_BATCH_SIZE` env var.
   
 ## TODO 
- [x]  Measure best batch size and hardcode it, instead of getting it from an environment variable.
- [x]  ~Merge #353 here~ Targets meta instead
 
 ## Performance improvement
| Commit | Description | k=15 bitcoin_sig (ms) | Δ vs base | k=17 cred_full (ms) | Δ vs base |
  |---|---|---:|---:|---:|---:|
  | `02e28d19` | baseline (main after CI update) | **3215.7** ± 8.7 | — | **13421.9** ± 26.5 | — |
  | `c0674bed` | flatten GraphEvaluator (custom gates) | **2979.8** ± 8.3 | **−7.3%** | **12478.6** ± 27.5 | **−7.0%** |
  | `5c3d837a` | + flatten lookup/trash | **2979.9** ± 16.6 | **−7.3%** | **12436.7** ± 20.3 | **−7.3%** |
  | `153a5a53` | + multi-element batching (B=4) | **2923.7** ± 16.4 | **−9.1%** | **12378.2** ± 25.2 | **−7.8%** |
  
CPU: Intel i5-11400H (6C/12T, 12 MB L3)
Turbo disabled for stability

The first 2 commits yield better improvements once the next PR, that introduces parallelism is added. Mainly, because parallelism increases memory pressure and the flattened evaluation gets more relevant.