### PR TITLE
Refactor commitment labels and commitment references

### DIFF
--- a/aggregation/CHANGELOG.md
+++ b/aggregation/CHANGELOG.md
@@ -17,6 +17,7 @@ and this project adheres to [Semantic Versioning](https://book.async.rs/overview
 * Adapt to new `ZkStdLib` curve accessors [#335](https://github.com/midnightntwrk/midnight-zk/pull/335)
 * `IvcCircuit`'s `Relation::Error` is now `IvcError` instead of `plonk::Error` [#311](https://github.com/midnightntwrk/midnight-zk/pull/311)
 * `IvcVerifier` is now generic over `T: Ivc` and stores the context internally; `verify` no longer takes a `ctx` parameter [#302](https://github.com/midnightntwrk/midnight-zk/pull/302)
+* Adapt to new `KZGCommitment` API [#381](https://github.com/midnightntwrk/midnight-zk/pull/381)
 * Introduce `IvcIO` trait and `Ivc` convenience trait [#264](https://github.com/midnightntwrk/midnight-zk/pull/264)
 * Proof aggregation example [#258](https://github.com/midnightntwrk/midnight-zk/pull/258)
 * Introduce `IvcContext` [#258](https://github.com/midnightntwrk/midnight-zk/pull/258)

--- a/aggregation/examples/single_circuit_aggregation.rs
+++ b/aggregation/examples/single_circuit_aggregation.rs
@@ -33,8 +33,8 @@ use midnight_proofs::{
     circuit::{Layouter, Value},
     plonk::{self, ConstraintSystem, Error},
     poly::{
-        kzg::{params::ParamsVerifierKZG, KZGCommitmentScheme},
-        EvaluationDomain,
+        kzg::{commitment::KZGCommitment, params::ParamsVerifierKZG, KZGCommitmentScheme},
+        CommitmentLabel, EvaluationDomain,
     },
     transcript::{CircuitTranscript, Transcript},
 };
@@ -237,7 +237,10 @@ impl IvcTransition for ProofAggregation {
             let dual_msm =
                 plonk::prepare::<F, KZGCommitmentScheme<E>, CircuitTranscript<PoseidonState<F>>>(
                     ctx.vk.vk(),
-                    &[C::identity()],
+                    &[KZGCommitment::Simple(
+                        C::identity(),
+                        CommitmentLabel::NoLabel,
+                    )],
                     &[&statement_pis],
                     &mut transcript,
                 )

--- a/aggregation/src/ivc/prover.rs
+++ b/aggregation/src/ivc/prover.rs
@@ -15,7 +15,10 @@ use midnight_circuits::{
 };
 use midnight_proofs::{
     plonk::{self},
-    poly::kzg::{params::ParamsKZG, KZGCommitmentScheme},
+    poly::{
+        kzg::{commitment::KZGCommitment, params::ParamsKZG, KZGCommitmentScheme},
+        CommitmentLabel,
+    },
     transcript::{CircuitTranscript, Transcript},
 };
 use midnight_zk_stdlib::MidnightPK;
@@ -94,11 +97,16 @@ impl<T: Ivc> IvcProver<T> {
 
             let mut transcript =
                 CircuitTranscript::<PoseidonState<F>>::init_from_bytes(&self.proof);
-            let dual_msm = plonk::prepare::<
-                F,
-                KZGCommitmentScheme<E>,
-                CircuitTranscript<PoseidonState<F>>,
-            >(vk, &[C::identity()], &[&prev_pi], &mut transcript)?;
+            let dual_msm =
+                plonk::prepare::<F, KZGCommitmentScheme<E>, CircuitTranscript<PoseidonState<F>>>(
+                    vk,
+                    &[KZGCommitment::Simple(
+                        C::identity(),
+                        CommitmentLabel::NoLabel,
+                    )],
+                    &[&prev_pi],
+                    &mut transcript,
+                )?;
 
             if !dual_msm.clone().check(&self.params.verifier_params()) {
                 return Err(IvcError::InvalidProof);

--- a/aggregation/src/ivc/verifier.rs
+++ b/aggregation/src/ivc/verifier.rs
@@ -9,7 +9,10 @@ use group::Group;
 use midnight_circuits::{hash::poseidon::PoseidonState, verifier::Accumulator};
 use midnight_proofs::{
     plonk::{self},
-    poly::kzg::{params::ParamsVerifierKZG, KZGCommitmentScheme},
+    poly::{
+        kzg::{commitment::KZGCommitment, params::ParamsVerifierKZG, KZGCommitmentScheme},
+        CommitmentLabel,
+    },
     transcript::{CircuitTranscript, Transcript},
 };
 use midnight_zk_stdlib::{MidnightVK, Relation};
@@ -60,12 +63,17 @@ impl<T: Ivc> IvcVerifier<T> {
             IvcCircuit::<T>::format_instance(instance).map_err(|_| IvcError::InvalidInstance)?;
 
         let mut transcript = CircuitTranscript::<PoseidonState<F>>::init_from_bytes(proof);
-        let dual_msm = plonk::prepare::<
-            F,
-            KZGCommitmentScheme<E>,
-            CircuitTranscript<PoseidonState<F>>,
-        >(self.vk.vk(), &[C::identity()], &[&pi], &mut transcript)
-        .map_err(|_| IvcError::InvalidProof)?;
+        let dual_msm =
+            plonk::prepare::<F, KZGCommitmentScheme<E>, CircuitTranscript<PoseidonState<F>>>(
+                self.vk.vk(),
+                &[KZGCommitment::Simple(
+                    C::identity(),
+                    CommitmentLabel::NoLabel,
+                )],
+                &[&pi],
+                &mut transcript,
+            )
+            .map_err(|_| IvcError::InvalidProof)?;
 
         transcript.assert_empty().map_err(|_| IvcError::TranscriptNotEmpty)?;
 

--- a/aggregation/src/light_aggregator/mod.rs
+++ b/aggregation/src/light_aggregator/mod.rs
@@ -75,11 +75,12 @@ use midnight_proofs::{
     poly::{
         commitment::{Guard, Params},
         kzg::{
+            commitment::KZGCommitment,
             msm::{DualMSM, MSMKZG},
             params::{ParamsKZG, ParamsVerifierKZG},
             KZGCommitmentScheme,
         },
-        EvaluationDomain,
+        CommitmentLabel, EvaluationDomain,
     },
     transcript::{CircuitTranscript, Hashable, Sampleable, Transcript},
 };
@@ -316,7 +317,10 @@ impl<const NB_PROOFS: usize> LightAggregator<NB_PROOFS> {
                     CircuitTranscript<LightPoseidonFS<F>>,
                 >(
                     &self.inner_vk,
-                    &[C::identity()],
+                    &[KZGCommitment::Simple(
+                        C::identity(),
+                        CommitmentLabel::NoLabel,
+                    )],
                     &[proof_instances],
                     &mut inner_transcript,
                 )?;
@@ -400,7 +404,7 @@ impl<const NB_PROOFS: usize> LightAggregator<NB_PROOFS> {
             &bases1,
             &bases2,
             &acc_rhs_evaluated,
-            &acc_rhs_scalars_committed,
+            acc_rhs_scalars_committed.as_point(),
             transcript,
         )
     }
@@ -432,7 +436,7 @@ impl<const NB_PROOFS: usize> LightAggregator<NB_PROOFS> {
             let n: u32 = transcript.read()?;
             (0..n).map(|_| transcript.read()).collect::<Result<Vec<C>, io::Error>>()?
         };
-        let acc_rhs_scalars_committed: C = transcript.read()?;
+        let acc_rhs_scalars_committed: KZGCommitment<E> = transcript.read()?;
         let acc_rhs_evaluated: C = transcript.read()?;
 
         // Verify the proof of validity of the native verification of all inner proofs.
@@ -450,7 +454,7 @@ impl<const NB_PROOFS: usize> LightAggregator<NB_PROOFS> {
         let proof_dual_msm = {
             prepare::<F, KZGCommitmentScheme<E>, T>(
                 &self.aggregator_vk,
-                &[acc_rhs_scalars_committed],
+                std::slice::from_ref(&acc_rhs_scalars_committed),
                 &[&aggregator_instances],
                 transcript,
             )?
@@ -477,7 +481,7 @@ impl<const NB_PROOFS: usize> LightAggregator<NB_PROOFS> {
             &bases1,
             &bases2,
             &acc_rhs_evaluated,
-            &acc_rhs_scalars_committed,
+            acc_rhs_scalars_committed.as_point(),
             transcript,
         )?;
 
@@ -608,7 +612,10 @@ mod tests {
             let dual_msm =
                 prepare::<F, KZGCommitmentScheme<E>, CircuitTranscript<LightPoseidonFS<F>>>(
                     inner_vk.vk(),
-                    &[C::identity()],
+                    &[KZGCommitment::Simple(
+                        C::identity(),
+                        CommitmentLabel::NoLabel,
+                    )],
                     &[&InnerCircuit::format_instance(&instances[i]).unwrap()],
                     &mut transcript,
                 )

--- a/aggregation/src/multi_circuit_aggregator/circuit.rs
+++ b/aggregation/src/multi_circuit_aggregator/circuit.rs
@@ -27,8 +27,8 @@ use midnight_proofs::{
     circuit::{Layouter, Value},
     plonk::{self, ConstraintSystem, Error},
     poly::{
-        kzg::{params::ParamsVerifierKZG, KZGCommitmentScheme},
-        EvaluationDomain,
+        kzg::{commitment::KZGCommitment, params::ParamsVerifierKZG, KZGCommitmentScheme},
+        CommitmentLabel, EvaluationDomain,
     },
     transcript::{CircuitTranscript, Transcript},
     utils::SerdeFormat,
@@ -250,7 +250,10 @@ impl IvcTransition for ProofAggregation {
             let dual_msm =
                 plonk::prepare::<F, KZGCommitmentScheme<E>, CircuitTranscript<PoseidonState<F>>>(
                     witness.claim.vk.vk(),
-                    &[C::identity()],
+                    &[KZGCommitment::Simple(
+                        C::identity(),
+                        CommitmentLabel::NoLabel,
+                    )],
                     &[&[statement]],
                     &mut transcript,
                 )
@@ -321,7 +324,10 @@ impl IvcTransition for ProofAggregation {
                     CircuitTranscript<PoseidonState<F>>,
                 >(
                     w.claim.vk.vk(),
-                    &[C::identity()],
+                    &[KZGCommitment::Simple(
+                        C::identity(),
+                        CommitmentLabel::NoLabel,
+                    )],
                     &[&[w.claim.statement.format_instance()]],
                     &mut transcript,
                 )

--- a/aggregation/src/multi_circuit_aggregator/utils.rs
+++ b/aggregation/src/multi_circuit_aggregator/utils.rs
@@ -67,8 +67,11 @@ pub fn assign_and_hash_vk(
 
     // Witness the VK commitment points.
     let base_values: Vec<Value<C>> = (0..nb_fixed)
-        .map(|i| vk.map(|vk| vk.vk().fixed_commitments()[i]))
-        .chain((0..nb_perm).map(|i| vk.map(|vk| vk.vk().permutation().commitments()[i])))
+        .map(|i| vk.map(|vk| vk.vk().fixed_commitments()[i].clone().into_point()))
+        .chain(
+            (0..nb_perm)
+                .map(|i| vk.map(|vk| vk.vk().permutation().commitments()[i].clone().into_point())),
+        )
         .collect();
 
     let assigned_bases = base_values

--- a/circuits/CHANGELOG.md
+++ b/circuits/CHANGELOG.md
@@ -23,6 +23,7 @@ verification keys break backwards compatibility.
 * Make `NB_ARITH_COLS` configurable instead of a compile-time constant [#287](https://github.com/midnightntwrk/midnight-zk/pull/287)
 * Support `fewer-point-sets` feature in verifier gadget [#281](https://github.com/midnightntwrk/midnight-zk/pull/281)
 * `multi_prepare` now takes a slice instead of `IntoIterator` [#281](https://github.com/midnightntwrk/midnight-zk/pull/281)
+* Adapt verifier gadget to new `KZGCommitment` API [#381](https://github.com/midnightntwrk/midnight-zk/pull/381)
 * Support `single-h-commitment` feature in verifier gadget [#276](https://github.com/midnightntwrk/midnight-zk/pull/276)
 * Filter out compile-time identity points in MSM [#256](https://github.com/midnightntwrk/midnight-zk/pull/256)
 * Sort point sets deterministically in KZG multiopen for in-circuit verification [#256](https://github.com/midnightntwrk/midnight-zk/pull/256)

--- a/circuits/src/verifier/kzg.rs
+++ b/circuits/src/verifier/kzg.rs
@@ -27,7 +27,7 @@ use std::{
 };
 
 use ff::Field;
-use midnight_proofs::{circuit::Layouter, plonk::Error, poly::CommitmentLabel};
+use midnight_proofs::{circuit::Layouter, plonk::Error};
 
 #[cfg(feature = "truncated-challenges")]
 use crate::verifier::utils::truncate;
@@ -196,8 +196,6 @@ fn construct_intermediate_sets<S: SelfEmulation>(
 pub(crate) struct VerifierQuery<S: SelfEmulation> {
     /// Point at which polynomial is queried.
     point: AssignedNative<S::F>,
-    /// Optional label identifying the commitment in this query.
-    label: CommitmentLabel,
     /// Commitment to the polynomial.
     commitment: AssignedMsm<S>,
     /// Evaluation of polynomial at query point.
@@ -210,13 +208,11 @@ impl<S: SelfEmulation> VerifierQuery<S> {
     pub(crate) fn new(
         one: &AssignedBoundedScalar<S::F>,
         point: &AssignedNative<S::F>,
-        label: CommitmentLabel,
         commitment: &S::AssignedPoint,
         eval: &AssignedNative<S::F>,
     ) -> Self {
         Self {
             point: point.clone(),
-            label,
             commitment: AssignedMsm::from_term(one, commitment),
             eval: eval.clone(),
         }
@@ -225,13 +221,11 @@ impl<S: SelfEmulation> VerifierQuery<S> {
     /// Create a verifier query on a commitment (represented as an MSM).
     pub(crate) fn new_from_msm(
         point: &AssignedNative<S::F>,
-        label: CommitmentLabel,
         commitment: &AssignedMsm<S>,
         eval: &AssignedNative<S::F>,
     ) -> Self {
         Self {
             point: point.clone(),
-            label,
             commitment: commitment.clone(),
             eval: eval.clone(),
         }
@@ -242,13 +236,11 @@ impl<S: SelfEmulation> VerifierQuery<S> {
     pub(crate) fn new_fixed(
         one: &AssignedBoundedScalar<S::F>,
         point: &AssignedNative<S::F>,
-        label: CommitmentLabel,
         commitment_name: &str,
         eval: &AssignedNative<S::F>,
     ) -> Self {
         Self {
             point: point.clone(),
-            label,
             commitment: AssignedMsm::from_fixed_term(one, commitment_name),
             eval: eval.clone(),
         }
@@ -264,14 +256,6 @@ impl<S: SelfEmulation> VerifierQuery<S> {
 
     fn get_commitment(&self) -> AssignedMsm<S> {
         self.commitment.clone()
-    }
-
-    #[allow(dead_code)]
-    // Neither this function nor the commitment labels on verifier
-    // queries are currently needed, but we keep them for consistency
-    // with the `proofs/` implementation and for potential future use.
-    fn get_label(&self) -> &CommitmentLabel {
-        &self.label
     }
 }
 
@@ -338,7 +322,6 @@ pub(crate) fn multi_prepare<S: SelfEmulation>(
         for (idx, point) in dummy_openings {
             queries.push(VerifierQuery {
                 point,
-                label: queries[idx].label.clone(),
                 commitment: queries[idx].commitment.clone(),
                 eval: transcript_gadget.read_scalar(layouter)?,
             });

--- a/circuits/src/verifier/lookup.rs
+++ b/circuits/src/verifier/lookup.rs
@@ -16,7 +16,7 @@
 //! This is the in-circuit analog of `proofs/src/plonk/logup/verifier.rs`.
 //! The constraint expressions are implemented in `expressions/lookup.rs`.
 
-use midnight_proofs::{circuit::Layouter, plonk::Error, poly::CommitmentLabel};
+use midnight_proofs::{circuit::Layouter, plonk::Error};
 
 use crate::{
     field::AssignedNative,
@@ -125,7 +125,6 @@ impl<S: SelfEmulation> Evaluated<S> {
             VerifierQuery::new(
                 one,
                 x,
-                CommitmentLabel::NoLabel,
                 &self.committed.multiplicities,
                 &self.evaluated.multiplicities_eval,
             ),
@@ -134,19 +133,12 @@ impl<S: SelfEmulation> Evaluated<S> {
         for (h_commit, h_eval) in
             self.committed.helper_polys.iter().zip(self.evaluated.helper_evals.iter())
         {
-            queries.push(VerifierQuery::new(
-                one,
-                x,
-                CommitmentLabel::NoLabel,
-                h_commit,
-                h_eval,
-            ));
+            queries.push(VerifierQuery::new(one, x, h_commit, h_eval));
         }
         // Open lookup table commitments at x
         queries.push(VerifierQuery::new(
             one,
             x,
-            CommitmentLabel::NoLabel,
             &self.committed.accumulator,
             &self.evaluated.accumulator_eval,
         ));
@@ -154,7 +146,6 @@ impl<S: SelfEmulation> Evaluated<S> {
         queries.push(VerifierQuery::new(
             one,
             x_next,
-            CommitmentLabel::NoLabel,
             &self.committed.accumulator,
             &self.evaluated.accumulator_next_eval,
         ));

--- a/circuits/src/verifier/mod.rs
+++ b/circuits/src/verifier/mod.rs
@@ -122,11 +122,11 @@ pub fn fixed_bases<S: SelfEmulation>(
     let perm_commitments = vk.permutation().commitments();
 
     for (i, com) in fixed_commitments.iter().enumerate() {
-        fixed_bases.insert(fixed_commitment_name(vk_name, i), *com);
+        fixed_bases.insert(fixed_commitment_name(vk_name, i), *com.as_point());
     }
 
     for (i, com) in perm_commitments.iter().enumerate() {
-        fixed_bases.insert(perm_commitment_name(vk_name, i), *com);
+        fixed_bases.insert(perm_commitment_name(vk_name, i), *com.as_point());
     }
 
     fixed_bases

--- a/circuits/src/verifier/permutation.rs
+++ b/circuits/src/verifier/permutation.rs
@@ -19,7 +19,6 @@
 use midnight_proofs::{
     circuit::Layouter,
     plonk::{ConstraintSystem, Error},
-    poly::CommitmentLabel,
 };
 
 use crate::{
@@ -135,14 +134,12 @@ impl<S: SelfEmulation> Evaluated<S> {
             queries.push(VerifierQuery::new(
                 one,
                 x,
-                CommitmentLabel::NoLabel,
                 &self.coms.permutation_product_commitments[i],
                 &set.permutation_product_eval,
             ));
             queries.push(VerifierQuery::new(
                 one,
                 x_next,
-                CommitmentLabel::NoLabel,
                 &self.coms.permutation_product_commitments[i],
                 &set.permutation_product_next_eval,
             ));
@@ -153,7 +150,6 @@ impl<S: SelfEmulation> Evaluated<S> {
             queries.push(VerifierQuery::new(
                 one,
                 x_last,
-                CommitmentLabel::NoLabel,
                 &self.coms.permutation_product_commitments[i],
                 set.permutation_product_last_eval.as_ref().unwrap(),
             ));
@@ -177,11 +173,8 @@ impl<S: SelfEmulation> CommonEvaluated<S> {
 
         commitment_names
             .iter()
-            .enumerate()
             .zip(self.permutation_evals.iter())
-            .map(|((i, com_name), eval)| {
-                VerifierQuery::new_fixed(one, x, CommitmentLabel::Permutation(i), com_name, eval)
-            })
+            .map(|(com_name, eval)| VerifierQuery::new_fixed(one, x, com_name, eval))
             .collect()
     }
 }

--- a/circuits/src/verifier/trash.rs
+++ b/circuits/src/verifier/trash.rs
@@ -16,7 +16,7 @@
 //!
 //! The "expressions" part is dealt with in our `expressions/` directory.
 
-use midnight_proofs::{circuit::Layouter, plonk::Error, poly::CommitmentLabel};
+use midnight_proofs::{circuit::Layouter, plonk::Error};
 
 use crate::{
     field::AssignedNative,
@@ -77,7 +77,6 @@ impl<S: SelfEmulation> Evaluated<S> {
         vec![VerifierQuery::new(
             one,
             x,
-            CommitmentLabel::NoLabel,
             &self.committed.trash_commitment,
             &self.evaluated.trash_eval,
         )]

--- a/circuits/src/verifier/verifier_gadget.rs
+++ b/circuits/src/verifier/verifier_gadget.rs
@@ -21,7 +21,7 @@ use ff::Field;
 use midnight_proofs::{
     circuit::{AssignedCell, Chip, Layouter, Value},
     plonk::{ConstraintSystem, Error},
-    poly::{CommitmentLabel, EvaluationDomain, Rotation},
+    poly::{EvaluationDomain, Rotation},
 };
 use num_bigint::BigUint;
 use num_traits::One;
@@ -764,7 +764,6 @@ impl<S: SelfEmulation> VerifierGadget<S> {
                     VerifierQuery::<S>::new(
                         &one,
                         get_point(&rot),
-                        CommitmentLabel::Advice(column.index()),
                         &advice_commitments[column.index()],
                         &advice_evals[query_index],
                     )
@@ -776,7 +775,6 @@ impl<S: SelfEmulation> VerifierGadget<S> {
                         Some(VerifierQuery::<S>::new(
                             &one,
                             get_point(&rot),
-                            CommitmentLabel::Instance(column.index()),
                             &assigned_committed_instances[column.index()],
                             &instance_evals[query_index],
                         ))
@@ -797,7 +795,6 @@ impl<S: SelfEmulation> VerifierGadget<S> {
                         VerifierQuery::new_fixed(
                             &one,
                             get_point(&rot),
-                            CommitmentLabel::Fixed(col.index()),
                             &assigned_vk.fixed_commitment_name(col.index()),
                             &fixed_evals[query_index],
                         )
@@ -814,7 +811,6 @@ impl<S: SelfEmulation> VerifierGadget<S> {
             )
             .chain(iter::once(VerifierQuery::new_from_msm(
                 &x,
-                CommitmentLabel::Custom("linearization_poly".into()),
                 &linearization_com,
                 &expected_lin_eval,
             )));
@@ -877,7 +873,10 @@ pub(crate) mod tests {
         circuit::SimpleFloorPlanner,
         dev::MockProver,
         plonk::{create_proof, keygen_pk, keygen_vk_with_k, prepare, Circuit, Error},
-        poly::kzg::{commitment::KZGCommitment, params::ParamsKZG, KZGCommitmentScheme},
+        poly::{
+            kzg::{commitment::KZGCommitment, params::ParamsKZG, KZGCommitmentScheme},
+            CommitmentLabel,
+        },
         transcript::{CircuitTranscript, Transcript},
     };
     use rand::SeedableRng;
@@ -1144,7 +1143,10 @@ pub(crate) mod tests {
                 CircuitTranscript::<PoseidonState<F>>::init_from_bytes(&inner_proof);
             prepare::<F, KZGCommitmentScheme<E>, CircuitTranscript<PoseidonState<F>>>(
                 &inner_vk,
-                &[KZGCommitment::Simple(C::identity(), CommitmentLabel::NoLabel)],
+                &[KZGCommitment::Simple(
+                    C::identity(),
+                    CommitmentLabel::NoLabel,
+                )],
                 &[&inner_public_inputs],
                 &mut transcript,
             )

--- a/circuits/src/verifier/verifier_gadget.rs
+++ b/circuits/src/verifier/verifier_gadget.rs
@@ -877,7 +877,7 @@ pub(crate) mod tests {
         circuit::SimpleFloorPlanner,
         dev::MockProver,
         plonk::{create_proof, keygen_pk, keygen_vk_with_k, prepare, Circuit, Error},
-        poly::kzg::{params::ParamsKZG, KZGCommitmentScheme},
+        poly::kzg::{commitment::KZGCommitment, params::ParamsKZG, KZGCommitmentScheme},
         transcript::{CircuitTranscript, Transcript},
     };
     use rand::SeedableRng;
@@ -1144,7 +1144,7 @@ pub(crate) mod tests {
                 CircuitTranscript::<PoseidonState<F>>::init_from_bytes(&inner_proof);
             prepare::<F, KZGCommitmentScheme<E>, CircuitTranscript<PoseidonState<F>>>(
                 &inner_vk,
-                &[C::identity()],
+                &[KZGCommitment::Simple(C::identity(), CommitmentLabel::NoLabel)],
                 &[&inner_public_inputs],
                 &mut transcript,
             )

--- a/curves/src/fft.rs
+++ b/curves/src/fft.rs
@@ -185,8 +185,8 @@ fn recursive_dif_pruned(a: &mut [Fq], n: usize, tc: usize, tw: &[Fq], nz: usize)
     );
 }
 
-/// In-place Gentleman-Sande butterfly on `a[i]` and `a[j]` with twiddle `t`:
-/// (a[i], a[j]) ← (a[i] + a[j], (a[i] - a[j])·t).
+/// In-place Gentleman-Sande butterfly on `a\[i\]` and `a\[j\]` with twiddle `t`:
+/// (a\[i\], a\[j\]) ← (a\[i\] + a\[j\], (a\[i\] - a\[j\])·t).
 #[inline(always)]
 fn gs(a: &mut [Fq], i: usize, j: usize, t: &Fq) {
     // SAFETY: i != j and both in bounds — callers always supply i = k, j = k + h

--- a/curves/src/fft.rs
+++ b/curves/src/fft.rs
@@ -185,8 +185,8 @@ fn recursive_dif_pruned(a: &mut [Fq], n: usize, tc: usize, tw: &[Fq], nz: usize)
     );
 }
 
-/// In-place Gentleman-Sande butterfly on `a\[i\]` and `a\[j\]` with twiddle `t`:
-/// (a\[i\], a\[j\]) ← (a\[i\] + a\[j\], (a\[i\] - a\[j\])·t).
+/// In-place Gentleman-Sande butterfly on `a\[i\]` and `a\[j\]` with twiddle
+/// `t`: (a\[i\], a\[j\]) ← (a\[i\] + a\[j\], (a\[i\] - a\[j\])·t).
 #[inline(always)]
 fn gs(a: &mut [Fq], i: usize, j: usize, t: &Fq) {
     // SAFETY: i != j and both in bounds — callers always supply i = k, j = k + h

--- a/proofs/CHANGELOG.md
+++ b/proofs/CHANGELOG.md
@@ -22,6 +22,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * Blind logup multiplicities polynomial on non-usable rows for ZK [#312](https://github.com/midnightntwrk/midnight-zk/pull/312)
 
 ### Changed
+* Introduce `KZGCommitment` enum with `Simple` and `Linear` variants; attach `CommitmentLabel` at `commit` time and propagate it homomorphically through arithmetic [#381](https://github.com/midnightntwrk/midnight-zk/pull/381)
+* Simplify `CommitmentReference` to a pointer wrapper with identity-based equality; remove `commitment_label` from `VerifierQuery` [#381](https://github.com/midnightntwrk/midnight-zk/pull/381)
 * Store SRS as affine and use an affine MSM path in KZG [#350](https://github.com/midnightntwrk/midnight-zk/pull/350)
 * Cache twiddle factors in `EvaluationDomain` and use a pruned DIF FFT for `coeff_to_extended` [#352](https://github.com/midnightntwrk/midnight-zk/pull/352)
 * Flatten and batch the graph evaluator for custom gates, lookups, and trash [#351](https://github.com/midnightntwrk/midnight-zk/pull/351)

--- a/proofs/benches/zswap_output.rs
+++ b/proofs/benches/zswap_output.rs
@@ -24,7 +24,8 @@ use midnight_proofs::{
     },
     poly::{
         commitment::Guard,
-        kzg::{params::ParamsKZG, KZGCommitmentScheme},
+        kzg::{commitment::KZGCommitment, params::ParamsKZG, KZGCommitmentScheme},
+        CommitmentLabel,
     },
     transcript::{CircuitTranscript, Transcript},
 };
@@ -282,7 +283,18 @@ fn bench_zswap_output(c: &mut Criterion) {
     group.bench_function("Parse trace", |b| {
         b.iter_batched(
             || transcript.clone(),
-            |mut t| parse_trace(pk.get_vk(), &[C::identity()], &[&instance], &mut t).unwrap(),
+            |mut t| {
+                parse_trace(
+                    pk.get_vk(),
+                    &[KZGCommitment::Simple(
+                        C::identity(),
+                        CommitmentLabel::NoLabel,
+                    )],
+                    &[&instance],
+                    &mut t,
+                )
+                .unwrap()
+            },
             BatchSize::SmallInput,
         )
     });
@@ -292,7 +304,16 @@ fn bench_zswap_output(c: &mut Criterion) {
             || {
                 let mut t = transcript.clone();
                 (
-                    parse_trace(pk.get_vk(), &[C::identity()], &[&instance], &mut t).unwrap(),
+                    parse_trace(
+                        pk.get_vk(),
+                        &[KZGCommitment::Simple(
+                            C::identity(),
+                            CommitmentLabel::NoLabel,
+                        )],
+                        &[&instance],
+                        &mut t,
+                    )
+                    .unwrap(),
                     t,
                 )
             },
@@ -300,7 +321,10 @@ fn bench_zswap_output(c: &mut Criterion) {
                 verify_algebraic_constraints(
                     pk.get_vk(),
                     trace,
-                    &[C::identity()],
+                    &[KZGCommitment::Simple(
+                        C::identity(),
+                        CommitmentLabel::NoLabel,
+                    )],
                     &[&instance],
                     &mut t,
                 )
@@ -313,12 +337,23 @@ fn bench_zswap_output(c: &mut Criterion) {
         b.iter_batched(
             || {
                 let mut t = transcript.clone();
-                let trace =
-                    parse_trace(pk.get_vk(), &[C::identity()], &[&instance], &mut t).unwrap();
+                let trace = parse_trace(
+                    pk.get_vk(),
+                    &[KZGCommitment::Simple(
+                        C::identity(),
+                        CommitmentLabel::NoLabel,
+                    )],
+                    &[&instance],
+                    &mut t,
+                )
+                .unwrap();
                 let guard = verify_algebraic_constraints(
                     pk.get_vk(),
                     trace,
-                    &[C::identity()],
+                    &[KZGCommitment::Simple(
+                        C::identity(),
+                        CommitmentLabel::NoLabel,
+                    )],
                     &[&instance],
                     &mut t,
                 )

--- a/proofs/src/plonk/bench/prover.rs
+++ b/proofs/src/plonk/bench/prover.rs
@@ -21,7 +21,7 @@ use crate::{
         traces::ProverTrace,
         trash, Error, ProvingKey,
     },
-    poly::commitment::PolynomialCommitmentScheme,
+    poly::{commitment::PolynomialCommitmentScheme, CommitmentLabel},
     transcript::{Hashable, Sampleable, Transcript},
     utils::arithmetic::eval_polynomial,
 };
@@ -282,7 +282,7 @@ where
                                 .par_iter()
                                 .map(|h| {
                                     let h_poly = domain.lagrange_from_vec(h.clone());
-                                    CS::commit(params, &h_poly)
+                                    CS::commit(params, &h_poly, CommitmentLabel::NoLabel)
                                 })
                                 .collect()
                         })
@@ -312,7 +312,7 @@ where
                     .par_iter()
                     .map(|h| {
                         let h_poly = domain.lagrange_from_vec(h.clone());
-                        CS::commit(params, &h_poly)
+                        CS::commit(params, &h_poly, CommitmentLabel::NoLabel)
                     })
                     .collect()
             })

--- a/proofs/src/plonk/keygen.rs
+++ b/proofs/src/plonk/keygen.rs
@@ -19,7 +19,7 @@ use crate::{
     poly::{
         batch_invert_rational,
         commitment::{Params, PolynomialCommitmentScheme},
-        EvaluationDomain, ExtendedLagrangeCoeff,
+        CommitmentLabel, EvaluationDomain, ExtendedLagrangeCoeff,
     },
     utils::{arithmetic::parallelize, rational::Rational},
 };
@@ -276,7 +276,11 @@ where
 
     let permutation_vk = assembly.permutation.build_vk(params, &domain, &cs.permutation);
 
-    let fixed_commitments = fixed.iter().map(|poly| CS::commit(params, poly)).collect();
+    let fixed_commitments = fixed
+        .iter()
+        .enumerate()
+        .map(|(i, poly)| CS::commit(params, poly, CommitmentLabel::Fixed(i)))
+        .collect();
 
     Ok(VerifyingKey::from_parts(
         domain,

--- a/proofs/src/plonk/linearization/verifier.rs
+++ b/proofs/src/plonk/linearization/verifier.rs
@@ -2,14 +2,12 @@ use std::collections::BTreeMap;
 
 use ff::PrimeField;
 
-use crate::{
-    plonk::VerifyingKey,
-    poly::{commitment::PolynomialCommitmentScheme, CommitmentLabel, VerifierQuery},
-};
+use crate::{plonk::VerifyingKey, poly::commitment::PolynomialCommitmentScheme};
 
-/// Construct the commitment to the linearization polynomial
-/// (which will be checked that it opens to `0` at `x` in the multi-open
-/// argument):
+/// Construct the commitment to the linearization polynomial and its expected
+/// evaluation at `x`.
+///
+/// The commitment is:
 ///
 ///  `S_0 * id_0(x) + y * S_1 * id_1(x) + ... + y^m * S_m * id_m(x)
 ///        - (h_0 + x^{n-1} * h_1 + ... + x^{l*(n-1)} * h_l) * (x^n-1),`
@@ -18,58 +16,35 @@ use crate::{
 /// * `y` is the batching challenge,
 /// * `x` is the evaluation challenge,
 /// * `id_j(x)` is a (partially or fully) evaluated identity at `x`,
-/// * `S_j` is, either,
-///      - (i)  the commitment to a fixed column representing a simple,
-///        multiplicative selector, or,
-///      - (ii) the commitment to the constant polynomial `P(X) = 1` (in case
-///        the corresponding identity `id_j` has been fully evaluated and, thus,
-///        the resulting scalar is part of the constant term of the
-///        linearization polynomial)
+/// * `S_j` is either the commitment to a simple selector column or the
+///   commitment to `P(X) = 1` (for fully evaluated identities),
 /// * `h_k` are commitments to the limbs of the quotient polynomial.
-///
-/// # Arguments
-///
-/// * `expressions` - the output of
-///   [crate::plonk::partially_evaluate_identities]
-/// * `splitting_factor` - the evaluated splitting factor `x^{n-1}` from
-///   decomposing the quotient polynomial `h(T)` into limbs
 ///
 /// # Returns
 ///
-/// A [VerifierQuery], that checks if the commitment to the linearization
-/// polynomial opens to `0` at the evaluation challenge `x`. The commitment
-/// itself is an MSM represented as a vector of points and a vector
-/// of scalars.
-#[allow(clippy::type_complexity)]
+/// `(commitment, expected_eval)` where the commitment to the linearization
+/// polynomial is expected to open to `expected_eval` at `x`.
 #[allow(clippy::too_many_arguments)]
 pub(crate) fn compute_linearization_commitment<
-    'com,
     F: PrimeField + ff::WithSmallOrderMulGroup<3> + ff::FromUniformBytes<64> + std::cmp::Ord,
     CS: PolynomialCommitmentScheme<F>,
 >(
     expressions: Vec<(Option<usize>, F)>,
-    vk: &'com VerifyingKey<F, CS>,
-    x: F,
+    vk: &VerifyingKey<F, CS>,
     y: &F,
     xn: &F,
     splitting_factor: &F,
-    quotient_limb_commitments: &'com [CS::Commitment],
-) -> VerifierQuery<'com, F, CS> {
-    let lin_com_len = vk.cs.num_simple_selectors() + quotient_limb_commitments.len() + 1;
-    let mut identities_points = Vec::with_capacity(lin_com_len);
-    let mut identities_scalars = Vec::with_capacity(lin_com_len);
-    let mut identities_labels = Vec::with_capacity(lin_com_len);
-
-    identities_points.extend(quotient_limb_commitments);
+    quotient_limb_commitments: &[CS::Commitment],
+) -> (CS::Commitment, F) {
+    let mut terms: Vec<(F, CS::Commitment)> = Vec::new();
 
     let mut splitting_pow = F::ONE - *xn;
-    for _ in 0..quotient_limb_commitments.len() {
-        identities_scalars.push(splitting_pow);
-        identities_labels.push(CommitmentLabel::NoLabel);
+    for com in quotient_limb_commitments {
+        terms.push((splitting_pow, com.clone()));
         splitting_pow *= splitting_factor;
     }
 
-    // Group multiples of the same point in the MSM
+    // Group multiples of the same fixed column in the MSM
     let mut grouped_points: BTreeMap<Option<usize>, F> = BTreeMap::new();
     let mut y_pow = F::ONE;
     expressions.iter().rev().for_each(|(col_idx, eval)| {
@@ -78,27 +53,16 @@ pub(crate) fn compute_linearization_commitment<
     });
 
     let mut expected_eval = F::ZERO;
-    grouped_points.into_iter().for_each(|(col_idx, eval)| {
-        match col_idx {
-            Some(col_idx) => {
-                identities_points.push(&vk.fixed_commitments[col_idx]);
-                identities_labels.push(CommitmentLabel::Fixed(col_idx));
-                identities_scalars.push(eval);
-            }
-            // Fully evaluated identities are not included and pass (negated)
-            // to the evaluation side.
-            None => {
-                expected_eval -= eval;
-            }
-        }
+    grouped_points.into_iter().for_each(|(col_idx, eval)| match col_idx {
+        Some(col_idx) => terms.push((eval, vk.fixed_commitments[col_idx].clone())),
+        None => expected_eval -= eval,
     });
 
-    VerifierQuery::new_linear(
-        x,
-        CommitmentLabel::Custom("linearization_poly".into()),
-        identities_points,
-        identities_scalars,
-        identities_labels,
-        expected_eval,
-    )
+    let commitment = terms
+        .into_iter()
+        .map(|(scalar, com)| com * scalar)
+        .reduce(|acc, term| acc + term)
+        .unwrap_or_default();
+
+    (commitment, expected_eval)
 }

--- a/proofs/src/plonk/linearization/verifier.rs
+++ b/proofs/src/plonk/linearization/verifier.rs
@@ -35,16 +35,10 @@ pub(crate) fn compute_linearization_commitment<
     splitting_factor: &F,
     quotient_limb_commitments: &[CS::Commitment],
 ) -> (CS::Commitment, F) {
-    let mut commitment = CS::Commitment::default();
     let mut expected_eval = F::ZERO;
 
-    let mut splitting_pow = F::ONE - *xn;
-    for com in quotient_limb_commitments {
-        commitment = commitment + com.clone() * splitting_pow;
-        splitting_pow *= splitting_factor;
-    }
-
-    // Group multiples of the same fixed column to reduce the number of scalar multiplications
+    // Group multiples of the same fixed column to reduce the number of scalar
+    // multiplications
     let mut grouped_points: BTreeMap<Option<usize>, F> = BTreeMap::new();
     let mut y_pow = F::ONE;
     for (col_idx, eval) in expressions.iter().rev() {
@@ -52,12 +46,33 @@ pub(crate) fn compute_linearization_commitment<
         y_pow *= y;
     }
 
-    for (col_idx, eval) in grouped_points {
-        match col_idx {
-            Some(idx) => commitment = commitment + vk.fixed_commitments[idx].clone() * eval,
-            None => expected_eval -= eval,
-        }
-    }
+    let mut splitting_pow = F::ONE - *xn;
+    let (first_com, rest_coms) = quotient_limb_commitments
+        .split_first()
+        .expect("at least one quotient limb commitment");
+
+    let init = {
+        let term = first_com.clone() * splitting_pow;
+        splitting_pow *= splitting_factor;
+        term
+    };
+
+    let commitment = rest_coms.iter().fold(init, |acc, com| {
+        let term = com.clone() * splitting_pow;
+        splitting_pow *= splitting_factor;
+        acc + term
+    });
+
+    let commitment =
+        grouped_points
+            .into_iter()
+            .fold(commitment, |acc, (col_idx, eval)| match col_idx {
+                Some(idx) => acc + vk.fixed_commitments[idx].clone() * eval,
+                None => {
+                    expected_eval -= eval;
+                    acc
+                }
+            });
 
     (commitment, expected_eval)
 }

--- a/proofs/src/plonk/linearization/verifier.rs
+++ b/proofs/src/plonk/linearization/verifier.rs
@@ -24,7 +24,6 @@ use crate::{plonk::VerifyingKey, poly::commitment::PolynomialCommitmentScheme};
 ///
 /// `(commitment, expected_eval)` where the commitment to the linearization
 /// polynomial is expected to open to `expected_eval` at `x`.
-#[allow(clippy::too_many_arguments)]
 pub(crate) fn compute_linearization_commitment<
     F: PrimeField + ff::WithSmallOrderMulGroup<3> + ff::FromUniformBytes<64> + std::cmp::Ord,
     CS: PolynomialCommitmentScheme<F>,
@@ -36,33 +35,29 @@ pub(crate) fn compute_linearization_commitment<
     splitting_factor: &F,
     quotient_limb_commitments: &[CS::Commitment],
 ) -> (CS::Commitment, F) {
-    let mut terms: Vec<(F, CS::Commitment)> = Vec::new();
+    let mut commitment = CS::Commitment::default();
+    let mut expected_eval = F::ZERO;
 
     let mut splitting_pow = F::ONE - *xn;
     for com in quotient_limb_commitments {
-        terms.push((splitting_pow, com.clone()));
+        commitment = commitment + com.clone() * splitting_pow;
         splitting_pow *= splitting_factor;
     }
 
-    // Group multiples of the same fixed column in the MSM
+    // Group multiples of the same fixed column to reduce the number of scalar multiplications
     let mut grouped_points: BTreeMap<Option<usize>, F> = BTreeMap::new();
     let mut y_pow = F::ONE;
-    expressions.iter().rev().for_each(|(col_idx, eval)| {
+    for (col_idx, eval) in expressions.iter().rev() {
         *grouped_points.entry(*col_idx).or_insert(F::ZERO) += y_pow * eval;
         y_pow *= y;
-    });
+    }
 
-    let mut expected_eval = F::ZERO;
-    grouped_points.into_iter().for_each(|(col_idx, eval)| match col_idx {
-        Some(col_idx) => terms.push((eval, vk.fixed_commitments[col_idx].clone())),
-        None => expected_eval -= eval,
-    });
-
-    let commitment = terms
-        .into_iter()
-        .map(|(scalar, com)| com * scalar)
-        .reduce(|acc, term| acc + term)
-        .unwrap_or_default();
+    for (col_idx, eval) in grouped_points {
+        match col_idx {
+            Some(idx) => commitment = commitment + vk.fixed_commitments[idx].clone() * eval,
+            None => expected_eval -= eval,
+        }
+    }
 
     (commitment, expected_eval)
 }

--- a/proofs/src/plonk/logup/prover.rs
+++ b/proofs/src/plonk/logup/prover.rs
@@ -287,7 +287,11 @@ impl<F: WithSmallOrderMulGroup<3> + Hash> ComputedMultiplicities<F> {
         // multiplicities m are highly contiguous and tables are zero-padded)
         // the aggregator is locally *linear*. Δ² converts them in zero runs,
         // which will be filtered out.
-        let aggregator_commitment = CS::commit(params, &aggregator_poly.to_double_delta(), CommitmentLabel::NoLabel);
+        let aggregator_commitment = CS::commit(
+            params,
+            &aggregator_poly.to_double_delta(),
+            CommitmentLabel::NoLabel,
+        );
 
         Ok(ComputedLogderivative {
             multiplicities: self.multiplicities,

--- a/proofs/src/plonk/logup/prover.rs
+++ b/proofs/src/plonk/logup/prover.rs
@@ -32,8 +32,8 @@ use crate::{
         Error, Expression, ProvingKey,
     },
     poly::{
-        commitment::PolynomialCommitmentScheme, Coeff, LagrangeCoeff, Polynomial, ProverQuery,
-        Rotation,
+        commitment::PolynomialCommitmentScheme, Coeff, CommitmentLabel, LagrangeCoeff, Polynomial,
+        ProverQuery, Rotation,
     },
     transcript::{Hashable, Transcript},
     utils::arithmetic::{eval_polynomial, parallelize},
@@ -161,7 +161,7 @@ impl<F: WithSmallOrderMulGroup<3> + Hash> ChunkedArgument<F> {
         // The Lagrange form is needed downstream for `eval_polynomial` and the
         // openings, so we borrow into a transient delta buffer rather than
         // transforming in place and prefix-summing back.
-        let commitment = CS::commit(params, &multiplicities.to_delta());
+        let commitment = CS::commit(params, &multiplicities.to_delta(), CommitmentLabel::NoLabel);
 
         Ok((
             ComputedMultiplicities {
@@ -287,7 +287,7 @@ impl<F: WithSmallOrderMulGroup<3> + Hash> ComputedMultiplicities<F> {
         // multiplicities m are highly contiguous and tables are zero-padded)
         // the aggregator is locally *linear*. Δ² converts them in zero runs,
         // which will be filtered out.
-        let aggregator_commitment = CS::commit(params, &aggregator_poly.to_double_delta());
+        let aggregator_commitment = CS::commit(params, &aggregator_poly.to_double_delta(), CommitmentLabel::NoLabel);
 
         Ok(ComputedLogderivative {
             multiplicities: self.multiplicities,

--- a/proofs/src/plonk/logup/verifier.rs
+++ b/proofs/src/plonk/logup/verifier.rs
@@ -22,7 +22,7 @@ use crate::{
         logup::{self, ChunkedArgument},
         Error, VerifyingKey,
     },
-    poly::{commitment::PolynomialCommitmentScheme, CommitmentLabel, Rotation, VerifierQuery},
+    poly::{commitment::PolynomialCommitmentScheme, Rotation, VerifierQuery},
     transcript::{Hashable, Transcript},
 };
 
@@ -130,7 +130,6 @@ impl<F: WithSmallOrderMulGroup<3>, CS: PolynomialCommitmentScheme<F>> Evaluated<
 
         let m_query = iter::once(VerifierQuery::new(
             x,
-            CommitmentLabel::NoLabel,
             &self.committed.multiplicities,
             self.evaluated.multiplicities_eval,
         ));
@@ -140,19 +139,17 @@ impl<F: WithSmallOrderMulGroup<3>, CS: PolynomialCommitmentScheme<F>> Evaluated<
             .helper_polys
             .iter()
             .zip(self.evaluated.helper_evals.iter())
-            .map(move |(com, &eval)| VerifierQuery::new(x, CommitmentLabel::NoLabel, com, eval))
+            .map(move |(com, &eval)| VerifierQuery::new(x, com, eval))
             .collect::<Vec<_>>();
 
         let z_queries = [
             VerifierQuery::new(
                 x,
-                CommitmentLabel::NoLabel,
                 &self.committed.accumulator,
                 self.evaluated.accumulator_eval,
             ),
             VerifierQuery::new(
                 x_next,
-                CommitmentLabel::NoLabel,
                 &self.committed.accumulator,
                 self.evaluated.accumulator_next_eval,
             ),

--- a/proofs/src/plonk/mod.rs
+++ b/proofs/src/plonk/mod.rs
@@ -17,7 +17,7 @@ use crate::{
     transcript::{Hashable, Transcript},
     utils::{
         helpers::{
-            byte_length, polynomial_slice_byte_length, read_polynomial_vec, write_polynomial_slice,
+            polynomial_slice_byte_length, read_polynomial_vec, write_polynomial_slice,
             ProcessedSerdeObject,
         },
         SerdeFormat,
@@ -214,7 +214,7 @@ where
 impl<F: WithSmallOrderMulGroup<3>, CS: PolynomialCommitmentScheme<F>> VerifyingKey<F, CS> {
     /// Return the bytes_length of a VerifyingKey
     pub fn bytes_length(&self, format: SerdeFormat) -> usize {
-        10 + (self.fixed_commitments.len() * byte_length::<CS::Commitment>(format))
+        10 + (self.fixed_commitments.iter().map(|c| c.byte_length(format)).sum::<usize>())
             + self.permutation.bytes_length(format)
     }
 

--- a/proofs/src/plonk/permutation.rs
+++ b/proofs/src/plonk/permutation.rs
@@ -25,7 +25,7 @@ use crate::{
         permutation::{keygen::compute_polys_and_cosets, verifier::CommonEvaluated},
     },
     poly::{commitment::PolynomialCommitmentScheme, EvaluationDomain},
-    utils::helpers::{byte_length, ProcessedSerdeObject},
+    utils::helpers::ProcessedSerdeObject,
 };
 
 /// A permutation argument.
@@ -130,7 +130,7 @@ impl<F: PrimeField, CS: PolynomialCommitmentScheme<F>> VerifyingKey<F, CS> {
     where
         CS::Commitment: ProcessedSerdeObject,
     {
-        self.commitments.len() * byte_length::<CS::Commitment>(format)
+        self.commitments.iter().map(|c| c.byte_length(format)).sum()
     }
 }
 

--- a/proofs/src/plonk/permutation/keygen.rs
+++ b/proofs/src/plonk/permutation/keygen.rs
@@ -7,8 +7,8 @@ use super::{Argument, ProvingKey, VerifyingKey};
 use crate::{
     plonk::{Any, Column, Error},
     poly::{
-        commitment::PolynomialCommitmentScheme, Coeff, EvaluationDomain, ExtendedLagrangeCoeff,
-        LagrangeCoeff, Polynomial,
+        commitment::PolynomialCommitmentScheme, Coeff, CommitmentLabel, EvaluationDomain,
+        ExtendedLagrangeCoeff, LagrangeCoeff, Polynomial,
     },
     utils::arithmetic::parallelize,
 };
@@ -242,9 +242,13 @@ pub(crate) fn build_vk<F: WithSmallOrderMulGroup<3>, CS: PolynomialCommitmentSch
 
     // Pre-compute commitments for the URS.
     let mut commitments = Vec::with_capacity(p.columns.len());
-    for permutation in &permutations {
+    for (i, permutation) in permutations.iter().enumerate() {
         // Compute commitment to permutation polynomial
-        commitments.push(CS::commit(params, permutation));
+        commitments.push(CS::commit(
+            params,
+            permutation,
+            CommitmentLabel::Permutation(i),
+        ));
     }
 
     VerifyingKey { commitments }

--- a/proofs/src/plonk/permutation/prover.rs
+++ b/proofs/src/plonk/permutation/prover.rs
@@ -14,8 +14,8 @@ use crate::{
         Error,
     },
     poly::{
-        commitment::PolynomialCommitmentScheme, Coeff, EvaluationDomain, LagrangeCoeff, Polynomial,
-        ProverQuery, Rotation,
+        commitment::PolynomialCommitmentScheme, Coeff, CommitmentLabel, EvaluationDomain,
+        LagrangeCoeff, Polynomial, ProverQuery, Rotation,
     },
     transcript::{Hashable, Transcript},
     utils::arithmetic::{eval_polynomial, eval_polynomial_seq, parallelize},
@@ -237,7 +237,7 @@ impl Argument {
                 // The Lagrange form is needed downstream for the linearization step,
                 // so we borrow into a transient delta buffer rather than transforming
                 // in place and prefix-summing back.
-                let commitment = CS::commit(params, &z.to_delta());
+                let commitment = CS::commit(params, &z.to_delta(), CommitmentLabel::NoLabel);
                 (commitment, z)
             })
             .collect();

--- a/proofs/src/plonk/permutation/verifier.rs
+++ b/proofs/src/plonk/permutation/verifier.rs
@@ -1,5 +1,3 @@
-use std::iter;
-
 use ff::{PrimeField, WithSmallOrderMulGroup};
 
 use super::{Argument, VerifyingKey};
@@ -102,55 +100,53 @@ impl<F: PrimeField, CS: PolynomialCommitmentScheme<F>> Committed<F, CS> {
 }
 
 impl<F: WithSmallOrderMulGroup<3>, CS: PolynomialCommitmentScheme<F>> Evaluated<F, CS> {
-    pub(in crate::plonk) fn queries<'r>(
-        &'r self,
-        vk: &'r plonk::VerifyingKey<F, CS>,
+    pub(in crate::plonk) fn queries(
+        &self,
+        vk: &plonk::VerifyingKey<F, CS>,
         x: F,
-    ) -> impl Iterator<Item = VerifierQuery<'r, F, CS>> + Clone + 'r {
+    ) -> impl Iterator<Item = VerifierQuery<'_, F, CS>> + Clone {
         let blinding_factors = vk.cs.blinding_factors();
         let x_next = vk.domain.rotate_omega(x, Rotation::next());
         let x_last = vk.domain.rotate_omega(x, Rotation(-((blinding_factors + 1) as i32)));
 
-        iter::empty()
-            .chain(self.sets.iter().enumerate().flat_map(move |(i, set)| {
-                iter::empty()
-                    // Open permutation product commitments at x and \omega x
-                    .chain(Some(VerifierQuery::new(
-                        x,
-                        CommitmentLabel::NoLabel,
-                        &self.coms.permutation_product_commitments[i],
-                        set.permutation_product_eval,
-                    )))
-                    .chain(Some(VerifierQuery::new(
-                        x_next,
-                        CommitmentLabel::NoLabel,
-                        &self.coms.permutation_product_commitments[i],
-                        set.permutation_product_next_eval,
-                    )))
-            }))
-            // Open it at \omega^{last} x for all but the last set
-            .chain(
-                self.sets.iter().enumerate().rev().skip(1).flat_map(move |(i, set)| {
-                    Some(VerifierQuery::new(
-                        x_last,
-                        CommitmentLabel::NoLabel,
-                        &self.coms.permutation_product_commitments[i],
-                        set.permutation_product_last_eval.unwrap(),
-                    ))
-                }),
-            )
+        let product_coms = &self.coms.permutation_product_commitments;
+        let mut queries = Vec::new();
+        for (i, set) in self.sets.iter().enumerate() {
+            queries.push(VerifierQuery::new(
+                x,
+                CommitmentLabel::NoLabel,
+                &product_coms[i],
+                set.permutation_product_eval,
+            ));
+            queries.push(VerifierQuery::new(
+                x_next,
+                CommitmentLabel::NoLabel,
+                &product_coms[i],
+                set.permutation_product_next_eval,
+            ));
+        }
+        // Open at \omega^{last} x for all but the last set
+        for (i, set) in self.sets.iter().enumerate().rev().skip(1) {
+            queries.push(VerifierQuery::new(
+                x_last,
+                CommitmentLabel::NoLabel,
+                &product_coms[i],
+                set.permutation_product_last_eval.unwrap(),
+            ));
+        }
+        queries.into_iter()
     }
 }
 
 impl<F: PrimeField> CommonEvaluated<F> {
-    pub(in crate::plonk) fn queries<'r, CS: PolynomialCommitmentScheme<F>>(
-        &'r self,
-        vkey: &'r VerifyingKey<F, CS>,
+    pub(in crate::plonk) fn queries<'vkey, CS: PolynomialCommitmentScheme<F>>(
+        &self,
+        vkey: &'vkey VerifyingKey<F, CS>,
         x: F,
-    ) -> impl Iterator<Item = VerifierQuery<'r, F, CS>> + Clone {
-        // Open permutation commitments for each permutation argument at x
-        vkey.commitments.iter().zip(self.permutation_evals.iter()).enumerate().map(
-            move |(i, (commitment, &eval))| {
+    ) -> impl Iterator<Item = VerifierQuery<'vkey, F, CS>> + Clone {
+        let evals = self.permutation_evals.clone();
+        vkey.commitments.iter().zip(evals).enumerate().map(
+            move |(i, (commitment, eval))| {
                 VerifierQuery::new(x, CommitmentLabel::Permutation(i), commitment, eval)
             },
         )

--- a/proofs/src/plonk/permutation/verifier.rs
+++ b/proofs/src/plonk/permutation/verifier.rs
@@ -3,7 +3,7 @@ use ff::{PrimeField, WithSmallOrderMulGroup};
 use super::{Argument, VerifyingKey};
 use crate::{
     plonk::{self, permutation, Error},
-    poly::{commitment::PolynomialCommitmentScheme, CommitmentLabel, Rotation, VerifierQuery},
+    poly::{commitment::PolynomialCommitmentScheme, Rotation, VerifierQuery},
     transcript::{Hashable, Transcript},
 };
 
@@ -114,13 +114,11 @@ impl<F: WithSmallOrderMulGroup<3>, CS: PolynomialCommitmentScheme<F>> Evaluated<
         for (i, set) in self.sets.iter().enumerate() {
             queries.push(VerifierQuery::new(
                 x,
-                CommitmentLabel::NoLabel,
                 &product_coms[i],
                 set.permutation_product_eval,
             ));
             queries.push(VerifierQuery::new(
                 x_next,
-                CommitmentLabel::NoLabel,
                 &product_coms[i],
                 set.permutation_product_next_eval,
             ));
@@ -129,7 +127,6 @@ impl<F: WithSmallOrderMulGroup<3>, CS: PolynomialCommitmentScheme<F>> Evaluated<
         for (i, set) in self.sets.iter().enumerate().rev().skip(1) {
             queries.push(VerifierQuery::new(
                 x_last,
-                CommitmentLabel::NoLabel,
                 &product_coms[i],
                 set.permutation_product_last_eval.unwrap(),
             ));
@@ -145,10 +142,9 @@ impl<F: PrimeField> CommonEvaluated<F> {
         x: F,
     ) -> impl Iterator<Item = VerifierQuery<'vkey, F, CS>> + Clone {
         let evals = self.permutation_evals.clone();
-        vkey.commitments.iter().zip(evals).enumerate().map(
-            move |(i, (commitment, eval))| {
-                VerifierQuery::new(x, CommitmentLabel::Permutation(i), commitment, eval)
-            },
-        )
+        vkey.commitments
+            .iter()
+            .zip(evals)
+            .map(move |(commitment, eval)| VerifierQuery::new(x, commitment, eval))
     }
 }

--- a/proofs/src/plonk/prover.rs
+++ b/proofs/src/plonk/prover.rs
@@ -27,9 +27,9 @@ use crate::{
         traces::ProverTrace, trash,
     },
     poly::{
-        batch_invert_rational, commitment::PolynomialCommitmentScheme, Coeff, EvaluationDomain,
-        ExtendedLagrangeCoeff, LagrangeCoeff, Polynomial, PolynomialRepresentation, ProverQuery,
-        Rotation,
+        batch_invert_rational, commitment::PolynomialCommitmentScheme, Coeff, CommitmentLabel,
+        EvaluationDomain, ExtendedLagrangeCoeff, LagrangeCoeff, Polynomial,
+        PolynomialRepresentation, ProverQuery, Rotation,
     },
     transcript::{Hashable, Sampleable, Transcript},
     utils::{
@@ -54,7 +54,7 @@ where
     for (poly_eval, value) in poly.iter_mut().zip(instances.iter()) {
         *poly_eval = *value;
     }
-    CS::commit(params, &poly)
+    CS::commit(params, &poly, CommitmentLabel::Instance(0))
 }
 
 /// This computes a proof trace for the provided `circuit` when given the
@@ -198,7 +198,7 @@ where
                         .par_iter()
                         .map(|h| {
                             let h_poly = domain.lagrange_from_vec(h.clone());
-                            CS::commit(params, &h_poly)
+                            CS::commit(params, &h_poly, CommitmentLabel::NoLabel)
                         })
                         .collect()
                 })
@@ -503,7 +503,7 @@ where
             }
 
             if is_committed_instance {
-                transcript.common(&CS::commit(params, &poly))?;
+                transcript.common(&CS::commit(params, &poly, CommitmentLabel::NoLabel))?;
             }
 
             Ok(poly)
@@ -598,8 +598,11 @@ where
         }
     }
 
-    let advice_commitments: Vec<_> =
-        advice_values.par_iter().map(|poly| CS::commit(params, poly)).collect();
+    let advice_commitments: Vec<_> = advice_values
+        .par_iter()
+        .enumerate()
+        .map(|(i, poly)| CS::commit(params, poly, CommitmentLabel::Advice(i)))
+        .collect();
 
     for commitment in &advice_commitments {
         transcript.write(commitment)?;
@@ -714,7 +717,7 @@ where
             values: h_poly,
             _marker: std::marker::PhantomData,
         };
-        let h_com = CS::commit(params, &h_poly);
+        let h_com = CS::commit(params, &h_poly, CommitmentLabel::NoLabel);
         transcript.write(&h_com)?;
         Ok(vec![h_poly])
     }
@@ -734,8 +737,10 @@ where
             h_limbs.into_iter().map(|h_limb| domain.coeff_from_vec(h_limb)).collect();
 
         // Compute commitment to each limb (parallel MSMs).
-        let h_commitments: Vec<_> =
-            h_limbs.par_iter().map(|h_piece| CS::commit(params, h_piece)).collect();
+        let h_commitments: Vec<_> = h_limbs
+            .par_iter()
+            .map(|h_piece| CS::commit(params, h_piece, CommitmentLabel::NoLabel))
+            .collect();
 
         // Write each limb commitment to the transcript in order.
         for c in h_commitments {

--- a/proofs/src/plonk/trash/prover.rs
+++ b/proofs/src/plonk/trash/prover.rs
@@ -4,8 +4,8 @@ use super::{super::Error, Argument};
 use crate::{
     plonk::{evaluation::evaluate, trash},
     poly::{
-        commitment::PolynomialCommitmentScheme, Coeff, EvaluationDomain, LagrangeCoeff, Polynomial,
-        ProverQuery,
+        commitment::PolynomialCommitmentScheme, Coeff, CommitmentLabel, EvaluationDomain,
+        LagrangeCoeff, Polynomial, ProverQuery,
     },
     transcript::{Hashable, Transcript},
     utils::arithmetic::eval_polynomial,
@@ -57,7 +57,7 @@ impl<F: WithSmallOrderMulGroup<3> + Ord> Argument<F> {
                 acc * trash_challenge + &expression
             });
 
-        let trash_commitment = CS::commit(params, &compressed_expression);
+        let trash_commitment = CS::commit(params, &compressed_expression, CommitmentLabel::NoLabel);
         let trash_poly = domain.lagrange_to_coeff(compressed_expression);
 
         // Hash permuted input commitment

--- a/proofs/src/plonk/trash/verifier.rs
+++ b/proofs/src/plonk/trash/verifier.rs
@@ -3,7 +3,7 @@ use ff::{PrimeField, WithSmallOrderMulGroup};
 use super::Argument;
 use crate::{
     plonk::{trash, Error},
-    poly::{commitment::PolynomialCommitmentScheme, CommitmentLabel, VerifierQuery},
+    poly::{commitment::PolynomialCommitmentScheme, VerifierQuery},
     transcript::{Hashable, Transcript},
 };
 
@@ -52,7 +52,6 @@ impl<F: WithSmallOrderMulGroup<3>, CS: PolynomialCommitmentScheme<F>> Evaluated<
     pub(crate) fn queries(&self, x: F) -> impl Iterator<Item = VerifierQuery<'_, F, CS>> + Clone {
         vec![VerifierQuery::new(
             x,
-            CommitmentLabel::NoLabel,
             &self.committed.trash_commitment,
             self.evaluated.trash_eval,
         )]

--- a/proofs/src/plonk/verifier.rs
+++ b/proofs/src/plonk/verifier.rs
@@ -11,7 +11,7 @@ use crate::{
         linearization::verifier::compute_linearization_commitment, partially_evaluate_identities,
         traces::VerifierTrace,
     },
-    poly::{commitment::PolynomialCommitmentScheme, CommitmentLabel, VerifierQuery},
+    poly::{commitment::PolynomialCommitmentScheme, VerifierQuery},
     transcript::{read_n, Hashable, Sampleable, Transcript},
     utils::arithmetic::compute_inner_product,
 };
@@ -285,7 +285,6 @@ where
             vk.cs.advice_queries.iter().enumerate().map(|(query_index, &(column, at))| {
                 VerifierQuery::new(
                     vk.domain.rotate_omega(x, at),
-                    CommitmentLabel::Advice(column.index()),
                     &advice_commitments[column.index()],
                     advice_evals[query_index],
                 )
@@ -296,7 +295,6 @@ where
                 if column.index() < nb_committed_instances {
                     Some(VerifierQuery::new(
                         vk.domain.rotate_omega(x, at),
-                        CommitmentLabel::Instance(column.index()),
                         &committed_instances[column.index()],
                         instance_evals[query_index],
                     ))
@@ -318,19 +316,13 @@ where
                 .map(|(query_index, &(column, at))| {
                     VerifierQuery::new(
                         vk.domain.rotate_omega(x, at),
-                        CommitmentLabel::Fixed(column.index()),
                         &vk.fixed_commitments[column.index()],
                         fixed_evals[query_index],
                     )
                 }),
         )
         .chain(permutations_common.queries(&vk.permutation, x))
-        .chain(iter::once(VerifierQuery::new(
-            x,
-            CommitmentLabel::Custom("linearization_poly".into()),
-            &lin_commitment,
-            lin_eval,
-        )))
+        .chain(iter::once(VerifierQuery::new(x, &lin_commitment, lin_eval)))
         .collect::<Vec<_>>();
 
     // We are now convinced the circuit is satisfied so long as the

--- a/proofs/src/plonk/verifier.rs
+++ b/proofs/src/plonk/verifier.rs
@@ -267,10 +267,9 @@ where
         trash_challenge,
     );
 
-    let lin_com = compute_linearization_commitment(
+    let (lin_commitment, lin_eval) = compute_linearization_commitment(
         expressions,
         vk,
-        x,
         &y,
         &xn,
         &splitting_factor,
@@ -326,7 +325,12 @@ where
                 }),
         )
         .chain(permutations_common.queries(&vk.permutation, x))
-        .chain(iter::once(lin_com))
+        .chain(iter::once(VerifierQuery::new(
+            x,
+            CommitmentLabel::Custom("linearization_poly".into()),
+            &lin_commitment,
+            lin_eval,
+        )))
         .collect::<Vec<_>>();
 
     // We are now convinced the circuit is satisfied so long as the

--- a/proofs/src/poly/commitment.rs
+++ b/proofs/src/poly/commitment.rs
@@ -6,7 +6,10 @@ use ff::{FromUniformBytes, PrimeField};
 
 use crate::{
     plonk::{k_from_circuit, Circuit},
-    poly::{Error, Polynomial, PolynomialRepresentation, ProverQuery, VerifierQuery},
+    poly::{
+        query::CommitmentLabel, Error, Polynomial, PolynomialRepresentation, ProverQuery,
+        VerifierQuery,
+    },
     transcript::{Hashable, Sampleable, Transcript},
     utils::helpers::ProcessedSerdeObject,
 };
@@ -40,10 +43,12 @@ pub trait PolynomialCommitmentScheme<F: PrimeField>: Clone + Debug {
     /// Extract the `VerifierParameters` from `Parameters`
     fn get_verifier_params(params: &Self::Parameters) -> Self::VerifierParameters;
 
-    /// Commit to a polynomial in coefficient form
+    /// Commit to a polynomial in coefficient form, tagging the result with
+    /// `label` for identification during multi-open accumulation.
     fn commit<B: PolynomialRepresentation>(
         params: &Self::Parameters,
         polynomial: &Polynomial<F, B>,
+        label: CommitmentLabel,
     ) -> Self::Commitment;
 
     /// Create a multi-opening proof at a set of [ProverQuery]'s.
@@ -64,7 +69,7 @@ pub trait PolynomialCommitmentScheme<F: PrimeField>: Clone + Debug {
     ) -> Result<Self::VerificationGuard, Error>
     where
         F: Sampleable<T::Hash> + Hash + Ord + Hashable<T::Hash>,
-        Self::Commitment: 'com + Hashable<T::Hash>;
+        Self::Commitment: Hashable<T::Hash> + 'com;
 }
 
 /// Interface for verifier finalizer

--- a/proofs/src/poly/kzg/commitment.rs
+++ b/proofs/src/poly/kzg/commitment.rs
@@ -25,7 +25,7 @@ use crate::{
 /// is a **verifier-internal** structure: the verifier assembles it from
 /// individually deserialized `Simple` points (via [`Mul`] and [`Add`]) so
 /// that all scalar multiplications can be batched in a single multi-scalar
-/// multiplication at the end of [`PolynomialCommitmentScheme::multi_prepare`].
+/// multiplication at the end of [`crate::poly::commitment::PolynomialCommitmentScheme::multi_prepare`].
 /// It is therefore a programming error to attempt to serialize or hash a
 /// `Linear` commitment; the corresponding trait methods panic.
 #[derive(Clone, Debug)]

--- a/proofs/src/poly/kzg/commitment.rs
+++ b/proofs/src/poly/kzg/commitment.rs
@@ -18,11 +18,23 @@ use crate::{
 /// Each point carries a [`CommitmentLabel`] that identifies its role in the
 /// protocol (e.g. `Fixed(i)`, `Advice(i)`).  Labels are protocol-level
 /// metadata; they are not included in serialization or hashing.
+///
+/// # Serialization invariant
+///
+/// Only `Simple` commitments are ever serialized or hashed.  `Linear`
+/// is a **verifier-internal** structure: the verifier assembles it from
+/// individually deserialized `Simple` points (via [`Mul`] and [`Add`]) so
+/// that all scalar multiplications can be batched in a single multi-scalar
+/// multiplication at the end of [`PolynomialCommitmentScheme::multi_prepare`].
+/// It is therefore a programming error to attempt to serialize or hash a
+/// `Linear` commitment; the corresponding trait methods panic.
 #[derive(Clone, Debug)]
 pub enum KZGCommitment<E: MultiMillerLoop> {
     /// A single committed point with its label.
     Simple(E::G1, CommitmentLabel),
-    /// A linear combination `∑ scalars[i] * points[i]` with per-term labels.
+    /// A lazy linear combination `∑ scalars[i] * points[i]` with per-term
+    /// labels, accumulated during verification for MSM batching.  Never
+    /// serialized or hashed directly.
     Linear(Vec<E::G1>, Vec<E::Fr>, Vec<CommitmentLabel>),
 }
 
@@ -69,12 +81,11 @@ where
     }
 }
 
-/// Serialization assumes commitments are `Simple`. `Linear` commitments are
-/// constructed by the verifier from individually serialized `Simple` points and
-/// are never written to or read from a transcript directly.
+/// Only `Simple` commitments are serialized; see the type-level doc for why
+/// `Linear` is never written to or read from a proof directly.
 ///
-/// Labels are not included in the serialized form; deserialized commitments
-/// always receive [`CommitmentLabel::NoLabel`].
+/// Labels are not part of the serialized form; deserialized commitments always
+/// receive [`CommitmentLabel::NoLabel`].
 impl<E: MultiMillerLoop> ProcessedSerdeObject for KZGCommitment<E>
 where
     E::G1: Default + ProcessedSerdeObject,
@@ -101,8 +112,9 @@ where
     }
 }
 
-/// Transcript operations assume commitments are `Simple` — see
-/// [`ProcessedSerdeObject`]. Labels are not part of the transcript.
+/// Only `Simple` commitments are hashed into transcripts; see the type-level
+/// doc for why `Linear` is never hashed directly. Labels are not part of the
+/// transcript.
 impl<H: TranscriptHash, E: MultiMillerLoop> Hashable<H> for KZGCommitment<E>
 where
     E::G1: Hashable<H>,

--- a/proofs/src/poly/kzg/commitment.rs
+++ b/proofs/src/poly/kzg/commitment.rs
@@ -25,7 +25,8 @@ use crate::{
 /// is a **verifier-internal** structure: the verifier assembles it from
 /// individually deserialized `Simple` points (via [`Mul`] and [`Add`]) so
 /// that all scalar multiplications can be batched in a single multi-scalar
-/// multiplication at the end of [`crate::poly::commitment::PolynomialCommitmentScheme::multi_prepare`].
+/// multiplication at the end of
+/// [`crate::poly::commitment::PolynomialCommitmentScheme::multi_prepare`].
 /// It is therefore a programming error to attempt to serialize or hash a
 /// `Linear` commitment; the corresponding trait methods panic.
 #[derive(Clone, Debug)]

--- a/proofs/src/poly/kzg/commitment.rs
+++ b/proofs/src/poly/kzg/commitment.rs
@@ -1,0 +1,161 @@
+use std::{
+    io::{self, Read},
+    ops::{Add, Mul},
+};
+
+use ff::Field;
+use midnight_curves::pairing::MultiMillerLoop;
+
+use crate::{
+    poly::query::CommitmentLabel,
+    transcript::{Hashable, TranscriptHash},
+    utils::helpers::{ProcessedSerdeObject, SerdeFormat},
+};
+
+/// A KZG commitment: either a single curve point, or a lazy linear combination
+/// of curve points kept unevaluated for MSM batching.
+///
+/// Each point carries a [`CommitmentLabel`] that identifies its role in the
+/// protocol (e.g. `Fixed(i)`, `Advice(i)`).  Labels are protocol-level
+/// metadata; they are not included in serialization or hashing.
+#[derive(Clone, Debug)]
+pub enum KZGCommitment<E: MultiMillerLoop> {
+    /// A single committed point with its label.
+    Simple(E::G1, CommitmentLabel),
+    /// A linear combination `∑ scalars[i] * points[i]` with per-term labels.
+    Linear(Vec<E::G1>, Vec<E::Fr>, Vec<CommitmentLabel>),
+}
+
+impl<E: MultiMillerLoop> PartialEq for KZGCommitment<E>
+where
+    E::G1: PartialEq,
+    E::Fr: PartialEq,
+{
+    fn eq(&self, other: &Self) -> bool {
+        match (self, other) {
+            (Self::Simple(p, _), Self::Simple(q, _)) => p == q,
+            (Self::Linear(ps, rs, _), Self::Linear(qs, ss, _)) => ps == qs && rs == ss,
+            _ => false,
+        }
+    }
+}
+
+impl<E: MultiMillerLoop> KZGCommitment<E> {
+    /// Extracts the inner curve point, panicking if this is a `Linear`
+    /// commitment.
+    pub fn into_point(self) -> E::G1 {
+        match self {
+            Self::Simple(p, _) => p,
+            Self::Linear(..) => panic!("expected KZGCommitment::Simple"),
+        }
+    }
+
+    /// Returns a reference to the inner curve point, panicking if this is a
+    /// `Linear` commitment.
+    pub fn as_point(&self) -> &E::G1 {
+        match self {
+            Self::Simple(p, _) => p,
+            Self::Linear(..) => panic!("expected KZGCommitment::Simple"),
+        }
+    }
+}
+
+impl<E: MultiMillerLoop> Default for KZGCommitment<E>
+where
+    E::G1: Default,
+{
+    fn default() -> Self {
+        Self::Simple(E::G1::default(), CommitmentLabel::NoLabel)
+    }
+}
+
+/// Serialization assumes commitments are `Simple`. `Linear` commitments are
+/// constructed by the verifier from individually serialized `Simple` points and
+/// are never written to or read from a transcript directly.
+///
+/// Labels are not included in the serialized form; deserialized commitments
+/// always receive [`CommitmentLabel::NoLabel`].
+impl<E: MultiMillerLoop> ProcessedSerdeObject for KZGCommitment<E>
+where
+    E::G1: Default + ProcessedSerdeObject,
+{
+    fn read<R: io::Read>(reader: &mut R, format: SerdeFormat) -> io::Result<Self> {
+        Ok(Self::Simple(
+            E::G1::read(reader, format)?,
+            CommitmentLabel::NoLabel,
+        ))
+    }
+
+    fn write<W: io::Write>(&self, writer: &mut W, format: SerdeFormat) -> io::Result<()> {
+        match self {
+            Self::Simple(p, _) => p.write(writer, format),
+            Self::Linear(..) => panic!("KZGCommitment::Linear cannot be serialized directly"),
+        }
+    }
+
+    fn byte_length(&self, format: SerdeFormat) -> usize {
+        match self {
+            Self::Simple(p, _) => p.byte_length(format),
+            Self::Linear(..) => panic!("KZGCommitment::Linear has no fixed byte length"),
+        }
+    }
+}
+
+/// Transcript operations assume commitments are `Simple` — see
+/// [`ProcessedSerdeObject`]. Labels are not part of the transcript.
+impl<H: TranscriptHash, E: MultiMillerLoop> Hashable<H> for KZGCommitment<E>
+where
+    E::G1: Hashable<H>,
+{
+    fn to_input(&self) -> H::Input {
+        match self {
+            Self::Simple(p, _) => p.to_input(),
+            Self::Linear(..) => panic!("KZGCommitment::Linear cannot be hashed directly"),
+        }
+    }
+
+    fn to_bytes(&self) -> Vec<u8> {
+        match self {
+            Self::Simple(p, _) => p.to_bytes(),
+            Self::Linear(..) => panic!("KZGCommitment::Linear cannot be serialized to bytes"),
+        }
+    }
+
+    fn read(buffer: &mut impl Read) -> io::Result<Self> {
+        Ok(Self::Simple(E::G1::read(buffer)?, CommitmentLabel::NoLabel))
+    }
+}
+
+impl<E: MultiMillerLoop> Mul<E::Fr> for KZGCommitment<E> {
+    type Output = Self;
+
+    fn mul(self, scalar: E::Fr) -> Self {
+        match self {
+            Self::Simple(p, label) => Self::Linear(vec![p], vec![scalar], vec![label]),
+            Self::Linear(points, scalars, labels) => Self::Linear(
+                points,
+                scalars.into_iter().map(|s| s * scalar).collect(),
+                labels,
+            ),
+        }
+    }
+}
+
+impl<E: MultiMillerLoop> Add for KZGCommitment<E> {
+    type Output = Self;
+
+    fn add(self, other: Self) -> Self {
+        let (mut points, mut scalars, mut labels) = match self {
+            Self::Simple(p, label) => (vec![p], vec![E::Fr::ONE], vec![label]),
+            Self::Linear(points, scalars, labels) => (points, scalars, labels),
+        };
+        let (other_points, other_scalars, other_labels) = match other {
+            Self::Simple(p, label) => (vec![p], vec![E::Fr::ONE], vec![label]),
+            Self::Linear(points, scalars, labels) => (points, scalars, labels),
+        };
+        points.extend(other_points);
+        scalars.extend(other_scalars);
+        labels.extend(other_labels);
+        Self::Linear(points, scalars, labels)
+    }
+}

--- a/proofs/src/poly/kzg/mod.rs
+++ b/proofs/src/poly/kzg/mod.rs
@@ -17,6 +17,8 @@ use rayon::iter::{
 #[cfg(feature = "fewer-point-sets")]
 use super::query::Query;
 
+/// KZG commitment type
+pub mod commitment;
 /// Multiscalar multiplication engines
 pub mod msm;
 /// KZG commitment scheme
@@ -56,6 +58,8 @@ use crate::{
     },
 };
 
+use commitment::KZGCommitment;
+
 #[derive(Clone, Debug)]
 /// KZG verifier
 pub struct KZGCommitmentScheme<E: Engine> {
@@ -69,7 +73,7 @@ where
 {
     type Parameters = ParamsKZG<E>;
     type VerifierParameters = ParamsVerifierKZG<E>;
-    type Commitment = E::G1;
+    type Commitment = KZGCommitment<E>;
     type VerificationGuard = DualMSM<E>;
 
     fn gen_params(k: u32) -> Self::Parameters {
@@ -83,11 +87,15 @@ where
     fn commit<B: PolynomialRepresentation>(
         params: &Self::Parameters,
         polynomial: &Polynomial<E::Fr, B>,
+        label: CommitmentLabel,
     ) -> Self::Commitment {
         let bases = params.bases::<B>();
         let size = polynomial.values.len();
         assert!(bases.len() >= size);
-        msm_specific::<E::G1Affine>(&polynomial.values, &bases[..size])
+        KZGCommitment::Simple(
+            msm_specific::<E::G1Affine>(&polynomial.values, &bases[..size]),
+            label,
+        )
     }
 
     fn multi_open<T: Transcript>(
@@ -97,7 +105,7 @@ where
     ) -> Result<(), Error>
     where
         E::Fr: Sampleable<T::Hash> + Hash + Ord + Hashable<T::Hash>,
-        E::G1: Hashable<T::Hash>,
+        KZGCommitment<E>: Hashable<T::Hash>,
     {
         /// Like [`inner_product`] but for coefficient-form polynomials that may
         /// have different lengths (zero-extending the shorter operands).
@@ -203,7 +211,7 @@ where
             poly_inner_product(&f_polys, powers(x2))
         };
 
-        let f_com = Self::commit(params, &f_poly);
+        let f_com = Self::commit(params, &f_poly, CommitmentLabel::NoLabel);
         transcript.write(&f_com).map_err(|_| Error::OpeningError)?;
 
         let x3: E::Fr = transcript.squeeze_challenge();
@@ -237,7 +245,7 @@ where
                 values: kate_division(&(&final_poly - v).values, x3),
                 _marker: PhantomData,
             };
-            Self::commit(params, &pi_poly)
+            Self::commit(params, &pi_poly, CommitmentLabel::NoLabel)
         };
 
         transcript.write(&pi).map_err(|_| Error::OpeningError)
@@ -249,7 +257,8 @@ where
     ) -> Result<DualMSM<E>, Error>
     where
         E::Fr: Sampleable<T::Hash> + Ord + Hash + Hashable<T::Hash>,
-        E::G1: 'com + Hashable<T::Hash> + CurveExt<ScalarExt = E::Fr>,
+        E::G1: 'com + CurveExt<ScalarExt = E::Fr>,
+        KZGCommitment<E>: Hashable<T::Hash>,
     {
         // Add dummy queries to reduce the number of distinct multi-open point sets.
         #[cfg(feature = "fewer-point-sets")]
@@ -279,13 +288,15 @@ where
 
         for com_data in commitment_map.into_iter() {
             let mut msm = MSMKZG::init();
-            let terms = com_data.commitment.as_terms();
-            let term_labels: Vec<CommitmentLabel> = match &com_data.commitment {
-                CommitmentReference::Linear(_, _, labels) => labels.clone(),
-                _ => vec![com_data.commitment_label.clone(); terms.len()],
-            };
-            for ((scalar, commitment), label) in terms.into_iter().zip(term_labels) {
-                msm.append_term(scalar, commitment, label);
+            for (scalar, commitment) in com_data.commitment.as_terms() {
+                match commitment {
+                    KZGCommitment::Simple(p, label) => msm.append_term(scalar, p, label),
+                    KZGCommitment::Linear(points, scalars, labels) => {
+                        for ((p, s), label) in points.into_iter().zip(scalars).zip(labels) {
+                            msm.append_term(scalar * s, p, label);
+                        }
+                    }
+                }
             }
             q_coms[com_data.set_index].push(msm);
             q_eval_sets[com_data.set_index].push(com_data.evals);
@@ -327,7 +338,10 @@ where
             (q_coms, q_eval_sets, point_sets)
         };
 
-        let f_com: E::G1 = transcript.read().map_err(|_| Error::SamplingError)?;
+        let f_com: E::G1 = transcript
+            .read::<KZGCommitment<E>>()
+            .map_err(|_| Error::SamplingError)?
+            .into_point();
 
         // Sample a challenge x_3 for checking that f(X) was committed to
         // correctly.
@@ -392,7 +406,10 @@ where
             inner_product(&evals, powers)
         };
 
-        let pi: E::G1 = transcript.read().map_err(|_| Error::SamplingError)?;
+        let pi: E::G1 = transcript
+            .read::<KZGCommitment<E>>()
+            .map_err(|_| Error::SamplingError)?
+            .into_point();
 
         let mut pi_msm = MSMKZG::<E>::init();
         pi_msm.append_term(E::Fr::ONE, pi, CommitmentLabel::Custom("π".into()));
@@ -431,6 +448,7 @@ mod tests {
         poly::{
             commitment::{Guard, PolynomialCommitmentScheme},
             kzg::{
+                commitment::KZGCommitment,
                 params::{ParamsKZG, ParamsVerifierKZG},
                 KZGCommitmentScheme,
             },
@@ -464,12 +482,13 @@ mod tests {
         E::Fr: Hashable<T::Hash> + Sampleable<T::Hash> + Ord + Hash,
         E::G1: Hashable<T::Hash> + CurveExt<ScalarExt = E::Fr, AffineExt = E::G1Affine>,
         E::G1Affine: CurveAffine<ScalarExt = E::Fr, CurveExt = E::G1> + SerdeObject,
+        KZGCommitment<E>: Hashable<T::Hash>,
     {
         let mut transcript = T::init_from_bytes(proof);
 
-        let a: E::G1 = transcript.read().unwrap();
-        let b: E::G1 = transcript.read().unwrap();
-        let c: E::G1 = transcript.read().unwrap();
+        let a: KZGCommitment<E> = transcript.read().unwrap();
+        let b: KZGCommitment<E> = transcript.read().unwrap();
+        let c: KZGCommitment<E> = transcript.read().unwrap();
 
         let x: E::Fr = transcript.squeeze_challenge();
         let y: E::Fr = transcript.squeeze_challenge();
@@ -534,9 +553,9 @@ mod tests {
 
         let mut transcript = T::init();
 
-        let a = KZGCommitmentScheme::commit(kzg_params, &ax);
-        let b = KZGCommitmentScheme::commit(kzg_params, &bx);
-        let c = KZGCommitmentScheme::commit(kzg_params, &cx);
+        let a = KZGCommitmentScheme::commit(kzg_params, &ax, CommitmentLabel::NoLabel);
+        let b = KZGCommitmentScheme::commit(kzg_params, &bx, CommitmentLabel::NoLabel);
+        let c = KZGCommitmentScheme::commit(kzg_params, &cx, CommitmentLabel::NoLabel);
 
         transcript.write(&a).unwrap();
         transcript.write(&b).unwrap();

--- a/proofs/src/poly/kzg/mod.rs
+++ b/proofs/src/poly/kzg/mod.rs
@@ -259,6 +259,22 @@ where
         E::G1: CurveExt<ScalarExt = E::Fr>,
         KZGCommitment<E>: Hashable<T::Hash> + 'com,
     {
+        // Add dummy queries to reduce the number of distinct multi-open point sets.
+        #[cfg(feature = "fewer-point-sets")]
+        let queries = &{
+            let mut queries = queries.to_vec();
+            let pairs: Vec<_> =
+                queries.iter().map(|q| (q.get_commitment(), q.get_point())).collect();
+            for (idx, point) in compute_dummy_queries(&pairs) {
+                queries.push(VerifierQuery::new(
+                    point,
+                    queries[idx].commitment.0,
+                    transcript.read().map_err(|_| Error::SamplingError)?,
+                ));
+            }
+            queries
+        };
+
         // Refer to the halo2 book for docs:
         // https://zcash.github.io/halo2/design/proving-system/multipoint-opening.html
         let x1: E::Fr = transcript.squeeze_challenge();

--- a/proofs/src/poly/kzg/mod.rs
+++ b/proofs/src/poly/kzg/mod.rs
@@ -27,6 +27,7 @@ mod utils;
 
 use std::{fmt::Debug, hash::Hash};
 
+use commitment::KZGCommitment;
 use ff::Field;
 use group::Group;
 use midnight_curves::pairing::MultiMillerLoop;
@@ -57,8 +58,6 @@ use crate::{
         helpers::ProcessedSerdeObject,
     },
 };
-
-use commitment::KZGCommitment;
 
 #[derive(Clone, Debug)]
 /// KZG verifier
@@ -479,16 +478,15 @@ mod tests {
         let bvx: E::Fr = transcript.read().unwrap();
         let cvy: E::Fr = transcript.read().unwrap();
 
-        use CommitmentLabel::NoLabel;
         let valid_queries = std::iter::empty()
-            .chain(Some(VerifierQuery::new(x, NoLabel, &a, avx)))
-            .chain(Some(VerifierQuery::new(x, NoLabel, &b, bvx)))
-            .chain(Some(VerifierQuery::new(y, NoLabel, &c, cvy)));
+            .chain(Some(VerifierQuery::new(x, &a, avx)))
+            .chain(Some(VerifierQuery::new(x, &b, bvx)))
+            .chain(Some(VerifierQuery::new(y, &c, cvy)));
 
         let invalid_queries = std::iter::empty()
-            .chain(Some(VerifierQuery::new(x, NoLabel, &a, avx)))
-            .chain(Some(VerifierQuery::new(x, NoLabel, &b, avx)))
-            .chain(Some(VerifierQuery::new(y, NoLabel, &c, cvy)));
+            .chain(Some(VerifierQuery::new(x, &a, avx)))
+            .chain(Some(VerifierQuery::new(x, &b, avx)))
+            .chain(Some(VerifierQuery::new(y, &c, cvy)));
 
         let queries = if should_fail {
             invalid_queries

--- a/proofs/src/poly/kzg/mod.rs
+++ b/proofs/src/poly/kzg/mod.rs
@@ -44,7 +44,7 @@ use crate::{
             params::{ParamsKZG, ParamsVerifierKZG},
             utils::construct_intermediate_sets,
         },
-        query::{CommitmentLabel, CommitmentReference, VerifierQuery},
+        query::{CommitmentLabel, VerifierQuery},
         Coeff, Error, Polynomial, PolynomialRepresentation, ProverQuery,
     },
     transcript::{Hashable, Sampleable, Transcript},
@@ -257,25 +257,9 @@ where
     ) -> Result<DualMSM<E>, Error>
     where
         E::Fr: Sampleable<T::Hash> + Ord + Hash + Hashable<T::Hash>,
-        E::G1: 'com + CurveExt<ScalarExt = E::Fr>,
-        KZGCommitment<E>: Hashable<T::Hash>,
+        E::G1: CurveExt<ScalarExt = E::Fr>,
+        KZGCommitment<E>: Hashable<T::Hash> + 'com,
     {
-        // Add dummy queries to reduce the number of distinct multi-open point sets.
-        #[cfg(feature = "fewer-point-sets")]
-        let queries = &{
-            let mut queries = queries.to_vec();
-            let pairs: Vec<_> = queries.iter().map(|q| (q.commitment.clone(), q.point)).collect();
-            for (idx, point) in compute_dummy_queries(&pairs) {
-                queries.push(VerifierQuery {
-                    point,
-                    commitment_label: queries[idx].commitment_label.clone(),
-                    commitment: queries[idx].commitment.clone(),
-                    eval: transcript.read().map_err(|_| Error::SamplingError)?,
-                });
-            }
-            queries
-        };
-
         // Refer to the halo2 book for docs:
         // https://zcash.github.io/halo2/design/proving-system/multipoint-opening.html
         let x1: E::Fr = transcript.squeeze_challenge();
@@ -288,13 +272,11 @@ where
 
         for com_data in commitment_map.into_iter() {
             let mut msm = MSMKZG::init();
-            for (scalar, commitment) in com_data.commitment.as_terms() {
-                match commitment {
-                    KZGCommitment::Simple(p, label) => msm.append_term(scalar, p, label),
-                    KZGCommitment::Linear(points, scalars, labels) => {
-                        for ((p, s), label) in points.into_iter().zip(scalars).zip(labels) {
-                            msm.append_term(scalar * s, p, label);
-                        }
+            match com_data.commitment.0 {
+                KZGCommitment::Simple(p, label) => msm.append_term(E::Fr::ONE, *p, label.clone()),
+                KZGCommitment::Linear(points, scalars, labels) => {
+                    for ((p, s), label) in points.iter().zip(scalars).zip(labels) {
+                        msm.append_term(*s, *p, label.clone());
                     }
                 }
             }

--- a/proofs/src/poly/kzg/params.rs
+++ b/proofs/src/poly/kzg/params.rs
@@ -411,6 +411,7 @@ mod test {
         poly::{
             commitment::PolynomialCommitmentScheme,
             kzg::{params::ParamsKZG, KZGCommitmentScheme},
+            CommitmentLabel,
         },
         utils::SerdeFormat,
     };
@@ -434,8 +435,8 @@ mod test {
 
         let b = domain.lagrange_to_coeff(a.clone());
 
-        let tmp = KZGCommitmentScheme::commit(&params, &a);
-        let commitment = KZGCommitmentScheme::commit(&params, &b);
+        let tmp = KZGCommitmentScheme::commit(&params, &a, CommitmentLabel::NoLabel);
+        let commitment = KZGCommitmentScheme::commit(&params, &b, CommitmentLabel::NoLabel);
 
         assert_eq!(commitment, tmp);
     }

--- a/proofs/src/poly/kzg/params.rs
+++ b/proofs/src/poly/kzg/params.rs
@@ -465,8 +465,8 @@ mod test {
             };
         }
 
-        let c_lagrange = KZGCommitmentScheme::commit(&params, &a);
-        let c_delta = KZGCommitmentScheme::commit(&params, &a.to_delta());
+        let c_lagrange = KZGCommitmentScheme::commit(&params, &a, CommitmentLabel::NoLabel);
+        let c_delta = KZGCommitmentScheme::commit(&params, &a.to_delta(), CommitmentLabel::NoLabel);
         assert_eq!(c_lagrange, c_delta);
 
         // Round-trip identity: to_delta then into_lagrange recovers the original.
@@ -499,12 +499,16 @@ mod test {
             };
         }
 
-        let c_lagrange = KZGCommitmentScheme::commit(&params, &a);
+        let c_lagrange = KZGCommitmentScheme::commit(&params, &a, CommitmentLabel::NoLabel);
 
         // Fused single-pass conversion matches the two-step path.
-        let c_double_delta_fused = KZGCommitmentScheme::commit(&params, &a.to_double_delta());
-        let c_double_delta_two_step =
-            KZGCommitmentScheme::commit(&params, &a.to_delta().into_double_delta());
+        let c_double_delta_fused =
+            KZGCommitmentScheme::commit(&params, &a.to_double_delta(), CommitmentLabel::NoLabel);
+        let c_double_delta_two_step = KZGCommitmentScheme::commit(
+            &params,
+            &a.to_delta().into_double_delta(),
+            CommitmentLabel::NoLabel,
+        );
         assert_eq!(c_lagrange, c_double_delta_fused);
         assert_eq!(c_lagrange, c_double_delta_two_step);
 

--- a/proofs/src/poly/kzg/utils.rs
+++ b/proofs/src/poly/kzg/utils.rs
@@ -6,11 +6,10 @@ use std::{
 
 use ff::Field;
 
-use crate::poly::{query::Query, CommitmentLabel, Error};
+use crate::poly::{query::Query, Error};
 
 #[derive(Clone, Debug)]
 pub(super) struct CommitmentData<F, T: PartialEq> {
-    pub(super) commitment_label: CommitmentLabel,
     pub(super) commitment: T,
     pub(super) set_index: usize,
     pub(super) point_indices: Vec<usize>,
@@ -18,9 +17,8 @@ pub(super) struct CommitmentData<F, T: PartialEq> {
 }
 
 impl<F, T: PartialEq> CommitmentData<F, T> {
-    fn new(commitment: T, commitment_label: CommitmentLabel) -> Self {
+    fn new(commitment: T) -> Self {
         CommitmentData {
-            commitment_label,
             commitment,
             set_index: 0,
             point_indices: vec![],
@@ -59,7 +57,7 @@ pub fn construct_intermediate_sets<F: Field + Hash + Ord, Q: Query<F>>(
             }
             commitment_map[pos].point_indices.push(*point_idx);
         } else {
-            let mut tmp = CommitmentData::new(query.get_commitment(), query.get_commitment_label());
+            let mut tmp = CommitmentData::new(query.get_commitment());
             tmp.point_indices.push(*point_idx);
             commitment_map.push(tmp);
         }

--- a/proofs/src/poly/query.rs
+++ b/proofs/src/poly/query.rs
@@ -44,7 +44,6 @@ pub trait Query<F>: Debug + Sized + Clone + Send + Sync {
     fn get_point(&self) -> F;
     fn get_eval(&self) -> Self::Eval;
     fn get_commitment(&self) -> Self::Commitment;
-    fn get_commitment_label(&self) -> CommitmentLabel;
 }
 
 /// A polynomial query at a point
@@ -91,9 +90,6 @@ impl<'com, F: PrimeField> Query<F> for ProverQuery<'com, F> {
     fn get_commitment(&self) -> Self::Commitment {
         PolynomialPointer { poly: self.poly }
     }
-    fn get_commitment_label(&self) -> CommitmentLabel {
-        CommitmentLabel::NoLabel
-    }
 }
 
 /// A pointer to a commitment, with pointer-based equality.
@@ -126,8 +122,6 @@ impl<F: PrimeField, CS: PolynomialCommitmentScheme<F>> PartialEq
 pub struct VerifierQuery<'com, F: PrimeField, CS: PolynomialCommitmentScheme<F>> {
     /// Point at which polynomial is queried.
     pub(crate) point: F,
-    /// Optional label identifying the commitment in this query.
-    pub(crate) commitment_label: CommitmentLabel,
     /// Commitment to polynomial.
     pub(crate) commitment: CommitmentReference<'com, F, CS>,
     /// Evaluation of polynomial at query point.
@@ -140,15 +134,9 @@ where
     CS: PolynomialCommitmentScheme<F>,
 {
     /// Create a new verifier query.
-    pub fn new(
-        point: F,
-        commitment_label: CommitmentLabel,
-        commitment: &'com CS::Commitment,
-        eval: F,
-    ) -> Self {
+    pub fn new(point: F, commitment: &'com CS::Commitment, eval: F) -> Self {
         VerifierQuery {
             point,
-            commitment_label,
             commitment: CommitmentReference(commitment),
             eval,
         }
@@ -169,8 +157,5 @@ impl<'com, F: PrimeField, CS: PolynomialCommitmentScheme<F>> Query<F>
     }
     fn get_commitment(&self) -> Self::Commitment {
         self.commitment
-    }
-    fn get_commitment_label(&self) -> CommitmentLabel {
-        self.commitment_label.clone()
     }
 }

--- a/proofs/src/poly/query.rs
+++ b/proofs/src/poly/query.rs
@@ -95,7 +95,7 @@ impl<'com, F: PrimeField> Query<F> for ProverQuery<'com, F> {
 /// A pointer to a commitment, with pointer-based equality.
 ///
 /// Two `CommitmentReference`s are equal iff they point to the same allocation,
-/// so that commitments are grouped by identity rather than by value.
+/// so that commitments are grouped by reference rather than by value.
 #[derive(Debug)]
 pub struct CommitmentReference<'com, F: PrimeField, CS: PolynomialCommitmentScheme<F>>(
     pub(crate) &'com CS::Commitment,

--- a/proofs/src/poly/query.rs
+++ b/proofs/src/poly/query.rs
@@ -96,70 +96,28 @@ impl<'com, F: PrimeField> Query<F> for ProverQuery<'com, F> {
     }
 }
 
-#[derive(Clone, Debug)]
-/// A reference to a polynomial commitment.
+/// A pointer to a commitment, with pointer-based equality.
 ///
-/// A commitment can either be a single piece (`OnePiece`) or a linear
-/// combination of commitments (`Linear`). The linear form is used, e.g., for
-/// the linearization polynomial, whose commitment is expressed as:
-///     * scalars (representing - partially or fully - evaluated identities),
-///       and
-///     * commitments (representing, either, commitments to simple,
-///       multiplicative selectors or the commitment to the constant polynomial
-///       `P(X) = 1`).
-/// The linear combination is given in form of two vectors: one holds references
-/// to the commitments, the other one holds the scalars.
-pub enum CommitmentReference<'com, F: PrimeField, CS: PolynomialCommitmentScheme<F>> {
-    OnePiece(&'com CS::Commitment),
-    Linear(Vec<&'com CS::Commitment>, Vec<F>, Vec<CommitmentLabel>),
+/// Two `CommitmentReference`s are equal iff they point to the same allocation,
+/// so that commitments are grouped by identity rather than by value.
+#[derive(Debug)]
+pub struct CommitmentReference<'com, F: PrimeField, CS: PolynomialCommitmentScheme<F>>(
+    pub(crate) &'com CS::Commitment,
+);
+
+impl<F: PrimeField, CS: PolynomialCommitmentScheme<F>> Copy for CommitmentReference<'_, F, CS> {}
+
+impl<F: PrimeField, CS: PolynomialCommitmentScheme<F>> Clone for CommitmentReference<'_, F, CS> {
+    fn clone(&self) -> Self {
+        *self
+    }
 }
 
 impl<F: PrimeField, CS: PolynomialCommitmentScheme<F>> PartialEq
     for CommitmentReference<'_, F, CS>
 {
     fn eq(&self, other: &Self) -> bool {
-        match (self, other) {
-            (
-                &CommitmentReference::OnePiece(self_com),
-                &CommitmentReference::OnePiece(other_com),
-            ) => std::ptr::eq(self_com, other_com),
-            (
-                CommitmentReference::Linear(self_points, self_scalars, _),
-                CommitmentReference::Linear(other_points, other_scalars, _),
-            ) => (self_points == other_points) && (self_scalars == other_scalars),
-            _ => false,
-        }
-    }
-}
-
-impl<F: PrimeField, CS: PolynomialCommitmentScheme<F>> CommitmentReference<'_, F, CS> {
-    /// Returns the commitment as a list of `(scalar, commitment)` pairs.
-    ///
-    /// If the commitment is represented in one piece, this function returns
-    /// `vec![(F::ONE, com)]`.
-    ///
-    /// If the commitment is a linear combination, this function returns the
-    /// pairs `(scalar_i, commitment_i)`.
-    ///
-    /// # Panics
-    ///
-    /// If the commitment is "linear" and the number of points and the number
-    /// of scalars are not equal.
-    pub(crate) fn as_terms(&self) -> Vec<(F, CS::Commitment)> {
-        match self.clone() {
-            CommitmentReference::OnePiece(com) => {
-                vec![(F::ONE, com.clone())]
-            }
-            CommitmentReference::Linear(points, scalars, _) => {
-                assert_eq!(points.len(), scalars.len());
-
-                let mut terms = Vec::with_capacity(points.len());
-                for (&p, s) in points.iter().zip(scalars.iter()) {
-                    terms.push((*s, p.clone()));
-                }
-                terms
-            }
-        }
+        std::ptr::eq(self.0, other.0)
     }
 }
 
@@ -181,7 +139,7 @@ where
     F: PrimeField,
     CS: PolynomialCommitmentScheme<F>,
 {
-    /// Create a new verifier query based on an optionally labeled commitment.
+    /// Create a new verifier query.
     pub fn new(
         point: F,
         commitment_label: CommitmentLabel,
@@ -191,42 +149,7 @@ where
         VerifierQuery {
             point,
             commitment_label,
-            commitment: CommitmentReference::OnePiece(commitment),
-            eval,
-        }
-    }
-
-    /// Create a new verifier query based on a commitment
-    /// represented in the form of curve points and corresponding
-    /// scalars. Each term carries its own `CommitmentLabel` so that
-    /// downstream consumers (e.g. `from_dual_msm`) can classify
-    /// individual bases correctly.
-    ///
-    /// # panics
-    ///
-    /// If the number of points, scalars, or base_labels differs.
-    pub fn new_linear(
-        point: F,
-        commitment_label: CommitmentLabel,
-        points: Vec<&'com CS::Commitment>,
-        scalars: Vec<F>,
-        base_labels: Vec<CommitmentLabel>,
-        eval: F,
-    ) -> Self {
-        assert_eq!(
-            points.len(),
-            scalars.len(),
-            "The number of points and scalars needs to be equal."
-        );
-        assert_eq!(
-            points.len(),
-            base_labels.len(),
-            "The number of points and base_labels needs to be equal."
-        );
-        VerifierQuery {
-            point,
-            commitment_label,
-            commitment: CommitmentReference::Linear(points, scalars, base_labels),
+            commitment: CommitmentReference(commitment),
             eval,
         }
     }
@@ -245,7 +168,7 @@ impl<'com, F: PrimeField, CS: PolynomialCommitmentScheme<F>> Query<F>
         self.eval
     }
     fn get_commitment(&self) -> Self::Commitment {
-        self.commitment.clone()
+        self.commitment
     }
     fn get_commitment_label(&self) -> CommitmentLabel {
         self.commitment_label.clone()

--- a/proofs/src/utils/helpers.rs
+++ b/proofs/src/utils/helpers.rs
@@ -28,7 +28,7 @@ pub enum SerdeFormat {
 }
 
 /// Interface for Serde objects that can be represented in compressed form.
-pub trait ProcessedSerdeObject: GroupEncoding {
+pub trait ProcessedSerdeObject: Sized {
     /// Reads an element from the buffer and parses it according to the
     /// `format`:
     /// - `Processed`: Reads a compressed element and decompress it
@@ -41,14 +41,9 @@ pub trait ProcessedSerdeObject: GroupEncoding {
     /// - `Processed`: Writes a compressed element
     /// - Otherwise: Writes an uncompressed element
     fn write<W: io::Write>(&self, writer: &mut W, format: SerdeFormat) -> io::Result<()>;
-}
 
-/// Byte length of an affine curve element according to `format`.
-pub fn byte_length<T: ProcessedSerdeObject>(format: SerdeFormat) -> usize {
-    match format {
-        SerdeFormat::Processed => <T as GroupEncoding>::Repr::default().as_ref().len(),
-        _ => <T as GroupEncoding>::Repr::default().as_ref().len() * 2,
-    }
+    /// Length in bytes of an element when serialized in the given `format`.
+    fn byte_length(&self, format: SerdeFormat) -> usize;
 }
 
 /// Helper function to read a field element with a serde format. There is no way
@@ -105,6 +100,13 @@ where
         match format {
             SerdeFormat::Processed => writer.write_all(self.to_bytes().as_ref()),
             _ => self.to_affine().write_raw(writer),
+        }
+    }
+
+    fn byte_length(&self, format: SerdeFormat) -> usize {
+        match format {
+            SerdeFormat::Processed => C::Repr::default().as_ref().len(),
+            _ => C::Repr::default().as_ref().len() * 2,
         }
     }
 }

--- a/zk_stdlib/CHANGELOG.md
+++ b/zk_stdlib/CHANGELOG.md
@@ -24,6 +24,7 @@ verification keys break backwards compatibility.
 * Fix cost model proof size check to account for committed instance columns [#280](https://github.com/midnightntwrk/midnight-zk/pull/280)
 
 ### Changed
+* Adapt to new `KZGCommitment` API [#381](https://github.com/midnightntwrk/midnight-zk/pull/381)
 * Adapt to single-proof prover API [#375](https://github.com/midnightntwrk/midnight-zk/pull/375)
 * Add `nb_arith_cols` field to `ZkStdLibArch` for configurable arithmetic columns (requires `ZKSTD_VERSION` bump before release) [#287](https://github.com/midnightntwrk/midnight-zk/pull/287)
 * Update goldenfiles and static VKs after logup blinding factor fix [#312](https://github.com/midnightntwrk/midnight-zk/pull/312)

--- a/zk_stdlib/examples/identity/jwt/enrollment.rs
+++ b/zk_stdlib/examples/identity/jwt/enrollment.rs
@@ -201,6 +201,7 @@ fn main() {
     let committed_credential: G1Affine = {
         let instance = CredentialEnrollment::format_committed_instances(&witness);
         commit_to_instances::<_, KZGCommitmentScheme<_>>(&srs, vk.vk().get_domain(), &instance)
+            .into_point()
             .into()
     };
     println!("... done\n{:?}", wit.elapsed());

--- a/zk_stdlib/examples/identity/jwt/property_check.rs
+++ b/zk_stdlib/examples/identity/jwt/property_check.rs
@@ -341,6 +341,7 @@ fn main() {
     let committed_credential: G1Affine = {
         let instance = CredentialProperty::format_committed_instances(&witness);
         commit_to_instances::<_, KZGCommitmentScheme<_>>(&srs, vk.vk().get_domain(), &instance)
+            .into_point()
             .into()
     };
     println!("... done ({:?})", wit.elapsed());

--- a/zk_stdlib/src/lib.rs
+++ b/zk_stdlib/src/lib.rs
@@ -2094,7 +2094,12 @@ where
                 CircuitTranscript<H>,
             >(
                 &vk.vk,
-                &[midnight_curves::G1Projective::identity()],
+                &[
+                    midnight_proofs::poly::kzg::commitment::KZGCommitment::Simple(
+                        midnight_curves::G1Projective::identity(),
+                        midnight_proofs::poly::CommitmentLabel::NoLabel,
+                    ),
+                ],
                 &[pi],
                 &mut transcript,
             )?;

--- a/zk_stdlib/src/utils/plonk_api.rs
+++ b/zk_stdlib/src/utils/plonk_api.rs
@@ -31,9 +31,11 @@ use midnight_proofs::{
     poly::{
         commitment::Guard,
         kzg::{
+            commitment::KZGCommitment,
             params::{ParamsKZG, ParamsVerifierKZG},
             KZGCommitmentScheme,
         },
+        CommitmentLabel,
     },
     transcript::{CircuitTranscript, Hashable, Sampleable, Transcript, TranscriptHash},
     utils::SerdeFormat,
@@ -147,7 +149,10 @@ macro_rules! plonk_api {
                 let start = Instant::now();
                 let res = prepare::<$native, KZGCommitmentScheme<$engine>, CircuitTranscript<H>>(
                     vk,
-                    &instance_commitments.iter().map(|c| c.into()).collect::<Vec<_>>(),
+                    &instance_commitments
+                        .iter()
+                        .map(|c| KZGCommitment::Simple((*c).into(), CommitmentLabel::NoLabel))
+                        .collect::<Vec<_>>(),
                     pi,
                     &mut transcript,
                 )?;


### PR DESCRIPTION
Move commitment labels to actual commitments (and not queries).

Move `OnePiece`/`Linear` abstraction to KZG commitments (through a new `KZGCommitment` enum), simplifying the type of `CommitmentReference`.

This allows us to truly use the homomorphic requirements in the PCS which were not being used before (the homomorphic property of KZG commitments was hard-coded in the multi-open argument).
