### PR TITLE
Deterministic prover

### DIFF
--- a/aggregation/Cargo.toml
+++ b/aggregation/Cargo.toml
@@ -16,14 +16,14 @@ rustdoc-args = ["--cfg", "docsrs", "--html-in-header", "katex-header.html"]
 group = { workspace = true }
 ff = { workspace = true }
 midnight-curves = "0.2.0"
-midnight-proofs = { version = "0.7.0", default-features = false, features = [
+midnight-proofs = { version = "0.7.1", default-features = false, features = [
     "circuit-params",
     "committed-instances",
 ] }
-midnight-circuits = { version = "6.0.0", default-features = false, features = [
+midnight-circuits = { version = "6.1.0", default-features = false, features = [
     "testing",
 ] }
-midnight-zk-stdlib = { path = "../zk_stdlib", version = "1.0.0" }
+midnight-zk-stdlib = { path = "../zk_stdlib", version = "1.1.0" }
 
 rand = { workspace = true }
 blake2b_simd = { workspace = true }

--- a/aggregation/src/light_aggregator/mod.rs
+++ b/aggregation/src/light_aggregator/mod.rs
@@ -377,8 +377,8 @@ impl<const NB_PROOFS: usize> LightAggregator<NB_PROOFS> {
             &[aggregator_circuit],
             1,
             &[&[&acc_committed_instances, &aggregator_instances]],
-            &mut rng,
             transcript,
+            &mut rng,
         )?;
 
         // Create the IPA proof

--- a/circuits/CHANGELOG.md
+++ b/circuits/CHANGELOG.md
@@ -85,6 +85,10 @@ verification keys break backwards compatibility.
 * Move external implementations to zk-stdlib [#178](https://github.com/midnightntwrk/midnight-zk/pull/178)
 * Remove native `secp256k1` `CircuitCurve` and `WeierstrassCurve` implementations [#216](https://github.com/midnightntwrk/midnight-zk/pull/216)
 
+## [6.1.0]
+### Changed
+* `ForeignEccChip::new` samples the windowed-MSM blinding point at construction time [#307](https://github.com/midnightntwrk/midnight-zk/pull/307)
+
 ## [6.0.0] - 18-12-2025
 ### Added
 * SHA512 chip [#96](https://github.com/midnightntwrk/midnight-zk/pull/96)

--- a/circuits/Cargo.toml
+++ b/circuits/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "midnight-circuits"
-version = "6.0.0"
+version = "6.1.0"
 edition = "2021"
 license-file.workspace = true
 description = "Circuit and gadget implementations for Midnight zero-knowledge proofs"
@@ -12,7 +12,7 @@ group = { workspace = true }
 ff = { workspace = true }
 rustc-hash = "2"
 midnight-curves = "0.2.0"
-midnight-proofs = { version = "0.7.0", default-features = false, features = [
+midnight-proofs = { version = "0.7.1", default-features = false, features = [
     "circuit-params",
     "committed-instances",
 ] }

--- a/circuits/Cargo.toml
+++ b/circuits/Cargo.toml
@@ -30,7 +30,7 @@ subtle = "2.6"
 base64 = "0.13.1"
 lazy_static = "1.5.0"
 goldenfile = { version = "=1.8.0", optional = true }
-rand_chacha = { version = "0.3.1", optional = true }
+rand_chacha = { workspace = true, optional = true }
 
 [dev-dependencies]
 criterion = "0.7"
@@ -53,6 +53,8 @@ heap_profiling = []
 truncated-challenges = ["midnight-proofs/truncated-challenges"]
 # Enable development curves (BN256, Pasta)
 dev-curves = ["midnight-curves/dev-curves", "midnight-proofs/dev-curves"]
+# Enable deterministic proofs
+deterministic-prover = ["rand_chacha"]
 
 [lib]
 bench = false

--- a/circuits/Cargo.toml
+++ b/circuits/Cargo.toml
@@ -53,7 +53,9 @@ heap_profiling = []
 truncated-challenges = ["midnight-proofs/truncated-challenges"]
 # Enable development curves (BN256, Pasta)
 dev-curves = ["midnight-curves/dev-curves", "midnight-proofs/dev-curves"]
-# Enable deterministic proofs
+# Enable deterministic proofs. This feature makes the prover deterministic, which breaks the
+# zero-knowledge property and may lead to completeness issues if circuits are chosen adversarially.
+# DO NOT enable this feature in production, only in tests that need to be reproducible.
 deterministic-prover = ["rand_chacha"]
 
 [lib]

--- a/circuits/src/ecc/foreign/weierstrass_chip.rs
+++ b/circuits/src/ecc/foreign/weierstrass_chip.rs
@@ -35,11 +35,11 @@ use midnight_proofs::{
 };
 use num_bigint::BigUint;
 use num_traits::One;
-use rand::rngs::OsRng;
+use rand::{CryptoRng, RngCore};
 #[cfg(any(test, feature = "testing"))]
 use {
     crate::testing_utils::Sampleable, crate::utils::util::FromScratch,
-    midnight_proofs::plonk::Instance, rand::RngCore,
+    midnight_proofs::plonk::Instance, rand::rngs::OsRng,
 };
 
 use super::gates::weierstrass::{
@@ -166,6 +166,10 @@ where
     // computations depending on it e.g. α can be cached and reused.
     // Importantly, such cache is keyed by window size.
     msm_randomness: Rc<RefCell<MsmRandomnessMap<F, C, B>>>,
+    // A random point used in windowed_msm (to shift the initial accumulator) so that the
+    // double-and-add loop can internally use incomplete addition. Sampled once at chip
+    // construction time.
+    random_point: C::CryptographicGroup,
 }
 
 /// Type for foreign EC points.
@@ -956,12 +960,19 @@ where
     N: NativeInstructions<F>,
 {
     /// Given config creates new chip that implements foreign ECC
+    /// The RNG is used to sample a random point used for incomplete addition
+    /// Soundness does not rely on this point being random, but completeness
+    /// does.
     pub fn new(
         config: &ForeignWeierstrassEccConfig<C>,
         native_gadget: &N,
         scalar_field_chip: &S,
+        mut rng: impl RngCore + CryptoRng,
     ) -> Self {
+        let random_point = C::random(&mut rng).into_subgroup();
+
         let base_field_chip = FieldChip::new(&config.base_field_config, native_gadget);
+
         Self {
             config: config.clone(),
             native_gadget: native_gadget.clone(),
@@ -969,6 +980,7 @@ where
             scalar_field_chip: scalar_field_chip.clone(),
             tag_cnt: Rc::new(RefCell::new(1)),
             msm_randomness: Rc::new(RefCell::new(HashMap::new())),
+            random_point,
         }
     }
 
@@ -1696,17 +1708,25 @@ where
             return Ok(cached.clone());
         }
 
-        let r: AssignedForeignPoint<F, C, B> = self.assign_without_subgroup_check(
-            layouter,
-            Value::known(C::CryptographicGroup::random(OsRng)),
-        )?;
+        let r: AssignedForeignPoint<F, C, B> = if let Some(cached) = self.msm_randomness.borrow().get(&1) {
+            cached.r
+        } else {
+            let p = self.assign_without_subgroup_check(
+                layouter,
+                Value::known(self.random_point)
+            )?;
 
-        Self::completeness_error_if(&r.point, |p| C::CryptographicGroup::is_identity(p).into())?;
+            // Cache the random point
+            let randomness = MsmRandomness { r: p.clone(), neg_alpha: p.clone() };
+            self.msm_randomness.borrow_mut().insert(1, randomness.clone());
 
-        // Assert the chosen r is not the identity point.
-        self.base_field_chip
-            .native_gadget
-            .assert_equal_to_fixed(layouter, &r.is_id, false)?;
+            // Assert the chosen r is not the identity point.
+            self.base_field_chip
+                .native_gadget
+                .assert_equal_to_fixed(layouter, &r.is_id, false)?;
+
+            p
+        };
 
         let alpha = self.mul_by_u128(layouter, (1u128 << WS) - 1, &r)?;
         let neg_alpha = self.negate(layouter, &alpha)?;
@@ -2023,7 +2043,7 @@ where
         let native_gadget = <N as FromScratch<F>>::new_from_scratch(&config.native_gadget_config);
         let scalar_field_chip =
             <S as FromScratch<F>>::new_from_scratch(&config.scalar_field_config);
-        ForeignWeierstrassEccChip::new(&config.ff_ecc_config, &native_gadget, &scalar_field_chip)
+        ForeignWeierstrassEccChip::new(&config.ff_ecc_config, &native_gadget, &scalar_field_chip, OsRng)
     }
 
     fn load_from_scratch(&self, layouter: &mut impl Layouter<F>) -> Result<(), Error> {

--- a/circuits/src/ecc/foreign/weierstrass_chip.rs
+++ b/circuits/src/ecc/foreign/weierstrass_chip.rs
@@ -1731,27 +1731,14 @@ where
             return Ok(cached.clone());
         }
 
-        let cached_r = self.msm_randomness.borrow().get(&1).map(|c| c.r.clone());
-        let r: AssignedForeignPoint<F, C, B> = if let Some(r) = cached_r {
-            r
-        } else {
-            let p =
-                self.assign_without_subgroup_check(layouter, Value::known(self.random_point))?;
-
-            self.base_field_chip
-                .native_gadget
-                .assert_equal_to_fixed(layouter, &p.is_id, false)?;
-
-            p
+        // Reuse `r` from any cached window size to avoid unnecessary point assignments.
+        let r = match self.msm_randomness.borrow().values().next().map(|c| c.r.clone()) {
+            Some(r) => r,
+            None => {
+                self.assign_without_subgroup_check(layouter, Value::known(self.random_point))?
+            }
         };
-
-        // Cache the random point from the chip. Note that `neg_alpha` is never used for
-        // the base randomness.
-        let randomness = MsmRandomness {
-            r: r.clone(),
-            neg_alpha: r.clone(),
-        };
-        self.msm_randomness.borrow_mut().insert(1, randomness.clone());
+        self.assert_non_zero(layouter, &r)?;
 
         let alpha = self.mul_by_u128(layouter, (1u128 << WS) - 1, &r)?;
         let neg_alpha = self.negate(layouter, &alpha)?;

--- a/circuits/src/ecc/foreign/weierstrass_chip.rs
+++ b/circuits/src/ecc/foreign/weierstrass_chip.rs
@@ -35,11 +35,15 @@ use midnight_proofs::{
 };
 use num_bigint::BigUint;
 use num_traits::One;
-use rand::{CryptoRng, RngCore};
+#[cfg(not(feature = "deterministic-prover"))]
+use rand::rngs::OsRng;
+use rand::RngCore;
+#[cfg(feature = "deterministic-prover")]
+use rand_chacha::{rand_core::SeedableRng, ChaCha20Rng};
 #[cfg(any(test, feature = "testing"))]
 use {
     crate::testing_utils::Sampleable, crate::utils::util::FromScratch,
-    midnight_proofs::plonk::Instance, rand::rngs::OsRng,
+    midnight_proofs::plonk::Instance,
 };
 
 use super::gates::weierstrass::{
@@ -967,8 +971,11 @@ where
         config: &ForeignWeierstrassEccConfig<C>,
         native_gadget: &N,
         scalar_field_chip: &S,
-        mut rng: impl RngCore + CryptoRng,
     ) -> Self {
+        #[cfg(feature = "deterministic-prover")]
+        let mut rng = ChaCha20Rng::seed_from_u64(0x9F3A7C2E);
+        #[cfg(not(feature = "deterministic-prover"))]
+        let mut rng = OsRng;
         let random_point = C::random(&mut rng).into_subgroup();
 
         let base_field_chip = FieldChip::new(&config.base_field_config, native_gadget);
@@ -2045,12 +2052,7 @@ where
         let native_gadget = <N as FromScratch<F>>::new_from_scratch(&config.native_gadget_config);
         let scalar_field_chip =
             <S as FromScratch<F>>::new_from_scratch(&config.scalar_field_config);
-        ForeignWeierstrassEccChip::new(
-            &config.ff_ecc_config,
-            &native_gadget,
-            &scalar_field_chip,
-            OsRng,
-        )
+        ForeignWeierstrassEccChip::new(&config.ff_ecc_config, &native_gadget, &scalar_field_chip)
     }
 
     fn load_from_scratch(&self, layouter: &mut impl Layouter<F>) -> Result<(), Error> {

--- a/circuits/src/ecc/foreign/weierstrass_chip.rs
+++ b/circuits/src/ecc/foreign/weierstrass_chip.rs
@@ -989,7 +989,7 @@ where
         scalar_field_chip: &S,
     ) -> Self {
         #[cfg(feature = "deterministic-prover")]
-        let mut rng = ChaCha20Rng::seed_from_u64(0x9F3A7C2E);
+        let mut rng = ChaCha20Rng::seed_from_u64(0x5EEDAB1E);
         #[cfg(not(feature = "deterministic-prover"))]
         let mut rng = OsRng;
         let random_point = C::random(&mut rng).into_subgroup();

--- a/circuits/src/ecc/foreign/weierstrass_chip.rs
+++ b/circuits/src/ecc/foreign/weierstrass_chip.rs
@@ -539,12 +539,12 @@ where
         constant: C::CryptographicGroup,
     ) -> Result<(), Error> {
         if constant.is_identity().into() {
-            self.native_gadget.assert_equal_to_fixed(layouter, &p.is_id, true)
+            self.assert_zero(layouter, p)
         } else {
             let coordinates = constant.into().coordinates().expect("Valid point");
             self.base_field_chip().assert_equal_to_fixed(layouter, &p.x, coordinates.0)?;
             self.base_field_chip().assert_equal_to_fixed(layouter, &p.y, coordinates.1)?;
-            self.native_gadget.assert_equal_to_fixed(layouter, &p.is_id, false)
+            self.assert_non_zero(layouter, p)
         }
     }
 
@@ -555,7 +555,7 @@ where
         constant: C::CryptographicGroup,
     ) -> Result<(), Error> {
         if constant.is_identity().into() {
-            self.native_gadget.assert_equal_to_fixed(layouter, &p.is_id, false)
+            self.assert_non_zero(layouter, p)
         } else {
             let equal = self.is_equal_to_fixed(layouter, p, constant)?;
             self.native_gadget.assert_equal_to_fixed(layouter, &equal, false)
@@ -641,6 +641,22 @@ where
     S::Scalar: InnerValue<Element = C::ScalarField>,
     N: NativeInstructions<F>,
 {
+    fn assert_zero(
+        &self,
+        layouter: &mut impl Layouter<F>,
+        x: &AssignedForeignPoint<F, C, B>,
+    ) -> Result<(), Error> {
+        self.native_gadget.assert_equal_to_fixed(layouter, &x.is_id, true)
+    }
+
+    fn assert_non_zero(
+        &self,
+        layouter: &mut impl Layouter<F>,
+        x: &AssignedForeignPoint<F, C, B>,
+    ) -> Result<(), Error> {
+        self.native_gadget.assert_equal_to_fixed(layouter, &x.is_id, false)
+    }
+
     fn is_zero(
         &self,
         _layouter: &mut impl Layouter<F>,
@@ -1779,7 +1795,7 @@ where
 
         // Assert that none of the bases is the identity point
         for p in bases.iter() {
-            self.native_gadget.assert_equal_to_fixed(layouter, &p.is_id, false)?
+            self.assert_non_zero(layouter, p)?;
         }
 
         // Pad all the sequences of chunks to have the same length.

--- a/circuits/src/ecc/foreign/weierstrass_chip.rs
+++ b/circuits/src/ecc/foreign/weierstrass_chip.rs
@@ -1708,32 +1708,34 @@ where
             return Ok(cached.clone());
         }
 
-        let r: AssignedForeignPoint<F, C, B> = if let Some(cached) = self.msm_randomness.borrow().get(&1) {
-            cached.r
+        let cached_r = self.msm_randomness.borrow().get(&1).map(|c| c.r.clone());
+        let r: AssignedForeignPoint<F, C, B> = if let Some(r) = cached_r {
+            r
         } else {
-            let p = self.assign_without_subgroup_check(
-                layouter,
-                Value::known(self.random_point)
-            )?;
+            let p =
+                self.assign_without_subgroup_check(layouter, Value::known(self.random_point))?;
 
-            // Cache the random point
-            let randomness = MsmRandomness { r: p.clone(), neg_alpha: p.clone() };
-            self.msm_randomness.borrow_mut().insert(1, randomness.clone());
-
-            // Assert the chosen r is not the identity point.
             self.base_field_chip
                 .native_gadget
-                .assert_equal_to_fixed(layouter, &r.is_id, false)?;
+                .assert_equal_to_fixed(layouter, &p.is_id, false)?;
 
             p
         };
 
+        // Cache the random point from the chip. Note that `neg_alpha` is never used for
+        // the base randomness.
+        let randomness = MsmRandomness {
+            r: r.clone(),
+            neg_alpha: r.clone(),
+        };
+        self.msm_randomness.borrow_mut().insert(1, randomness.clone());
+
         let alpha = self.mul_by_u128(layouter, (1u128 << WS) - 1, &r)?;
         let neg_alpha = self.negate(layouter, &alpha)?;
 
-        let randomness = MsmRandomness { r, neg_alpha };
-        self.msm_randomness.borrow_mut().insert(WS, randomness.clone());
-        Ok(randomness)
+        let windowed_randomness = MsmRandomness { r, neg_alpha };
+        self.msm_randomness.borrow_mut().insert(WS, windowed_randomness.clone());
+        Ok(windowed_randomness)
     }
 
     /// Curve multi-scalar multiplication.
@@ -2043,7 +2045,12 @@ where
         let native_gadget = <N as FromScratch<F>>::new_from_scratch(&config.native_gadget_config);
         let scalar_field_chip =
             <S as FromScratch<F>>::new_from_scratch(&config.scalar_field_config);
-        ForeignWeierstrassEccChip::new(&config.ff_ecc_config, &native_gadget, &scalar_field_chip, OsRng)
+        ForeignWeierstrassEccChip::new(
+            &config.ff_ecc_config,
+            &native_gadget,
+            &scalar_field_chip,
+            OsRng,
+        )
     }
 
     fn load_from_scratch(&self, layouter: &mut impl Layouter<F>) -> Result<(), Error> {

--- a/circuits/src/verifier/verifier_gadget.rs
+++ b/circuits/src/verifier/verifier_gadget.rs
@@ -997,8 +997,8 @@ pub(crate) mod tests {
                 &[InnerCircuit::from_witness(preimage)],
                 1,
                 &[&[&[], &inner_public_inputs]],
-                &mut rng,
                 &mut transcript,
+                &mut rng,
             )
             .unwrap_or_else(|_| panic!("Problem creating the inner proof"));
             transcript.finalize()

--- a/circuits/src/verifier/verifier_gadget.rs
+++ b/circuits/src/verifier/verifier_gadget.rs
@@ -748,7 +748,7 @@ pub(crate) mod tests {
         poly::kzg::{params::ParamsKZG, KZGCommitmentScheme},
         transcript::{CircuitTranscript, Transcript},
     };
-    use rand::SeedableRng;
+    use rand::{rngs::OsRng, SeedableRng};
     use rand_chacha::ChaCha8Rng;
 
     use super::*;
@@ -935,7 +935,7 @@ pub(crate) mod tests {
             let core_decomp_chip = P2RDecompositionChip::new(&config.1, &16);
             let native_gadget = NativeGadget::new(core_decomp_chip.clone(), native_chip.clone());
             let curve_chip =
-                ForeignWeierstrassEccChip::new(&config.2, &native_gadget, &native_gadget);
+                ForeignWeierstrassEccChip::new(&config.2, &native_gadget, &native_gadget, OsRng);
             let poseidon_chip = PoseidonChip::new(&config.3, &native_chip);
 
             let verifier_chip =

--- a/circuits/src/verifier/verifier_gadget.rs
+++ b/circuits/src/verifier/verifier_gadget.rs
@@ -748,7 +748,7 @@ pub(crate) mod tests {
         poly::kzg::{params::ParamsKZG, KZGCommitmentScheme},
         transcript::{CircuitTranscript, Transcript},
     };
-    use rand::{rngs::OsRng, SeedableRng};
+    use rand::SeedableRng;
     use rand_chacha::ChaCha8Rng;
 
     use super::*;
@@ -935,7 +935,7 @@ pub(crate) mod tests {
             let core_decomp_chip = P2RDecompositionChip::new(&config.1, &16);
             let native_gadget = NativeGadget::new(core_decomp_chip.clone(), native_chip.clone());
             let curve_chip =
-                ForeignWeierstrassEccChip::new(&config.2, &native_gadget, &native_gadget, OsRng);
+                ForeignWeierstrassEccChip::new(&config.2, &native_gadget, &native_gadget);
             let poseidon_chip = PoseidonChip::new(&config.3, &native_chip);
 
             let verifier_chip =

--- a/proofs/CHANGELOG.md
+++ b/proofs/CHANGELOG.md
@@ -27,6 +27,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Removed
 
+## [0.7.1]
+### Changed
+* Thread the prover RNG explicitly [#307](https://github.com/midnightntwrk/midnight-zk/pull/307)
+* Add `s_g2()` accessor on `ParamsVerifierKZG` [#307](https://github.com/midnightntwrk/midnight-zk/pull/307)
+
 ## [0.7.0]
 ### Added
 * changed `sha256` name in benches to account for the change of naming convention in `circuits` [#135](https://github.com/midnightntwrk/midnight-zk/pull/135)

--- a/proofs/Cargo.toml
+++ b/proofs/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "midnight-proofs"
-version = "0.7.0"
+version = "0.7.1"
 edition = "2021"
 rust-version = "1.76.0"
 description = """

--- a/proofs/benches/plonk.rs
+++ b/proofs/benches/plonk.rs
@@ -290,8 +290,8 @@ fn criterion_benchmark(c: &mut Criterion) {
             #[cfg(feature = "committed-instances")]
             0,
             &[&[]],
-            rng,
             &mut transcript,
+            rng,
         )
         .expect("proof generation should not fail");
         transcript.finalize()

--- a/proofs/benches/zswap_output.rs
+++ b/proofs/benches/zswap_output.rs
@@ -268,8 +268,8 @@ fn bench_zswap_output(c: &mut Criterion) {
         std::slice::from_ref(&circuit),
         1,
         &[&[&[], &instance]],
-        &mut OsRng,
         &mut transcript,
+        &mut OsRng,
         &mut group,
     )
     .expect("Failed to generate proof");

--- a/proofs/benches/zswap_output.rs
+++ b/proofs/benches/zswap_output.rs
@@ -268,7 +268,7 @@ fn bench_zswap_output(c: &mut Criterion) {
         std::slice::from_ref(&circuit),
         1,
         &[&[&[], &instance]],
-        OsRng,
+        &mut OsRng,
         &mut transcript,
         &mut group,
     )

--- a/proofs/examples/serialization.rs
+++ b/proofs/examples/serialization.rs
@@ -161,8 +161,8 @@ fn main() {
         #[cfg(feature = "committed-instances")]
         0,
         &[instances],
-        OsRng,
         &mut transcript,
+        OsRng,
     )
     .expect("proof generation should not fail");
 

--- a/proofs/examples/vector-ops-unblinded.rs
+++ b/proofs/examples/vector-ops-unblinded.rs
@@ -537,8 +537,8 @@ where
             #[cfg(feature = "committed-instances")]
             NB_INSTANCE_COMS,
             &[&public_inputs],
-            OsRng,
             &mut transcript,
+            OsRng,
         )
         .expect("proof generation should not fail");
 

--- a/proofs/src/dev/cost_model.rs
+++ b/proofs/src/dev/cost_model.rs
@@ -829,8 +829,8 @@ mod tests {
             #[cfg(feature = "committed-instances")]
             0,
             &[instances],
-            OsRng,
             &mut transcript,
+            OsRng,
         )
         .expect("proof generation should not fail");
 

--- a/proofs/src/plonk/bench/prover.rs
+++ b/proofs/src/plonk/bench/prover.rs
@@ -44,7 +44,7 @@ pub(crate) fn compute_trace<
     // instances that the verifier receives in committed form.
     #[cfg(feature = "committed-instances")] nb_committed_instances: usize,
     instances: &[&[&[F]]],
-    mut rng: impl RngCore + CryptoRng,
+    rng: &mut (impl RngCore + CryptoRng),
     transcript: &mut T,
     group: &mut BenchmarkGroup<criterion::measurement::WallTime>,
 ) -> Result<ProverTrace<F>, Error>
@@ -112,13 +112,13 @@ where
                 || transcript.clone(),
                 |mut t| {
                     let _ = parse_advices::<F, CS, ConcreteCircuit, T>(
-                        params, pk, circuits, instances, &mut t, &mut rng,
+                        params, pk, circuits, instances, &mut t, rng,
                     );
                 },
                 criterion::BatchSize::LargeInput,
             )
         });
-        parse_advices(params, pk, circuits, instances, transcript, &mut rng)?
+        parse_advices(params, pk, circuits, instances, transcript, rng)?
     };
 
     // Sample theta challenge for keeping lookup columns linearly independent
@@ -148,7 +148,7 @@ where
                                         &pk.fixed_values,
                                         &instance.instance_values,
                                         &challenges,
-                                        &mut rng,
+                                        rng,
                                         &mut t,
                                     )
                                 })
@@ -178,7 +178,7 @@ where
                             &pk.fixed_values,
                             &instance.instance_values,
                             &challenges,
-                            &mut rng,
+                            rng,
                             transcript,
                         )
                     })
@@ -212,7 +212,7 @@ where
                                 &instance.instance_values,
                                 beta,
                                 gamma,
-                                &mut rng,
+                                rng,
                                 &mut t,
                             )
                         })
@@ -234,7 +234,7 @@ where
                     &instance.instance_values,
                     beta,
                     gamma,
-                    &mut rng,
+                    rng,
                     transcript,
                 )
             })
@@ -253,7 +253,7 @@ where
                             lookups
                                 .into_iter()
                                 .map(|lookup| {
-                                    lookup.commit_product(pk, params, beta, gamma, &mut rng, &mut t)
+                                    lookup.commit_product(pk, params, beta, gamma, rng, &mut t)
                                 })
                                 .collect::<Result<Vec<_>, _>>()
                         })
@@ -268,9 +268,7 @@ where
                 // Construct and commit to products for each lookup
                 lookups
                     .into_iter()
-                    .map(|lookup| {
-                        lookup.commit_product(pk, params, beta, gamma, &mut rng, transcript)
-                    })
+                    .map(|lookup| lookup.commit_product(pk, params, beta, gamma, rng, transcript))
                     .collect::<Result<Vec<_>, _>>()
             })
             .collect::<Result<Vec<_>, _>>()?
@@ -341,12 +339,12 @@ where
         b.iter_batched(
             || transcript.clone(),
             |mut t| {
-                let _ = vanishing::Argument::<F, CS>::commit(params, domain, &mut rng, &mut t);
+                let _ = vanishing::Argument::<F, CS>::commit(params, domain, rng, &mut t);
             },
             criterion::BatchSize::SmallInput,
         )
     });
-    let vanishing = vanishing::Argument::<F, CS>::commit(params, domain, &mut rng, transcript)?;
+    let vanishing = vanishing::Argument::<F, CS>::commit(params, domain, rng, transcript)?;
 
     // Obtain challenge for keeping all separate gates linearly independent
     let y: F = transcript.squeeze_challenge();
@@ -396,6 +394,7 @@ pub(crate) fn finalise_proof<'a, F, CS: PolynomialCommitmentScheme<F>, T: Transc
     // instances that the verifier receives in committed form.
     #[cfg(feature = "committed-instances")] nb_committed_instances: usize,
     trace: ProverTrace<F>,
+    rng: &mut (impl RngCore + CryptoRng),
     transcript: &mut T,
     rng: impl RngCore,
     group: &mut BenchmarkGroup<criterion::measurement::WallTime>,
@@ -439,7 +438,7 @@ where
             b.iter_batched(
                 || (transcript.clone(), h_poly.clone(), vanishing.clone()),
                 |(mut t, h, v)| {
-                    let _ = v.construct::<CS, T>(params, domain, h, &mut t, OsRng);
+                    let _ = v.construct::<CS, T>(params, domain, h, &mut t, rng);
                 },
                 criterion::BatchSize::PerIteration,
             )
@@ -585,7 +584,7 @@ pub fn benchmark_create_proof<
     circuits: &[ConcreteCircuit],
     #[cfg(feature = "committed-instances")] nb_committed_instances: usize,
     instances: &[&[&[F]]],
-    mut rng: impl RngCore + CryptoRng,
+    rng: &mut (impl RngCore + CryptoRng),
     transcript: &mut T,
     group: &mut BenchmarkGroup<criterion::measurement::WallTime>,
 ) -> Result<(), Error>
@@ -608,8 +607,8 @@ where
         #[cfg(feature = "committed-instances")]
         nb_committed_instances,
         instances,
-        &mut rng,
         transcript,
+        rng,
         group,
     )?;
 
@@ -619,6 +618,7 @@ where
         #[cfg(feature = "committed-instances")]
         nb_committed_instances,
         trace,
+        rng,
         transcript,
         rng,
         group,

--- a/proofs/src/plonk/bench/prover.rs
+++ b/proofs/src/plonk/bench/prover.rs
@@ -4,7 +4,7 @@ use std::hash::Hash;
 
 use criterion::BenchmarkGroup;
 use ff::{FromUniformBytes, WithSmallOrderMulGroup};
-use rand_core::{CryptoRng, OsRng, RngCore};
+use rand_core::{CryptoRng, RngCore};
 
 use crate::{
     plonk::{

--- a/proofs/src/plonk/bench/prover.rs
+++ b/proofs/src/plonk/bench/prover.rs
@@ -44,8 +44,8 @@ pub(crate) fn compute_trace<
     // instances that the verifier receives in committed form.
     #[cfg(feature = "committed-instances")] nb_committed_instances: usize,
     instances: &[&[&[F]]],
-    rng: &mut (impl RngCore + CryptoRng),
     transcript: &mut T,
+    rng: &mut (impl RngCore + CryptoRng),
     group: &mut BenchmarkGroup<criterion::measurement::WallTime>,
 ) -> Result<ProverTrace<F>, Error>
 where
@@ -394,9 +394,8 @@ pub(crate) fn finalise_proof<'a, F, CS: PolynomialCommitmentScheme<F>, T: Transc
     // instances that the verifier receives in committed form.
     #[cfg(feature = "committed-instances")] nb_committed_instances: usize,
     trace: ProverTrace<F>,
-    rng: &mut (impl RngCore + CryptoRng),
     transcript: &mut T,
-    rng: impl RngCore,
+    rng: &mut (impl RngCore + CryptoRng),
     group: &mut BenchmarkGroup<criterion::measurement::WallTime>,
 ) -> Result<(), Error>
 where
@@ -584,8 +583,8 @@ pub fn benchmark_create_proof<
     circuits: &[ConcreteCircuit],
     #[cfg(feature = "committed-instances")] nb_committed_instances: usize,
     instances: &[&[&[F]]],
-    rng: &mut (impl RngCore + CryptoRng),
     transcript: &mut T,
+    rng: &mut (impl RngCore + CryptoRng),
     group: &mut BenchmarkGroup<criterion::measurement::WallTime>,
 ) -> Result<(), Error>
 where
@@ -618,7 +617,6 @@ where
         #[cfg(feature = "committed-instances")]
         nb_committed_instances,
         trace,
-        rng,
         transcript,
         rng,
         group,

--- a/proofs/src/plonk/lookup/prover.rs
+++ b/proofs/src/plonk/lookup/prover.rs
@@ -59,7 +59,6 @@ impl<F: WithSmallOrderMulGroup<3> + Ord + Hash> Argument<F> {
         'a,
         'params: 'a,
         CS: PolynomialCommitmentScheme<F>,
-        R: RngCore,
         T: Transcript,
     >(
         &self,
@@ -71,7 +70,7 @@ impl<F: WithSmallOrderMulGroup<3> + Ord + Hash> Argument<F> {
         fixed_values: &'a [Polynomial<F, LagrangeCoeff>],
         instance_values: &'a [Polynomial<F, LagrangeCoeff>],
         challenges: &'a [F],
-        mut rng: R,
+        rng: &mut impl RngCore,
         transcript: &mut T,
     ) -> Result<Permuted<F>, Error>
     where
@@ -109,7 +108,7 @@ impl<F: WithSmallOrderMulGroup<3> + Ord + Hash> Argument<F> {
         let (permuted_input_expression, permuted_table_expression) = permute_expression_pair(
             pk,
             domain,
-            &mut rng,
+            rng,
             &compressed_input_expression,
             &compressed_table_expression,
         )?;
@@ -159,7 +158,7 @@ impl<F: WithSmallOrderMulGroup<3>> Permuted<F> {
         params: &CS::Parameters,
         beta: F,
         gamma: F,
-        mut rng: impl RngCore + CryptoRng,
+        rng: &mut (impl RngCore + CryptoRng),
         transcript: &mut T,
     ) -> Result<Committed<F>, Error>
     where
@@ -237,7 +236,7 @@ impl<F: WithSmallOrderMulGroup<3>> Permuted<F> {
             // be a boolean (and ideally 1, else soundness is broken)
             .take(pk.vk.n() as usize - blinding_factors)
             // Chain random blinding factors.
-            .chain((0..blinding_factors).map(|_| F::random(&mut rng)))
+            .chain((0..blinding_factors).map(|_| F::random(&mut *rng)))
             .collect::<Vec<_>>();
         assert_eq!(z.len(), pk.vk.n() as usize);
         let z = pk.vk.domain.lagrange_from_vec(z);
@@ -377,10 +376,10 @@ type ExpressionPair<F> = (Polynomial<F, LagrangeCoeff>, Polynomial<F, LagrangeCo
 ///   corresponding value in S'.
 ///
 /// This method returns (A', S') if no errors are encountered.
-fn permute_expression_pair<F, CS: PolynomialCommitmentScheme<F>, R: RngCore>(
+fn permute_expression_pair<F, CS: PolynomialCommitmentScheme<F>>(
     pk: &ProvingKey<F, CS>,
     domain: &EvaluationDomain<F>,
-    mut rng: R,
+    rng: &mut impl RngCore,
     input_expression: &Polynomial<F, LagrangeCoeff>,
     table_expression: &Polynomial<F, LagrangeCoeff>,
 ) -> Result<ExpressionPair<F>, Error>
@@ -435,8 +434,8 @@ where
     }
     assert!(repeated_input_rows.is_empty());
 
-    permuted_input_expression.extend((0..(blinding_factors + 1)).map(|_| F::random(&mut rng)));
-    permuted_table_coeffs.extend((0..(blinding_factors + 1)).map(|_| F::random(&mut rng)));
+    permuted_input_expression.extend((0..(blinding_factors + 1)).map(|_| F::random(&mut *rng)));
+    permuted_table_coeffs.extend((0..(blinding_factors + 1)).map(|_| F::random(&mut *rng)));
     assert_eq!(permuted_input_expression.len(), pk.vk.n() as usize);
     assert_eq!(permuted_table_coeffs.len(), pk.vk.n() as usize);
 

--- a/proofs/src/plonk/permutation/prover.rs
+++ b/proofs/src/plonk/permutation/prover.rs
@@ -2,7 +2,7 @@ use std::iter::{self, ExactSizeIterator};
 
 use ff::{PrimeField, WithSmallOrderMulGroup};
 use group::ff::BatchInvert;
-use rand_core::RngCore;
+use rand_core::{CryptoRng, RngCore};
 
 use super::{super::circuit::Any, Argument, ProvingKey};
 use crate::{
@@ -36,7 +36,6 @@ impl Argument {
     pub(crate) fn commit<
         F: WithSmallOrderMulGroup<3>,
         CS: PolynomialCommitmentScheme<F>,
-        R: RngCore,
         T: Transcript,
     >(
         &self,
@@ -48,7 +47,7 @@ impl Argument {
         instance: &[Polynomial<F, LagrangeCoeff>],
         beta: F,
         gamma: F,
-        mut rng: R,
+        rng: &mut (impl RngCore + CryptoRng),
         transcript: &mut T,
     ) -> Result<Committed<F>, Error>
     where
@@ -148,7 +147,7 @@ impl Argument {
             let mut z = domain.lagrange_from_vec(z);
             // Set blinding factors
             for z in &mut z[domain.n as usize - blinding_factors..] {
-                *z = F::random(&mut rng);
+                *z = F::random(&mut *rng);
             }
             // Set new last_z
             last_z = z[domain.n as usize - (blinding_factors + 1)];

--- a/proofs/src/plonk/prover.rs
+++ b/proofs/src/plonk/prover.rs
@@ -68,8 +68,8 @@ pub(crate) fn compute_trace<
     // instances that the verifier receives in committed form.
     #[cfg(feature = "committed-instances")] nb_committed_instances: usize,
     instances: &[&[&[F]]],
-    rng: &mut (impl RngCore + CryptoRng),
     transcript: &mut T,
+    rng: &mut (impl RngCore + CryptoRng),
 ) -> Result<ProverTrace<F>, Error>
 where
     CS::Commitment: Hashable<T::Hash>,
@@ -247,9 +247,8 @@ pub(crate) fn finalise_proof<'a, F, CS: PolynomialCommitmentScheme<F>, T: Transc
     // instances that the verifier receives in committed form.
     #[cfg(feature = "committed-instances")] nb_committed_instances: usize,
     trace: ProverTrace<F>,
-    rng: &mut (impl RngCore + CryptoRng),
     transcript: &mut T,
-    rng: impl RngCore,
+    rng: &mut (impl RngCore + CryptoRng),
 ) -> Result<(), Error>
 where
     CS::Commitment: Hashable<T::Hash>,
@@ -357,8 +356,8 @@ pub fn create_proof<
     circuits: &[ConcreteCircuit],
     #[cfg(feature = "committed-instances")] nb_committed_instances: usize,
     instances: &[&[&[F]]],
-    mut rng: impl RngCore + CryptoRng,
     transcript: &mut T,
+    mut rng: impl RngCore + CryptoRng,
 ) -> Result<(), Error>
 where
     CS::Commitment: Hashable<T::Hash>,
@@ -369,7 +368,6 @@ where
         + Ord
         + FromUniformBytes<64>,
 {
-    let mut rng = rng;
     let trace = compute_trace(
         params,
         pk,
@@ -377,8 +375,8 @@ where
         #[cfg(feature = "committed-instances")]
         nb_committed_instances,
         instances,
-        &mut rng,
         transcript,
+        &mut rng,
     )?;
     finalise_proof(
         params,
@@ -386,9 +384,8 @@ where
         #[cfg(feature = "committed-instances")]
         nb_committed_instances,
         trace,
-        &mut rng,
         transcript,
-        rng,
+        &mut rng,
     )
 }
 
@@ -982,8 +979,8 @@ fn test_create_proof() {
         #[cfg(feature = "committed-instances")]
         0,
         &[],
-        OsRng,
         &mut transcript,
+        OsRng,
     );
     assert!(matches!(proof.unwrap_err(), Error::InvalidInstances));
 
@@ -995,8 +992,8 @@ fn test_create_proof() {
         #[cfg(feature = "committed-instances")]
         0,
         &[&[], &[]],
-        OsRng,
         &mut transcript,
+        OsRng,
     )
     .expect("proof generation should not fail");
 }

--- a/proofs/src/plonk/prover.rs
+++ b/proofs/src/plonk/prover.rs
@@ -68,7 +68,7 @@ pub(crate) fn compute_trace<
     // instances that the verifier receives in committed form.
     #[cfg(feature = "committed-instances")] nb_committed_instances: usize,
     instances: &[&[&[F]]],
-    mut rng: impl RngCore + CryptoRng,
+    rng: &mut (impl RngCore + CryptoRng),
     transcript: &mut T,
 ) -> Result<ProverTrace<F>, Error>
 where
@@ -102,8 +102,7 @@ where
 
     let instance = compute_instances(params, pk, instances, nb_committed_instances, transcript)?;
 
-    let (advice, challenges) =
-        parse_advices(params, pk, circuits, instances, transcript, &mut rng)?;
+    let (advice, challenges) = parse_advices(params, pk, circuits, instances, transcript, rng)?;
 
     // Sample theta challenge for keeping lookup columns linearly independent
     let theta: F = transcript.squeeze_challenge();
@@ -127,7 +126,7 @@ where
                         &pk.fixed_values,
                         &instance.instance_values,
                         &challenges,
-                        &mut rng,
+                        rng,
                         transcript,
                     )
                 })
@@ -155,7 +154,7 @@ where
                 &instance.instance_values,
                 beta,
                 gamma,
-                &mut rng,
+                rng,
                 transcript,
             )
         })
@@ -167,7 +166,7 @@ where
             // Construct and commit to products for each lookup
             lookups
                 .into_iter()
-                .map(|lookup| lookup.commit_product(pk, params, beta, gamma, &mut rng, transcript))
+                .map(|lookup| lookup.commit_product(pk, params, beta, gamma, rng, transcript))
                 .collect::<Result<Vec<_>, _>>()
         })
         .collect::<Result<Vec<_>, _>>()?;
@@ -200,7 +199,7 @@ where
         .collect::<Result<Vec<_>, _>>()?;
 
     // Commit to the vanishing argument's random polynomial for blinding h(x_3)
-    let vanishing = vanishing::Argument::<F, CS>::commit(params, domain, &mut rng, transcript)?;
+    let vanishing = vanishing::Argument::<F, CS>::commit(params, domain, rng, transcript)?;
 
     // Obtain challenge for keeping all separate gates linearly independent
     let y: F = transcript.squeeze_challenge();
@@ -248,6 +247,7 @@ pub(crate) fn finalise_proof<'a, F, CS: PolynomialCommitmentScheme<F>, T: Transc
     // instances that the verifier receives in committed form.
     #[cfg(feature = "committed-instances")] nb_committed_instances: usize,
     trace: ProverTrace<F>,
+    rng: &mut (impl RngCore + CryptoRng),
     transcript: &mut T,
     rng: impl RngCore,
 ) -> Result<(), Error>
@@ -369,6 +369,7 @@ where
         + Ord
         + FromUniformBytes<64>,
 {
+    let mut rng = rng;
     let trace = compute_trace(
         params,
         pk,
@@ -385,6 +386,7 @@ where
         #[cfg(feature = "committed-instances")]
         nb_committed_instances,
         trace,
+        &mut rng,
         transcript,
         rng,
     )
@@ -464,7 +466,7 @@ pub(super) fn parse_advices<F, CS, ConcreteCircuit, T>(
     circuits: &[ConcreteCircuit],
     instances: &[&[&[F]]],
     transcript: &mut T,
-    mut rng: impl RngCore + CryptoRng,
+    rng: &mut (impl RngCore + CryptoRng),
 ) -> Result<(Vec<AdviceSingle<F, LagrangeCoeff>>, Vec<F>), Error>
 where
     F: WithSmallOrderMulGroup<3> + Sampleable<T::Hash>,
@@ -556,7 +558,7 @@ where
             for (column_index, advice_values) in column_indices.iter().zip(&mut advice_values) {
                 if !witness.unblinded_advice.contains(column_index) {
                     for cell in &mut advice_values[unusable_rows_start..] {
-                        *cell = F::random(&mut rng);
+                        *cell = F::random(&mut *rng);
                     }
                 } else {
                     #[cfg(debug_assertions)]
@@ -967,12 +969,13 @@ fn test_create_proof() {
 
     const K: u32 = 4;
     let params: ParamsKZG<Bn256> = ParamsKZG::unsafe_setup(K, OsRng);
-    let vk = keygen_vk_with_k(&params, &MyCircuit, K).expect("keygen_vk should not fail");
+    let vk = keygen_vk_with_k::<Fr, KZGCommitmentScheme<Bn256>, _>(&params, &MyCircuit, K)
+        .expect("keygen_vk should not fail");
     let pk = keygen_pk(vk, &MyCircuit).expect("keygen_pk should not fail");
     let mut transcript = CircuitTranscript::<_>::init();
 
     // Create proof with wrong number of instances
-    let proof = create_proof::<Fr, KZGCommitmentScheme<Bn256>, _, _>(
+    let proof = create_proof(
         &params,
         &pk,
         &[MyCircuit, MyCircuit],
@@ -985,7 +988,7 @@ fn test_create_proof() {
     assert!(matches!(proof.unwrap_err(), Error::InvalidInstances));
 
     // Create proof with correct number of instances
-    create_proof::<Fr, KZGCommitmentScheme<Bn256>, _, _>(
+    create_proof(
         &params,
         &pk,
         &[MyCircuit, MyCircuit],

--- a/proofs/src/plonk/vanishing/prover.rs
+++ b/proofs/src/plonk/vanishing/prover.rs
@@ -89,7 +89,7 @@ impl<F: WithSmallOrderMulGroup<3>> Committed<F> {
         domain: &EvaluationDomain<F>,
         h_poly: Polynomial<F, ExtendedLagrangeCoeff>,
         transcript: &mut T,
-        rng: &mut (impl RngCore + CryptoRng)
+        rng: &mut (impl RngCore + CryptoRng),
     ) -> Result<Constructed<F>, Error>
     where
         CS::Commitment: Hashable<T::Hash>,

--- a/proofs/src/plonk/vanishing/prover.rs
+++ b/proofs/src/plonk/vanishing/prover.rs
@@ -2,7 +2,7 @@ use std::{collections::HashMap, iter};
 
 use ff::{PrimeField, WithSmallOrderMulGroup};
 use rand_chacha::ChaCha20Rng;
-use rand_core::{RngCore, SeedableRng};
+use rand_core::{CryptoRng, RngCore, SeedableRng};
 use rayon::current_num_threads;
 
 use super::Argument;
@@ -34,10 +34,10 @@ pub(crate) struct Evaluated<F: PrimeField> {
 }
 
 impl<F: WithSmallOrderMulGroup<3>, CS: PolynomialCommitmentScheme<F>> Argument<F, CS> {
-    pub(crate) fn commit<R: RngCore, T: Transcript>(
+    pub(crate) fn commit<T: Transcript>(
         params: &CS::Parameters,
         domain: &EvaluationDomain<F>,
-        mut rng: R,
+        rng: &mut (impl RngCore + CryptoRng),
         transcript: &mut T,
     ) -> Result<Committed<F>, Error>
     where
@@ -89,7 +89,7 @@ impl<F: WithSmallOrderMulGroup<3>> Committed<F> {
         domain: &EvaluationDomain<F>,
         h_poly: Polynomial<F, ExtendedLagrangeCoeff>,
         transcript: &mut T,
-        rng: impl RngCore,
+        rng: &mut (impl RngCore + CryptoRng)
     ) -> Result<Constructed<F>, Error>
     where
         CS::Commitment: Hashable<T::Hash>,
@@ -135,12 +135,15 @@ impl<F: WithSmallOrderMulGroup<3>> Committed<F> {
     }
 }
 
-fn blind_quotient_limbs<F: PrimeField>(quotient_limbs: &mut [Vec<F>], mut rng: impl RngCore) {
+fn blind_quotient_limbs<F: PrimeField>(
+    quotient_limbs: &mut [Vec<F>],
+    rng: &mut (impl RngCore + CryptoRng),
+) {
     let nr_limbs = quotient_limbs.len();
     assert!(nr_limbs >= 2);
 
     for i in 1..nr_limbs {
-        let t = F::random(&mut rng);
+        let t = F::random(&mut *rng);
         quotient_limbs[i - 1].push(t);
         quotient_limbs[i][0] -= t;
     }

--- a/proofs/src/poly/kzg/params.rs
+++ b/proofs/src/poly/kzg/params.rs
@@ -127,7 +127,7 @@ impl<E: Engine + Debug> ParamsKZG<E> {
         self.g2
     }
 
-    /// Returns first power of secret on G2
+    /// Returns \[τ\]₂, a commitment to τ in G2.
     pub fn s_g2(&self) -> E::G2 {
         self.s_g2
     }
@@ -242,6 +242,11 @@ impl<E: MultiMillerLoop + Debug> ParamsVerifierKZG<E>
 where
     E::G2: Curve + ProcessedSerdeObject,
 {
+    /// Returns \[τ\]₂, a commitment to τ in G2.
+    pub fn s_g2(&self) -> E::G2 {
+        self.s_g2
+    }
+
     /// Writes parameters to buffer
     pub fn write<W: io::Write>(&self, writer: &mut W, format: SerdeFormat) -> io::Result<()> {
         self.s_g2.write(writer, format)?;

--- a/proofs/tests/plonk_api.rs
+++ b/proofs/tests/plonk_api.rs
@@ -489,8 +489,8 @@ fn plonk_api() {
             #[cfg(feature = "committed-instances")]
             0,
             &[&[&[instance]], &[&[instance]]],
-            rng,
             &mut transcript,
+            rng,
         )
         .expect("proof generation should not fail");
 

--- a/zk_stdlib/CHANGELOG.md
+++ b/zk_stdlib/CHANGELOG.md
@@ -48,7 +48,11 @@ verification keys break backwards compatibility.
 ### Removed
 * Move Blake2b and SHA3-256/Keccak256 implementations to zk-stdlib [#178](https://github.com/midnightntwrk/midnight-zk/pull/178)
 
-## 1.0.0
+## [1.1.0]
+### Changed
+* Update `prove` to accept `impl RngCore + CryptoRng` by value [#307](https://github.com/midnightntwrk/midnight-zk/pull/307)
+
+## [1.0.0] 
 ### Added
 - Initial release of zk_stdlib extracted from circuits crate
 

--- a/zk_stdlib/Cargo.toml
+++ b/zk_stdlib/Cargo.toml
@@ -19,7 +19,7 @@ midnight-proofs = { version = "0.7.1", default-features = false, features = [
 ] }
 
 keccak_sha3 = { package = "sha3-circuit", version = "0.1.0" }
-blake2b = { package = "blake2b_halo2", git = "https://github.com/eryxcoop/blake2b_halo2", rev = "2296aa2" }
+blake2b = { package = "blake2b_halo2", git = "https://github.com/eryxcoop/blake2b_halo2", branch = "v0.2" }
 
 serde = { workspace = true, optional = true }
 sha2 = { workspace = true }

--- a/zk_stdlib/Cargo.toml
+++ b/zk_stdlib/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "midnight-zk-stdlib"
-version = "1.0.0"
+version = "1.1.0"
 edition = "2021"
 license-file.workspace = true
 description = "Standard library of circuits and utilities for Midnight zero-knowledge proofs"
@@ -11,9 +11,9 @@ description = "Standard library of circuits and utilities for Midnight zero-know
 group = { workspace = true }
 ff = { workspace = true }
 blake2b_simd = { workspace = true }
-midnight-circuits = { version = "6.0.0", features = ["testing"] }
+midnight-circuits = { version = "6.1.0", features = ["testing"]  }
 midnight-curves = { version = "0.2.0" }
-midnight-proofs = { version = "0.7.0", default-features = false, features = [
+midnight-proofs = { version = "0.7.1", default-features = false, features = [
     "circuit-params",
     "committed-instances",
 ] }

--- a/zk_stdlib/Cargo.toml
+++ b/zk_stdlib/Cargo.toml
@@ -34,7 +34,7 @@ hex-literal = "1.1"
 
 [dev-dependencies]
 criterion = "0.7"
-rand_chacha = "0.3.1"
+rand_chacha = { workspace = true }
 goldenfile = "=1.8.0"
 num-bigint = { workspace = true, features = ["rand"] }
 serde_json = { workspace = true }

--- a/zk_stdlib/src/lib.rs
+++ b/zk_stdlib/src/lib.rs
@@ -106,7 +106,7 @@ use midnight_proofs::{
     utils::SerdeFormat,
 };
 use num_bigint::BigUint;
-use rand::{rngs::OsRng, CryptoRng, RngCore};
+use rand::{CryptoRng, RngCore};
 
 use crate::{
     external::{blake2b::Blake2bWrapper, keccak_sha3::KeccakSha3Wrapper},
@@ -348,17 +348,17 @@ impl ZkStdLib {
         let secp256k1_chip = (config.secp256k1_config.as_ref())
             .zip(secp256k1_scalar_chip.as_ref())
             .map(|(curve_config, scalar_chip)| {
-                ForeignWeierstrassEccChip::new(curve_config, &native_gadget, scalar_chip, OsRng)
+                ForeignWeierstrassEccChip::new(curve_config, &native_gadget, scalar_chip)
             });
         let p256_scalar_chip = (config.p256_scalar_config.as_ref())
             .map(|scalar_config| FieldChip::new(scalar_config, &native_gadget));
         let p256_chip = (config.p256_config.as_ref()).zip(p256_scalar_chip.as_ref()).map(
             |(curve_config, scalar_chip)| {
-                ForeignWeierstrassEccChip::new(curve_config, &native_gadget, scalar_chip, OsRng)
+                ForeignWeierstrassEccChip::new(curve_config, &native_gadget, scalar_chip)
             },
         );
         let bls12_381_chip = (config.bls12_381_config.as_ref()).map(|curve_config| {
-            ForeignWeierstrassEccChip::new(curve_config, &native_gadget, &native_gadget, OsRng)
+            ForeignWeierstrassEccChip::new(curve_config, &native_gadget, &native_gadget)
         });
         let curve25519_scalar_chip = (config.curve25519_scalar_config.as_ref())
             .map(|scalar_config| FieldChip::new(scalar_config, &native_gadget));

--- a/zk_stdlib/src/lib.rs
+++ b/zk_stdlib/src/lib.rs
@@ -106,7 +106,7 @@ use midnight_proofs::{
     utils::SerdeFormat,
 };
 use num_bigint::BigUint;
-use rand::{CryptoRng, RngCore};
+use rand::{rngs::OsRng, CryptoRng, RngCore};
 
 use crate::{
     external::{blake2b::Blake2bWrapper, keccak_sha3::KeccakSha3Wrapper},
@@ -348,17 +348,17 @@ impl ZkStdLib {
         let secp256k1_chip = (config.secp256k1_config.as_ref())
             .zip(secp256k1_scalar_chip.as_ref())
             .map(|(curve_config, scalar_chip)| {
-                ForeignWeierstrassEccChip::new(curve_config, &native_gadget, scalar_chip)
+                ForeignWeierstrassEccChip::new(curve_config, &native_gadget, scalar_chip, OsRng)
             });
         let p256_scalar_chip = (config.p256_scalar_config.as_ref())
             .map(|scalar_config| FieldChip::new(scalar_config, &native_gadget));
         let p256_chip = (config.p256_config.as_ref()).zip(p256_scalar_chip.as_ref()).map(
             |(curve_config, scalar_chip)| {
-                ForeignWeierstrassEccChip::new(curve_config, &native_gadget, scalar_chip)
+                ForeignWeierstrassEccChip::new(curve_config, &native_gadget, scalar_chip, OsRng)
             },
         );
         let bls12_381_chip = (config.bls12_381_config.as_ref()).map(|curve_config| {
-            ForeignWeierstrassEccChip::new(curve_config, &native_gadget, &native_gadget)
+            ForeignWeierstrassEccChip::new(curve_config, &native_gadget, &native_gadget, OsRng)
         });
         let curve25519_scalar_chip = (config.curve25519_scalar_config.as_ref())
             .map(|scalar_config| FieldChip::new(scalar_config, &native_gadget));

--- a/zk_stdlib/src/utils/plonk_api.rs
+++ b/zk_stdlib/src/utils/plonk_api.rs
@@ -113,8 +113,8 @@ macro_rules! plonk_api {
                         std::slice::from_ref(circuit),
                         nb_instance_commitments,
                         &[pi],
-                        rng,
                         &mut transcript,
+                        rng,
                     )?;
                     transcript.finalize()
                 };


### PR DESCRIPTION
This PR cherry-picks the commit of version `1.1.0`. It also adds a new feature, `deterministic-prover` to ensure deterministic proof generation when using foreign field chip. 

The problem was that the `ZkStdLib` calls `new` in the `synthesis` function. The function `new` creates the foreign ECC chip (which contains the random point used for MSM). It does not make sense to pass in a `rng` in synthesis, so we now use a deterministic rng in the computation of the point `R` when the `deterministic-prover` feature is enabled. 