### PR TITLE
Prover Optimization: Fused coset FFT

### DIFF
--- a/proofs/src/plonk/bench/prover.rs
+++ b/proofs/src/plonk/bench/prover.rs
@@ -464,22 +464,30 @@ where
     // Obtain challenge for keeping all separate gates linearly independent
     let y: F = transcript.squeeze_challenge();
 
-    let (instance_polys, instance_values) =
-        instance.into_iter().map(|i| (i.instance_polys, i.instance_values)).unzip();
+    let mut instance_polys = Vec::with_capacity(instance.len());
+    let mut instance_cosets = Vec::with_capacity(instance.len());
+    let mut instance_values = Vec::with_capacity(instance.len());
+    for i in instance {
+        instance_polys.push(i.instance_polys);
+        instance_cosets.push(i.instance_cosets);
+        instance_values.push(i.instance_values);
+    }
 
-    let advice_polys = advice
+    let (advice_polys, advice_cosets): (Vec<_>, Vec<_>) = advice
         .into_iter()
         .map(|a| {
             a.advice_polys
                 .into_iter()
-                .map(|p| domain.lagrange_to_coeff(p))
-                .collect::<Vec<_>>()
+                .map(|p| domain.lagrange_to_coeff_and_extended(p))
+                .unzip::<_, _, Vec<_>, Vec<_>>()
         })
-        .collect::<Vec<_>>();
+        .unzip();
 
     Ok(ProverTrace {
         advice_polys,
+        advice_cosets,
         instance_polys,
+        instance_cosets,
         instance_values,
         lookups,
         trashcans,

--- a/proofs/src/plonk/prover.rs
+++ b/proofs/src/plonk/prover.rs
@@ -408,22 +408,35 @@ where
     // Obtain challenge for keeping all separate gates linearly independent
     let y: F = transcript.squeeze_challenge();
 
-    let (instance_polys, instance_values) =
-        instance.into_iter().map(|i| (i.instance_polys, i.instance_values)).unzip();
+    // Pull instance data out of `InstanceSingle`. The Coeff and extended-coset
+    // forms were already produced jointly via `lagrange_to_coeff_and_extended`
+    // in `compute_instances`, so no extra FFT work happens here.
+    let mut instance_polys = Vec::with_capacity(instance.len());
+    let mut instance_cosets = Vec::with_capacity(instance.len());
+    let mut instance_values = Vec::with_capacity(instance.len());
+    for i in instance {
+        instance_polys.push(i.instance_polys);
+        instance_cosets.push(i.instance_cosets);
+        instance_values.push(i.instance_values);
+    }
 
-    let advice_polys = advice
+    // For advice, do the Lagrange → (Coeff, Extended) conversion in a single
+    // fused pass, populating both forms of the trace at once.
+    let (advice_polys, advice_cosets): (Vec<_>, Vec<_>) = advice
         .into_iter()
         .map(|a| {
             a.advice_polys
                 .into_par_iter()
-                .map(|p| domain.lagrange_to_coeff(p))
-                .collect::<Vec<_>>()
+                .map(|p| domain.lagrange_to_coeff_and_extended(p))
+                .unzip::<_, _, Vec<_>, Vec<_>>()
         })
-        .collect::<Vec<_>>();
+        .unzip();
 
     Ok(ProverTrace {
         advice_polys,
+        advice_cosets,
         instance_polys,
+        instance_cosets,
         instance_values,
         lookups,
         trashcans,
@@ -681,17 +694,18 @@ where
                 })
                 .collect::<Result<Vec<_>, _>>()?;
 
-            let instance_polys: Vec<_> = instance_values
+            let (instance_polys, instance_cosets): (Vec<_>, Vec<_>) = instance_values
                 .iter()
                 .map(|poly| {
                     let lagrange_vec = pk.vk.domain.lagrange_from_vec(poly.to_vec());
-                    pk.vk.domain.lagrange_to_coeff(lagrange_vec)
+                    pk.vk.domain.lagrange_to_coeff_and_extended(lagrange_vec)
                 })
-                .collect();
+                .unzip();
 
             Ok(InstanceSingle {
                 instance_values,
                 instance_polys,
+                instance_cosets,
             })
         })
         .collect::<Result<Vec<_>, _>>()
@@ -838,8 +852,8 @@ pub(super) fn compute_nu_poly<F: WithSmallOrderMulGroup<3>, CS: PolynomialCommit
     trace: &ProverTrace<F>,
 ) -> Polynomial<F, ExtendedLagrangeCoeff> {
     let ProverTrace {
-        advice_polys,
-        instance_polys,
+        advice_cosets,
+        instance_cosets,
         lookups,
         trashcans,
         permutations,
@@ -851,25 +865,8 @@ pub(super) fn compute_nu_poly<F: WithSmallOrderMulGroup<3>, CS: PolynomialCommit
         y,
         ..
     } = &trace;
-    // Calculate the advice and instance cosets
-    let advice_cosets: Vec<Vec<Polynomial<F, ExtendedLagrangeCoeff>>> = advice_polys
-        .iter()
-        .map(|advice_polys| {
-            advice_polys
-                .par_iter()
-                .map(|poly| pk.vk.get_domain().coeff_to_extended(poly.clone()))
-                .collect()
-        })
-        .collect();
-    let instance_cosets: Vec<Vec<Polynomial<F, ExtendedLagrangeCoeff>>> = instance_polys
-        .iter()
-        .map(|instance_polys| {
-            instance_polys
-                .par_iter()
-                .map(|poly| pk.vk.get_domain().coeff_to_extended(poly.clone()))
-                .collect()
-        })
-        .collect();
+    // Advice and instance cosets were produced eagerly in `compute_trace` via
+    // the fused `lagrange_to_coeff_and_extended`, so no FFT work happens here.
 
     // Evaluate the numerator polynomial nu(X) of the quotient polynomial
     // h(X) = nu(X) / (X^n-1): nu(X) is a random linear combination of all
@@ -1064,6 +1061,10 @@ pub(super) fn compute_queries<
 pub(super) struct InstanceSingle<F: PrimeField> {
     pub instance_values: Vec<Polynomial<F, LagrangeCoeff>>,
     pub instance_polys: Vec<Polynomial<F, Coeff>>,
+    /// Extended-domain coset evaluations, computed eagerly via
+    /// `lagrange_to_coeff_and_extended` so the iFFT and forward FFT share
+    /// a single fused scalar pass.
+    pub instance_cosets: Vec<Polynomial<F, ExtendedLagrangeCoeff>>,
 }
 
 #[derive(Clone)]

--- a/proofs/src/plonk/traces.rs
+++ b/proofs/src/plonk/traces.rs
@@ -5,7 +5,10 @@ use ff::PrimeField;
 
 use crate::{
     plonk::{logup, permutation, trash},
-    poly::{commitment::PolynomialCommitmentScheme, Coeff, LagrangeCoeff, Polynomial},
+    poly::{
+        commitment::PolynomialCommitmentScheme, Coeff, ExtendedLagrangeCoeff, LagrangeCoeff,
+        Polynomial,
+    },
 };
 
 /// Prover's trace of a set of proofs. This type guarantees that the size of the
@@ -13,7 +16,14 @@ use crate::{
 #[derive(Debug)]
 pub struct ProverTrace<F: PrimeField> {
     pub(crate) advice_polys: Vec<Vec<Polynomial<F, Coeff>>>,
+    /// Extended coset evaluations for each advice poly, computed eagerly
+    /// alongside `advice_polys` via `lagrange_to_coeff_and_extended`. Consumed
+    /// by `compute_nu_poly` so the iFFT and forward FFT can share a single
+    /// fused scalar pass between them.
+    pub(crate) advice_cosets: Vec<Vec<Polynomial<F, ExtendedLagrangeCoeff>>>,
     pub(crate) instance_polys: Vec<Vec<Polynomial<F, Coeff>>>,
+    /// See [`Self::advice_cosets`].
+    pub(crate) instance_cosets: Vec<Vec<Polynomial<F, ExtendedLagrangeCoeff>>>,
     #[allow(dead_code)]
     // This field will be useful for split accumulation
     pub(crate) instance_values: Vec<Vec<Polynomial<F, LagrangeCoeff>>>,

--- a/proofs/src/poly/domain.rs
+++ b/proofs/src/poly/domain.rs
@@ -8,7 +8,10 @@ use group::ff::{BatchInvert, Field};
 use midnight_curves::fft::{best_fft_with_twiddles, compute_twiddles, fft_coeff_to_extended};
 
 use super::{Coeff, ExtendedLagrangeCoeff, LagrangeCoeff, Polynomial, Rotation};
-use crate::utils::{arithmetic::parallelize, rational::Rational};
+use crate::utils::{
+    arithmetic::{parallelize, parallelize_two},
+    rational::Rational,
+};
 
 /// Precomputed twiddle factors for the FFT.
 ///
@@ -274,6 +277,79 @@ impl<F: WithSmallOrderMulGroup<3>> EvaluationDomain<F> {
             values: a.values,
             _marker: PhantomData,
         }
+    }
+
+    /// This takes us from an n-length Lagrange-form polynomial directly to
+    /// **both** its coefficient form and its coset-of-extended-domain
+    /// evaluation form, in a single fused pass between the inverse and
+    /// forward FFTs.
+    ///
+    /// Equivalent to `(lagrange_to_coeff(p), coeff_to_extended(p.clone()))`,
+    /// but saves two full memory sweeps over n elements: the post-iFFT
+    /// `× ifft_divisor` scale and the pre-FFT `distribute_powers_zeta` twist
+    /// are folded into the single pass that also writes both output buffers
+    /// (the input `Vec` is re-used as the coefficient buffer; the extended
+    /// buffer is freshly allocated at full extended length, zero-padded).
+    ///
+    /// Use this when the caller needs both representations — i.e. when a
+    /// polynomial will be both opened (Coeff) and consumed by
+    /// `evaluate_numerator` (Extended). When only one is needed, prefer
+    /// [`Self::lagrange_to_coeff`] or
+    /// `lagrange_to_coeff(...) -> coeff_to_extended(...)` directly.
+    pub fn lagrange_to_coeff_and_extended(
+        &self,
+        mut a: Polynomial<F, LagrangeCoeff>,
+    ) -> (Polynomial<F, Coeff>, Polynomial<F, ExtendedLagrangeCoeff>) {
+        let n = a.values.len();
+        assert_eq!(n, 1 << self.k);
+        let extended_len = self.extended_len();
+
+        // 1. Inverse FFT in place. We omit the `× ifft_divisor` scale here — it is
+        //    folded into the fused pass below.
+        best_fft_with_twiddles(&mut a.values, &self.twiddles.omega_inv, self.k);
+
+        // 2. Allocate the extended buffer (zero-padded out to extended_len).
+        let mut ext_values = vec![F::ZERO; extended_len];
+
+        // 3. Single fused pass over the n-element prefix: coeff[i] = ifft_out[i] ·
+        //    ifft_divisor ext[i]   = coeff[i]    · ζ^(i mod 3) where ζ = g_coset is a
+        //    cube root of unity, so the twist cycles through `[1, ζ, ζ²]`. This
+        //    replaces the post-iFFT divisor scale (pass A) and the pre-FFT
+        //    `distribute_powers_zeta` twist (pass B) with a single read-and-write-twice
+        //    sweep.
+        let coset_factors = [F::ONE, self.g_coset, self.g_coset_inv];
+        let divisor = self.ifft_divisor;
+        parallelize_two(
+            &mut a.values,
+            &mut ext_values[..n],
+            |coeff_chunk, ext_chunk, start| {
+                for (i, (c, e)) in coeff_chunk.iter_mut().zip(ext_chunk.iter_mut()).enumerate() {
+                    let scaled = *c * divisor;
+                    *c = scaled;
+                    *e = scaled * coset_factors[(start + i) % 3];
+                }
+            },
+        );
+
+        // 4. Forward FFT on the extended buffer using the pruned DIF path —
+        //    only the first `n` entries are non-zero, which is exactly the
+        //    zero-padded structure its early-stage skip exploits.
+        fft_coeff_to_extended(
+            &mut ext_values,
+            &self.twiddles.extended_omega,
+            self.extended_k,
+            n,
+        );
+
+        let coeff = Polynomial {
+            values: a.values,
+            _marker: PhantomData,
+        };
+        let extended = Polynomial {
+            values: ext_values,
+            _marker: PhantomData,
+        };
+        (coeff, extended)
     }
 
     /// This takes us from an n-length coefficient vector into a coset of the

--- a/proofs/src/poly/domain.rs
+++ b/proofs/src/poly/domain.rs
@@ -655,6 +655,34 @@ fn test_rotate() {
 }
 
 #[test]
+fn test_lagrange_to_coeff_and_extended_matches_unfused() {
+    use midnight_curves::Fq as Scalar;
+    use rand_core::OsRng;
+
+    // Multiple (k, j) shapes to cover non-trivial extension factors.
+    for &(k, j) in &[(3u32, 2u32), (4, 2), (4, 4), (5, 4), (6, 4)] {
+        let domain = EvaluationDomain::<Scalar>::new(j, k);
+        let mut poly = domain.empty_lagrange();
+        for value in poly.iter_mut() {
+            *value = Scalar::random(OsRng);
+        }
+
+        let (fused_coeff, fused_ext) = domain.lagrange_to_coeff_and_extended(poly.clone());
+        let unfused_coeff = domain.lagrange_to_coeff(poly.clone());
+        let unfused_ext = domain.coeff_to_extended(unfused_coeff.clone());
+
+        assert_eq!(
+            fused_coeff.values, unfused_coeff.values,
+            "coeff (k={k}, j={j})"
+        );
+        assert_eq!(
+            fused_ext.values, unfused_ext.values,
+            "extended (k={k}, j={j})"
+        );
+    }
+}
+
+#[test]
 fn test_l_i() {
     use midnight_curves::Fq;
     use rand_core::OsRng;

--- a/proofs/src/utils/arithmetic.rs
+++ b/proofs/src/utils/arithmetic.rs
@@ -177,6 +177,49 @@ pub fn parallelize<T: Send, F: Fn(&mut [T], usize) + Send + Sync + Clone>(v: &mu
     });
 }
 
+/// Like [`parallelize`] but iterates over two slices of the same length
+/// jointly. The closure receives the matching chunks of each slice and the
+/// global starting offset of the chunk.
+pub fn parallelize_two<T, U, F>(a: &mut [T], b: &mut [U], f: F)
+where
+    T: Send,
+    U: Send,
+    F: Fn(&mut [T], &mut [U], usize) + Send + Sync + Clone,
+{
+    assert_eq!(a.len(), b.len());
+
+    let total_iters = a.len();
+    let num_threads = rayon::current_num_threads();
+    let base_chunk_size = total_iters / num_threads;
+    let cutoff_chunk_id = total_iters % num_threads;
+    let split_pos = cutoff_chunk_id * (base_chunk_size + 1);
+    let (a_hi, a_lo) = a.split_at_mut(split_pos);
+    let (b_hi, b_lo) = b.split_at_mut(split_pos);
+
+    let f = &f;
+    rayon::scope(|scope| {
+        if cutoff_chunk_id != 0 {
+            let large = base_chunk_size + 1;
+            for (chunk_id, (a_chunk, b_chunk)) in
+                a_hi.chunks_exact_mut(large).zip(b_hi.chunks_exact_mut(large)).enumerate()
+            {
+                let offset = chunk_id * large;
+                scope.spawn(move |_| f(a_chunk, b_chunk, offset));
+            }
+        }
+        if base_chunk_size != 0 {
+            for (chunk_id, (a_chunk, b_chunk)) in a_lo
+                .chunks_exact_mut(base_chunk_size)
+                .zip(b_lo.chunks_exact_mut(base_chunk_size))
+                .enumerate()
+            {
+                let offset = split_pos + (chunk_id * base_chunk_size);
+                scope.spawn(move |_| f(a_chunk, b_chunk, offset));
+            }
+        }
+    });
+}
+
 /// Returns coefficients of an n - 1 degree polynomial given a set of n points
 /// and their evaluations. This function will panic if two values in `points`
 /// are the same.


### PR DESCRIPTION
Merges into #349 

 ## Summary
Adds a fused FFT + iFFT function that computes the coefficient representation and extended coset evaluation representation in one call.

## Performance

  | Commit | k=15 | Δ | k=17 | Δ |
  |---|---:|---:|---:|---:|
  | `e81c7fc4` (base) | 2353.7 ms | — | 9203.3 ms | — |
  | `4aa8f21c` perf(fft): fuse lagrange_to_coeff_and_extended | 2347.8 ms | −0.25% | 9226.8 ms | +0.25% |
