### PR TITLE
Prover Optimization: FFT

### DIFF
--- a/curves/src/bls12_381/fq.rs
+++ b/curves/src/bls12_381/fq.rs
@@ -334,6 +334,14 @@ impl MulAssign<&Fq> for Fq {
     }
 }
 
+impl Fq {
+    /// Fused Gentleman-Sande (DIF) butterfly: `d = x0 - x1; x0 += x1; x1 = d * tw`.
+    #[inline]
+    pub fn gs_butterfly(x0: &mut Fq, x1: &mut Fq, twiddle: &Fq) {
+        unsafe { blst_fr_gs_bfly(&mut x0.0, &mut x1.0, &twiddle.0) };
+    }
+}
+
 impl<T> Sum<T> for Fq
 where
     T: Borrow<Fq>,

--- a/curves/src/bls12_381/fq.rs
+++ b/curves/src/bls12_381/fq.rs
@@ -335,7 +335,8 @@ impl MulAssign<&Fq> for Fq {
 }
 
 impl Fq {
-    /// Fused Gentleman-Sande (DIF) butterfly: `d = x0 - x1; x0 += x1; x1 = d * tw`.
+    /// Fused Gentleman-Sande (DIF) butterfly: `d = x0 - x1; x0 += x1; x1 = d *
+    /// tw`.
     #[inline]
     pub fn gs_butterfly(x0: &mut Fq, x1: &mut Fq, twiddle: &Fq) {
         unsafe { blst_fr_gs_bfly(&mut x0.0, &mut x1.0, &twiddle.0) };

--- a/curves/src/bls12_381/fq.rs
+++ b/curves/src/bls12_381/fq.rs
@@ -335,8 +335,8 @@ impl MulAssign<&Fq> for Fq {
 }
 
 impl Fq {
-    /// Fused Gentleman-Sande (DIF) butterfly: `d = x0 - x1; x0 += x1; x1 = d *
-    /// tw`.
+    /// Fused Gentleman-Sande (DIF) butterfly:
+    /// `d = x0 - x1; x0 += x1; x1 = d * tw`.
     #[inline]
     pub fn gs_butterfly(x0: &mut Fq, x1: &mut Fq, twiddle: &Fq) {
         unsafe { blst_fr_gs_bfly(&mut x0.0, &mut x1.0, &twiddle.0) };

--- a/curves/src/fft.rs
+++ b/curves/src/fft.rs
@@ -1,5 +1,6 @@
 use std::any::TypeId;
 
+use curve25519_dalek::Scalar;
 use ff::Field;
 use group::{GroupOpsOwned, ScalarMulOwned};
 
@@ -21,27 +22,22 @@ where
 {
 }
 
-/// Reverse the low `log_n` bits of `n`.
-fn bitreverse(mut n: usize, log_n: u32) -> usize {
-    let mut r = 0;
-    for _ in 0..log_n {
-        r = (r << 1) | (n & 1);
-        n >>= 1;
-    }
-    r
+/// Reverse the low `log_n` bits of `n`. Requires `log_n > 0`.
+fn bitreverse(n: usize, log_n: u32) -> usize {
+    n.reverse_bits() >> (usize::BITS - log_n)
 }
 
 /// Precompute twiddle factors `[1, ω, ω², …, ω^(n/2 - 1)]` for an FFT of size
 /// `2^log_n`.
 pub fn compute_twiddles<Scalar: Field>(omega: &Scalar, log_n: u32) -> Vec<Scalar> {
     let half_n = 1usize << (log_n - 1);
-    (0..half_n)
-        .scan(Scalar::ONE, |w, _| {
-            let tw = *w;
-            *w *= omega;
-            Some(tw)
-        })
-        .collect()
+    let mut twiddles = Vec::with_capacity(half_n);
+    let mut w = Scalar::ONE;
+    for _ in 0..half_n {
+        twiddles.push(w);
+        w *= omega;
+    }
+    twiddles
 }
 
 /// Performs a radix-2 Fast-Fourier Transformation (FFT) on a vector of size
@@ -118,8 +114,8 @@ pub fn fft_coeff_to_extended<Scalar: Field, G: FftGroup<Scalar>>(
     log_n: u32,
     n_real: usize,
 ) {
-    if TypeId::of::<G>() == TypeId::of::<Fq>() {
-        // SAFETY: G == Fq verified by TypeId. Fq is #[repr(transparent)].
+    if TypeId::of::<G>() == TypeId::of::<Fq>() && TypeId::of::<Scalar>() == TypeId::of::<Fq>() {
+        // SAFETY: G == Fq == Scalar verified by TypeId. Fq is #[repr(transparent)].
         let a = unsafe { &mut *(a as *mut [G] as *mut [Fq]) };
         let tw = unsafe { &*(twiddles as *const [Scalar] as *const [Fq]) };
         fft_dif_pruned_fq(a, tw, log_n, n_real);
@@ -133,8 +129,8 @@ pub fn fft_coeff_to_extended<Scalar: Field, G: FftGroup<Scalar>>(
 ///
 /// DIF does large-stride butterflies first (on cold data) and small-stride
 /// last (leaving data warm for the final bit-reversal). The pruning skips
-/// butterflies whose operands are both zero and replaces `(data, 0)` butterflies
-/// with a single multiply.
+/// butterflies whose operands are both zero and replaces `(data, 0)`
+/// butterflies with a single multiply.
 fn fft_dif_pruned_fq(a: &mut [Fq], twiddles: &[Fq], log_n: u32, n_real: usize) {
     let n = a.len();
     assert_eq!(n, 1 << log_n);

--- a/curves/src/fft.rs
+++ b/curves/src/fft.rs
@@ -1,6 +1,9 @@
+use std::any::TypeId;
+
 use ff::Field;
 use group::{GroupOpsOwned, ScalarMulOwned};
 
+use crate::bls12_381::Fq;
 pub use crate::{CurveAffine, CurveExt};
 
 /// This represents an element of a group with basic operations that can be
@@ -99,6 +102,103 @@ pub fn best_fft_with_twiddles<Scalar: Field, G: FftGroup<Scalar>>(
         }
     } else {
         recursive_butterfly_arithmetic(a, n, 1, twiddles)
+    }
+}
+
+/// FFT for the `coeff_to_extended` pattern: the first `n_real` entries of `a`
+/// hold coefficients and the rest are zero-padded out to `2^log_n`. Exploits
+/// the zero-padded structure to skip butterfly work on all-zero subtrees.
+///
+/// Uses pruned DIF (Gentleman-Sande) when `G` is the BLS12-381 scalar field
+/// [`Fq`]; falls back to standard DIT for other fields. The TypeId check is
+/// monomorphized to a constant — zero runtime cost.
+pub fn fft_coeff_to_extended<Scalar: Field, G: FftGroup<Scalar>>(
+    a: &mut [G],
+    twiddles: &[Scalar],
+    log_n: u32,
+    n_real: usize,
+) {
+    if TypeId::of::<G>() == TypeId::of::<Fq>() {
+        // SAFETY: G == Fq verified by TypeId. Fq is #[repr(transparent)].
+        let a = unsafe { &mut *(a as *mut [G] as *mut [Fq]) };
+        let tw = unsafe { &*(twiddles as *const [Scalar] as *const [Fq]) };
+        fft_dif_pruned_fq(a, tw, log_n, n_real);
+    } else {
+        best_fft_with_twiddles(a, twiddles, log_n);
+    }
+}
+
+/// Pruned DIF (Gentleman-Sande) FFT for zero-padded input. `a[0..n_real]` are
+/// data, `a[n_real..n]` are zero.
+///
+/// DIF does large-stride butterflies first (on cold data) and small-stride
+/// last (leaving data warm for the final bit-reversal). The pruning skips
+/// butterflies whose operands are both zero and replaces `(data, 0)` butterflies
+/// with a single multiply.
+fn fft_dif_pruned_fq(a: &mut [Fq], twiddles: &[Fq], log_n: u32, n_real: usize) {
+    let n = a.len();
+    assert_eq!(n, 1 << log_n);
+    recursive_dif_pruned(a, n, 1, twiddles, n_real);
+    for k in 0..n {
+        let rk = bitreverse(k, log_n);
+        if k < rk {
+            a.swap(rk, k);
+        }
+    }
+}
+
+/// Recursive DIF butterflies assuming the first `nz` entries of `a` are
+/// potentially non-zero and the remaining `n - nz` are zero. Maintains this
+/// "data-at-front" invariant across recursive calls.
+fn recursive_dif_pruned(a: &mut [Fq], n: usize, tc: usize, tw: &[Fq], nz: usize) {
+    if nz == 0 {
+        return;
+    }
+    if n == 2 {
+        // Base case. GS butterfly on (a[0], a[1]). Correct whether a[1] is
+        // zero (nz == 1) or not, since (a, 0; tw) → (a, a·tw).
+        gs(a, 0, 1, &tw[0]);
+        return;
+    }
+
+    let h = n / 2;
+
+    if nz <= h {
+        // Right half is entirely zero. The GS butterfly (a, 0; tw) simplifies
+        // to (a, a·tw): the low half keeps a[i], the high half becomes a[i]·tw.
+        // The tail of the left half stays zero.
+        for i in 0..nz {
+            a[i + h] = a[i];
+            a[i + h] *= &tw[i * tc];
+        }
+    } else {
+        // Both halves carry data. Full butterflies across the split. Pairs
+        // with i >= nz - h have a[i+h] == 0, which the butterfly still
+        // handles correctly (one extra mul each; not worth a special case).
+        for i in 0..h {
+            gs(a, i, i + h, &tw[i * tc]);
+        }
+    }
+
+    // After the split, each half holds exactly `min(nz, h)` potentially
+    // non-zero entries, placed at the front.
+    let child_nz = nz.min(h);
+    let (left, right) = a.split_at_mut(h);
+    rayon::join(
+        || recursive_dif_pruned(left, h, tc * 2, tw, child_nz),
+        || recursive_dif_pruned(right, h, tc * 2, tw, child_nz),
+    );
+}
+
+/// In-place Gentleman-Sande butterfly on `a[i]` and `a[j]` with twiddle `t`:
+/// (a[i], a[j]) ← (a[i] + a[j], (a[i] - a[j])·t).
+#[inline(always)]
+fn gs(a: &mut [Fq], i: usize, j: usize, t: &Fq) {
+    // SAFETY: i != j and both in bounds — callers always supply i = k, j = k + h
+    // with k < h <= a.len()/2.
+    unsafe {
+        let p = a.as_mut_ptr();
+        Fq::gs_butterfly(&mut *p.add(i), &mut *p.add(j), t);
     }
 }
 

--- a/curves/src/fft.rs
+++ b/curves/src/fft.rs
@@ -18,47 +18,59 @@ where
 {
 }
 
-/// Performs a radix-$2$ Fast-Fourier Transformation (FFT) on a vector of size
-/// $n = 2^k$, when provided `log_n` = $k$ and an element of multiplicative
-/// order $n$ called `omega` ($\omega$). The result is that the vector `a`, when
-/// interpreted as the coefficients of a polynomial of degree $n - 1$, is
-/// transformed into the evaluations of this polynomial at each of the $n$
-/// distinct powers of $\omega$. This transformation is invertible by providing
-/// $\omega^{-1}$ in place of $\omega$ and dividing each resulting field element
-/// by $n$.
-///
-/// This will use multithreading if beneficial.
-pub fn best_fft<Scalar: Field, G: FftGroup<Scalar>>(a: &mut [G], omega: Scalar, log_n: u32) {
-    fn bitreverse(mut n: usize, l: usize) -> usize {
-        let mut r = 0;
-        for _ in 0..l {
-            r = (r << 1) | (n & 1);
-            n >>= 1;
-        }
-        r
+/// Reverse the low `log_n` bits of `n`.
+fn bitreverse(mut n: usize, log_n: u32) -> usize {
+    let mut r = 0;
+    for _ in 0..log_n {
+        r = (r << 1) | (n & 1);
+        n >>= 1;
     }
+    r
+}
 
-    let threads = rayon::current_num_threads();
-    let log_threads = threads.ilog2();
+/// Precompute twiddle factors `[1, ω, ω², …, ω^(n/2 - 1)]` for an FFT of size
+/// `2^log_n`.
+pub fn compute_twiddles<Scalar: Field>(omega: &Scalar, log_n: u32) -> Vec<Scalar> {
+    let half_n = 1usize << (log_n - 1);
+    (0..half_n)
+        .scan(Scalar::ONE, |w, _| {
+            let tw = *w;
+            *w *= omega;
+            Some(tw)
+        })
+        .collect()
+}
+
+/// Performs a radix-2 Fast-Fourier Transformation (FFT) on a vector of size
+/// `n = 2^log_n`. Interprets `a` as the coefficients of a polynomial of degree
+/// `n - 1` and transforms it into evaluations at each of the `n` distinct
+/// powers of `omega`. This transformation is invertible by providing `ω⁻¹` in
+/// place of `ω` and dividing each resulting element by `n`.
+///
+/// Uses multithreading if beneficial.
+pub fn best_fft<Scalar: Field, G: FftGroup<Scalar>>(a: &mut [G], omega: Scalar, log_n: u32) {
+    let twiddles = compute_twiddles(&omega, log_n);
+    best_fft_with_twiddles(a, &twiddles, log_n);
+}
+
+/// Same as [`best_fft`] but uses precomputed twiddle factors.
+/// Use [`compute_twiddles`] to generate the twiddle array.
+pub fn best_fft_with_twiddles<Scalar: Field, G: FftGroup<Scalar>>(
+    a: &mut [G],
+    twiddles: &[Scalar],
+    log_n: u32,
+) {
     let n = a.len();
     assert_eq!(n, 1 << log_n);
 
     for k in 0..n {
-        let rk = bitreverse(k, log_n as usize);
+        let rk = bitreverse(k, log_n);
         if k < rk {
             a.swap(rk, k);
         }
     }
 
-    // precompute twiddle factors
-    let twiddles: Vec<_> = (0..(n / 2))
-        .scan(Scalar::ONE, |w, _| {
-            let tw = *w;
-            *w *= &omega;
-            Some(tw)
-        })
-        .collect();
-
+    let log_threads = rayon::current_num_threads().ilog2();
     if log_n <= log_threads {
         let mut chunk = 2_usize;
         let mut twiddle_chunk = n / 2;
@@ -66,7 +78,7 @@ pub fn best_fft<Scalar: Field, G: FftGroup<Scalar>>(a: &mut [G], omega: Scalar, 
             a.chunks_mut(chunk).for_each(|coeffs| {
                 let (left, right) = coeffs.split_at_mut(chunk / 2);
 
-                // case when twiddle factor is one
+                // Case when twiddle factor is one.
                 let (a, left) = left.split_at_mut(1);
                 let (b, right) = right.split_at_mut(1);
                 let t = b[0];
@@ -86,11 +98,12 @@ pub fn best_fft<Scalar: Field, G: FftGroup<Scalar>>(a: &mut [G], omega: Scalar, 
             twiddle_chunk /= 2;
         }
     } else {
-        recursive_butterfly_arithmetic(a, n, 1, &twiddles)
+        recursive_butterfly_arithmetic(a, n, 1, twiddles)
     }
 }
 
-/// This perform recursive butterfly arithmetic
+/// Recursive Cooley-Tukey (DIT) butterflies. Used by [`best_fft_with_twiddles`]
+/// when the FFT size exceeds the available parallelism.
 pub fn recursive_butterfly_arithmetic<Scalar: Field, G: FftGroup<Scalar>>(
     a: &mut [G],
     n: usize,
@@ -109,7 +122,7 @@ pub fn recursive_butterfly_arithmetic<Scalar: Field, G: FftGroup<Scalar>>(
             || recursive_butterfly_arithmetic(right, n / 2, twiddle_chunk * 2, twiddles),
         );
 
-        // case when twiddle factor is one
+        // Case when twiddle factor is one.
         let (a, left) = left.split_at_mut(1);
         let (b, right) = right.split_at_mut(1);
         let t = b[0];

--- a/proofs/src/poly/domain.rs
+++ b/proofs/src/poly/domain.rs
@@ -5,10 +5,27 @@ use std::marker::PhantomData;
 
 use ff::WithSmallOrderMulGroup;
 use group::ff::{BatchInvert, Field};
-use midnight_curves::fft::best_fft;
+use midnight_curves::fft::{best_fft_with_twiddles, compute_twiddles};
 
 use super::{Coeff, ExtendedLagrangeCoeff, LagrangeCoeff, Polynomial, Rotation};
 use crate::utils::{arithmetic::parallelize, rational::Rational};
+
+/// Precomputed twiddle factors for the FFT.
+///
+/// Twiddle factors are the powers of the root of unity used in the
+/// butterfly operations of the Cooley-Tukey FFT:
+///   `[1, ω, ω², ..., ω^(n/2 - 1)]`
+/// where ω is the n-th root of unity in the field.
+///
+/// Four sets are stored: forward and inverse for both the base domain (size
+/// 2^k) and the extended domain (size 2^extended_k).
+#[derive(Clone, Debug)]
+struct CachedTwiddles<F: Field> {
+    omega: Vec<F>,
+    omega_inv: Vec<F>,
+    extended_omega: Vec<F>,
+    extended_omega_inv: Vec<F>,
+}
 
 /// This structure contains precomputed constants and other details needed for
 /// performing operations on an evaluation domain of size $2^k$ and an extended
@@ -21,7 +38,6 @@ pub struct EvaluationDomain<F: Field> {
     omega: F,
     omega_inv: F,
     extended_omega: F,
-    extended_omega_inv: F,
     pub(crate) g_coset: F,
     g_coset_inv: F,
     quotient_poly_degree: u64,
@@ -29,6 +45,7 @@ pub struct EvaluationDomain<F: Field> {
     extended_ifft_divisor: F,
     t_evaluations: Vec<F>,
     barycentric_weight: F,
+    twiddles: CachedTwiddles<F>,
 }
 
 impl<F: WithSmallOrderMulGroup<3>> EvaluationDomain<F> {
@@ -123,6 +140,14 @@ impl<F: WithSmallOrderMulGroup<3>> EvaluationDomain<F> {
             .chain(Some(&mut omega_inv))
             .batch_invert();
 
+        // Precompute twiddle factors for all FFT configurations.
+        let twiddles = CachedTwiddles {
+            omega: compute_twiddles(&omega, k),
+            omega_inv: compute_twiddles(&omega_inv, k),
+            extended_omega: compute_twiddles(&extended_omega, extended_k),
+            extended_omega_inv: compute_twiddles(&extended_omega_inv, extended_k),
+        };
+
         EvaluationDomain {
             n,
             k,
@@ -130,7 +155,6 @@ impl<F: WithSmallOrderMulGroup<3>> EvaluationDomain<F> {
             omega,
             omega_inv,
             extended_omega,
-            extended_omega_inv,
             g_coset,
             g_coset_inv,
             quotient_poly_degree,
@@ -138,6 +162,7 @@ impl<F: WithSmallOrderMulGroup<3>> EvaluationDomain<F> {
             extended_ifft_divisor,
             t_evaluations,
             barycentric_weight,
+            twiddles,
         }
     }
 
@@ -224,8 +249,13 @@ impl<F: WithSmallOrderMulGroup<3>> EvaluationDomain<F> {
     pub fn lagrange_to_coeff(&self, mut a: Polynomial<F, LagrangeCoeff>) -> Polynomial<F, Coeff> {
         assert_eq!(a.values.len(), 1 << self.k);
 
-        // Perform inverse FFT to obtain the polynomial in coefficient form
-        Self::ifft(&mut a.values, self.omega_inv, self.k, self.ifft_divisor);
+        // Perform inverse FFT using cached twiddle factors.
+        Self::ifft(
+            &mut a.values,
+            &self.twiddles.omega_inv,
+            self.k,
+            self.ifft_divisor,
+        );
 
         Polynomial {
             values: a.values,
@@ -238,7 +268,7 @@ impl<F: WithSmallOrderMulGroup<3>> EvaluationDomain<F> {
     pub fn coeff_to_lagrange(&self, mut a: Polynomial<F, Coeff>) -> Polynomial<F, LagrangeCoeff> {
         assert_eq!(a.values.len(), 1 << self.k);
 
-        best_fft(&mut a.values, self.omega, self.k);
+        best_fft_with_twiddles(&mut a.values, &self.twiddles.omega, self.k);
 
         Polynomial {
             values: a.values,
@@ -247,7 +277,7 @@ impl<F: WithSmallOrderMulGroup<3>> EvaluationDomain<F> {
     }
 
     /// This takes us from an n-length coefficient vector into a coset of the
-    /// extended evaluation domain, rotating by `rotation` if desired.
+    /// extended evaluation domain.
     pub fn coeff_to_extended(
         &self,
         mut a: Polynomial<F, Coeff>,
@@ -256,7 +286,11 @@ impl<F: WithSmallOrderMulGroup<3>> EvaluationDomain<F> {
 
         self.distribute_powers_zeta(&mut a.values, true);
         a.values.resize(self.extended_len(), F::ZERO);
-        best_fft(&mut a.values, self.extended_omega, self.extended_k);
+        best_fft_with_twiddles(
+            &mut a.values,
+            &self.twiddles.extended_omega,
+            self.extended_k,
+        );
 
         Polynomial {
             values: a.values,
@@ -272,10 +306,10 @@ impl<F: WithSmallOrderMulGroup<3>> EvaluationDomain<F> {
     pub fn extended_to_coeff(&self, mut a: Polynomial<F, ExtendedLagrangeCoeff>) -> Vec<F> {
         assert_eq!(a.values.len(), self.extended_len());
 
-        // Inverse FFT
+        // Inverse FFT using cached twiddle factors.
         Self::ifft(
             &mut a.values,
-            self.extended_omega_inv,
+            &self.twiddles.extended_omega_inv,
             self.extended_k,
             self.extended_ifft_divisor,
         );
@@ -300,7 +334,7 @@ impl<F: WithSmallOrderMulGroup<3>> EvaluationDomain<F> {
 
         Self::ifft(
             &mut a.values,
-            self.extended_omega_inv,
+            &self.twiddles.extended_omega_inv,
             self.extended_k,
             self.extended_ifft_divisor,
         );
@@ -308,7 +342,7 @@ impl<F: WithSmallOrderMulGroup<3>> EvaluationDomain<F> {
         a.values.truncate(self.n as usize);
         self.distribute_powers_zeta(&mut a.values, false);
 
-        best_fft(&mut a.values, self.omega, self.k);
+        best_fft_with_twiddles(&mut a.values, &self.twiddles.omega, self.k);
 
         Polynomial {
             values: a.values,
@@ -328,7 +362,7 @@ impl<F: WithSmallOrderMulGroup<3>> EvaluationDomain<F> {
         // domain.
         parallelize(&mut a.values, |h, mut index| {
             for h in h {
-                *h *= &self.t_evaluations[index % self.t_evaluations.len()];
+                *h *= &self.t_evaluations[index & (self.t_evaluations.len() - 1)];
                 index += 1;
             }
         });
@@ -346,6 +380,15 @@ impl<F: WithSmallOrderMulGroup<3>> EvaluationDomain<F> {
     ///
     /// `into_coset` should be set to `true` when moving into the coset,
     /// and `false` when moving out. This toggles the choice of `zeta`.
+    fn ifft(a: &mut [F], twiddles: &[F], log_n: u32, divisor: F) {
+        best_fft_with_twiddles(a, twiddles, log_n);
+        parallelize(a, |a, _| {
+            for a in a {
+                *a *= &divisor;
+            }
+        });
+    }
+
     fn distribute_powers_zeta(&self, a: &mut [F], into_coset: bool) {
         let coset_powers = if into_coset {
             [self.g_coset, self.g_coset_inv]
@@ -360,16 +403,6 @@ impl<F: WithSmallOrderMulGroup<3>> EvaluationDomain<F> {
                     *a *= &coset_powers[i - 1];
                 }
                 index += 1;
-            }
-        });
-    }
-
-    fn ifft(a: &mut [F], omega_inv: F, log_n: u32, divisor: F) {
-        best_fft(a, omega_inv, log_n);
-        parallelize(a, |a, _| {
-            for a in a {
-                // Finish iFFT
-                *a *= &divisor;
             }
         });
     }

--- a/proofs/src/poly/domain.rs
+++ b/proofs/src/poly/domain.rs
@@ -5,7 +5,7 @@ use std::marker::PhantomData;
 
 use ff::WithSmallOrderMulGroup;
 use group::ff::{BatchInvert, Field};
-use midnight_curves::fft::{best_fft_with_twiddles, compute_twiddles};
+use midnight_curves::fft::{best_fft_with_twiddles, compute_twiddles, fft_coeff_to_extended};
 
 use super::{Coeff, ExtendedLagrangeCoeff, LagrangeCoeff, Polynomial, Rotation};
 use crate::utils::{arithmetic::parallelize, rational::Rational};
@@ -278,18 +278,24 @@ impl<F: WithSmallOrderMulGroup<3>> EvaluationDomain<F> {
 
     /// This takes us from an n-length coefficient vector into a coset of the
     /// extended evaluation domain.
+    ///
+    /// Uses a pruned DIF FFT that exploits the zero-padded structure
+    /// (`n_real = 2^k` coefficients padded to `2^extended_k`) to skip work on
+    /// all-zero subtrees. Falls back to standard DIT for non-Fq fields.
     pub fn coeff_to_extended(
         &self,
         mut a: Polynomial<F, Coeff>,
     ) -> Polynomial<F, ExtendedLagrangeCoeff> {
-        assert_eq!(a.values.len(), 1 << self.k);
+        let n_real = a.values.len();
+        assert_eq!(n_real, 1 << self.k);
 
         self.distribute_powers_zeta(&mut a.values, true);
         a.values.resize(self.extended_len(), F::ZERO);
-        best_fft_with_twiddles(
+        fft_coeff_to_extended(
             &mut a.values,
             &self.twiddles.extended_omega,
             self.extended_k,
+            n_real,
         );
 
         Polynomial {

--- a/proofs/src/poly/domain.rs
+++ b/proofs/src/poly/domain.rs
@@ -368,7 +368,7 @@ impl<F: WithSmallOrderMulGroup<3>> EvaluationDomain<F> {
         // domain.
         parallelize(&mut a.values, |h, mut index| {
             for h in h {
-                *h *= &self.t_evaluations[index & (self.t_evaluations.len() - 1)];
+                *h *= &self.t_evaluations[index % self.t_evaluations.len()];
                 index += 1;
             }
         });


### PR DESCRIPTION
Merges into #349 

 ## Summary

  1. **Cache twiddle factors**
Precompute the four twiddle arrays (forward/inverse × base/extended) once in `EvaluationDomain::new()`.
Extract `compute_twiddles` and `best_fft_with_twiddles` as public API.

  2. **Pruned DIF FFT**
 Fq-specialized Gentleman-Sande FFT exploiting the zero-padded structure of `coeff_to_extended` (n coefficients in a 4n  buffer). Skips all-zero subtrees and simplifies `(data, 0)` butterflies to a single multiply. 

## Performance Improvements

Performance improvement of this PR is not an accurate reflection of the final impact in the prover, since `opt_4` will increase FFT parallelization. It will be reported only in the meta PR.

## Future work
 - Integrate in blst to push performance improvements further: 
   * Coarse Montgomery reduction
   * Fused bit-reversal + stage 1
   * Prefetching
   * Improve Twiddle layout (contiguous access).
   * Inline ASM (no FFI boundary)
   * Flat loop + bitmask indexing
   * Thread model (Fixed slicing instead of  `rayon::join`)


   