### PR TITLE
Remove deterministic features

### DIFF
--- a/circuits/Cargo.toml
+++ b/circuits/Cargo.toml
@@ -53,10 +53,7 @@ heap_profiling = []
 truncated-challenges = ["midnight-proofs/truncated-challenges"]
 # Enable development curves (BN256, Pasta)
 dev-curves = ["midnight-curves/dev-curves", "midnight-proofs/dev-curves"]
-# Enable deterministic proofs. This feature makes the prover deterministic, which breaks the
-# zero-knowledge property and may lead to completeness issues if circuits are chosen adversarially.
-# DO NOT enable this feature in production, only in tests that need to be reproducible.
-deterministic-prover = ["rand_chacha"]
+
 
 [lib]
 bench = false

--- a/circuits/src/ecc/foreign/weierstrass_chip.rs
+++ b/circuits/src/ecc/foreign/weierstrass_chip.rs
@@ -39,8 +39,7 @@ use rand::rngs::OsRng;
 #[cfg(any(test, feature = "testing"))]
 use {
     crate::testing_utils::Sampleable, crate::utils::util::FromScratch,
-    midnight_proofs::plonk::Instance,
-    rand::RngCore
+    midnight_proofs::plonk::Instance, rand::RngCore,
 };
 
 use super::gates::weierstrass::{

--- a/circuits/src/ecc/foreign/weierstrass_chip.rs
+++ b/circuits/src/ecc/foreign/weierstrass_chip.rs
@@ -35,15 +35,12 @@ use midnight_proofs::{
 };
 use num_bigint::BigUint;
 use num_traits::One;
-#[cfg(not(feature = "deterministic-prover"))]
 use rand::rngs::OsRng;
-use rand::RngCore;
-#[cfg(feature = "deterministic-prover")]
-use rand_chacha::{rand_core::SeedableRng, ChaCha20Rng};
 #[cfg(any(test, feature = "testing"))]
 use {
     crate::testing_utils::Sampleable, crate::utils::util::FromScratch,
     midnight_proofs::plonk::Instance,
+    rand::RngCore
 };
 
 use super::gates::weierstrass::{
@@ -988,9 +985,6 @@ where
         native_gadget: &N,
         scalar_field_chip: &S,
     ) -> Self {
-        #[cfg(feature = "deterministic-prover")]
-        let mut rng = ChaCha20Rng::seed_from_u64(0x5EEDAB1E);
-        #[cfg(not(feature = "deterministic-prover"))]
         let mut rng = OsRng;
         let random_point = C::random(&mut rng).into_subgroup();
 


### PR DESCRIPTION
The use of a HashMap cannot guarantee determinism of proof generation, meaning that the feature did not achieve its intended behaviour.