### PR TITLE
Implement various traits for `AssignedScalar` of the native ECC chip

### DIFF
--- a/circuits/CHANGELOG.md
+++ b/circuits/CHANGELOG.md
@@ -12,6 +12,7 @@ verification keys break backwards compatibility.
 
 ## [Unreleased]
 ### Added
+* Implement `AssertionInstructions`, `EqualityInstructions`, `ZeroInstructions`, `ControlFlowInstructions` and `ArithInstructions` for `AssignedScalarOfNativeCurve` on `EccChip` [#383](https://github.com/midnightntwrk/midnight-zk/pull/383)
 
 ### Changed
 

--- a/circuits/goldenfiles/cost-model.json
+++ b/circuits/goldenfiles/cost-model.json
@@ -3541,7 +3541,7 @@
       "max_deg": "5",
       "permutations": "10",
       "point_sets": "4",
-      "rows": "481",
+      "rows": "321",
       "table_rows": "455"
     },
     "add_and_mul": {
@@ -3552,7 +3552,7 @@
       "max_deg": "5",
       "permutations": "10",
       "point_sets": "4",
-      "rows": "1442",
+      "rows": "965",
       "table_rows": "455"
     },
     "add_constant": {
@@ -3563,7 +3563,7 @@
       "max_deg": "5",
       "permutations": "10",
       "point_sets": "4",
-      "rows": "522",
+      "rows": "362",
       "table_rows": "455"
     },
     "assert_eq": {
@@ -3640,7 +3640,7 @@
       "max_deg": "5",
       "permutations": "11",
       "point_sets": "4",
-      "rows": "898",
+      "rows": "578",
       "table_rows": "455"
     },
     "cond_swap": {
@@ -3651,7 +3651,7 @@
       "max_deg": "5",
       "permutations": "11",
       "point_sets": "4",
-      "rows": "1400",
+      "rows": "760",
       "table_rows": "455"
     },
     "div": {
@@ -3662,7 +3662,7 @@
       "max_deg": "5",
       "permutations": "10",
       "point_sets": "4",
-      "rows": "653",
+      "rows": "333",
       "table_rows": "455"
     },
     "inv": {
@@ -3673,7 +3673,7 @@
       "max_deg": "5",
       "permutations": "10",
       "point_sets": "4",
-      "rows": "743",
+      "rows": "423",
       "table_rows": "455"
     },
     "is_equal": {
@@ -3739,7 +3739,7 @@
       "max_deg": "5",
       "permutations": "10",
       "point_sets": "4",
-      "rows": "1032",
+      "rows": "712",
       "table_rows": "487"
     },
     "mul": {
@@ -3750,7 +3750,7 @@
       "max_deg": "5",
       "permutations": "10",
       "point_sets": "4",
-      "rows": "485",
+      "rows": "325",
       "table_rows": "455"
     },
     "mul_by_const": {
@@ -3761,7 +3761,7 @@
       "max_deg": "5",
       "permutations": "10",
       "point_sets": "4",
-      "rows": "523",
+      "rows": "363",
       "table_rows": "455"
     },
     "neg": {
@@ -3772,7 +3772,7 @@
       "max_deg": "5",
       "permutations": "10",
       "point_sets": "4",
-      "rows": "636",
+      "rows": "476",
       "table_rows": "455"
     },
     "pow": {
@@ -3783,7 +3783,7 @@
       "max_deg": "5",
       "permutations": "10",
       "point_sets": "4",
-      "rows": "798",
+      "rows": "478",
       "table_rows": "455"
     },
     "public_inputs": {
@@ -3805,7 +3805,7 @@
       "max_deg": "5",
       "permutations": "11",
       "point_sets": "4",
-      "rows": "700",
+      "rows": "380",
       "table_rows": "455"
     },
     "sub": {
@@ -3816,7 +3816,7 @@
       "max_deg": "5",
       "permutations": "10",
       "point_sets": "4",
-      "rows": "600",
+      "rows": "440",
       "table_rows": "455"
     }
   },

--- a/circuits/goldenfiles/cost-model.json
+++ b/circuits/goldenfiles/cost-model.json
@@ -3541,7 +3541,7 @@
       "max_deg": "5",
       "permutations": "10",
       "point_sets": "4",
-      "rows": "702",
+      "rows": "481",
       "table_rows": "455"
     },
     "add_and_mul": {
@@ -3552,7 +3552,7 @@
       "max_deg": "5",
       "permutations": "10",
       "point_sets": "4",
-      "rows": "1889",
+      "rows": "1442",
       "table_rows": "455"
     },
     "add_constant": {
@@ -3662,7 +3662,7 @@
       "max_deg": "5",
       "permutations": "10",
       "point_sets": "4",
-      "rows": "852",
+      "rows": "653",
       "table_rows": "455"
     },
     "inv": {
@@ -3673,7 +3673,7 @@
       "max_deg": "5",
       "permutations": "10",
       "point_sets": "4",
-      "rows": "844",
+      "rows": "743",
       "table_rows": "455"
     },
     "is_equal": {
@@ -3750,7 +3750,7 @@
       "max_deg": "5",
       "permutations": "10",
       "point_sets": "4",
-      "rows": "684",
+      "rows": "485",
       "table_rows": "455"
     },
     "mul_by_const": {
@@ -3816,7 +3816,7 @@
       "max_deg": "5",
       "permutations": "10",
       "point_sets": "4",
-      "rows": "791",
+      "rows": "600",
       "table_rows": "455"
     }
   },

--- a/circuits/goldenfiles/cost-model.json
+++ b/circuits/goldenfiles/cost-model.json
@@ -120,17 +120,6 @@
       "rows": "100",
       "table_rows": "257"
     },
-    "static parsing perf (input length = 50)": {
-      "advice_columns": "5",
-      "column_queries": "56",
-      "fixed_columns": "32",
-      "lookups": "6",
-      "max_deg": "5",
-      "permutations": "8",
-      "point_sets": "4",
-      "rows": "75",
-      "table_rows": "315"
-    },
     "substring perf (full length = 16, sub length = 5)": {
       "advice_columns": "6",
       "column_queries": "66",
@@ -140,17 +129,6 @@
       "permutations": "9",
       "point_sets": "4",
       "rows": "39",
-      "table_rows": "257"
-    },
-    "substring perf (full length = 65, sub length = 50)": {
-      "advice_columns": "6",
-      "column_queries": "66",
-      "fixed_columns": "33",
-      "lookups": "9",
-      "max_deg": "5",
-      "permutations": "9",
-      "point_sets": "4",
-      "rows": "156",
       "table_rows": "257"
     },
     "varlen full substring perf (M_SEQ = 16, M_SUB = 8, sub length = 5)": {

--- a/circuits/goldenfiles/cost-model.json
+++ b/circuits/goldenfiles/cost-model.json
@@ -3552,7 +3552,7 @@
       "max_deg": "5",
       "permutations": "10",
       "point_sets": "4",
-      "rows": "419",
+      "rows": "259",
       "table_rows": "455"
     },
     "assert_eq_fixed": {
@@ -3574,7 +3574,7 @@
       "max_deg": "5",
       "permutations": "10",
       "point_sets": "4",
-      "rows": "427",
+      "rows": "267",
       "table_rows": "455"
     },
     "assert_neq_fixed": {
@@ -3596,8 +3596,8 @@
       "max_deg": "5",
       "permutations": "11",
       "point_sets": "4",
-      "rows": "204",
-      "table_rows": "455"
+      "rows": "44",
+      "table_rows": "2"
     },
     "assert_zero": {
       "advice_columns": "9",
@@ -3607,8 +3607,8 @@
       "max_deg": "5",
       "permutations": "11",
       "point_sets": "4",
-      "rows": "196",
-      "table_rows": "455"
+      "rows": "36",
+      "table_rows": "2"
     },
     "cond_assert_equal": {
       "advice_columns": "9",
@@ -3618,8 +3618,8 @@
       "max_deg": "5",
       "permutations": "11",
       "point_sets": "4",
-      "rows": "578",
-      "table_rows": "455"
+      "rows": "255",
+      "table_rows": "3"
     },
     "cond_swap": {
       "advice_columns": "9",
@@ -3629,8 +3629,8 @@
       "max_deg": "5",
       "permutations": "11",
       "point_sets": "4",
-      "rows": "760",
-      "table_rows": "455"
+      "rows": "434",
+      "table_rows": "8"
     },
     "div": {
       "advice_columns": "9",
@@ -3662,8 +3662,8 @@
       "max_deg": "5",
       "permutations": "11",
       "point_sets": "4",
-      "rows": "400",
-      "table_rows": "455"
+      "rows": "80",
+      "table_rows": "2"
     },
     "is_equal_to_fixed": {
       "advice_columns": "9",
@@ -3673,8 +3673,8 @@
       "max_deg": "5",
       "permutations": "11",
       "point_sets": "4",
-      "rows": "204",
-      "table_rows": "455"
+      "rows": "44",
+      "table_rows": "2"
     },
     "is_not_equal": {
       "advice_columns": "9",
@@ -3684,8 +3684,8 @@
       "max_deg": "5",
       "permutations": "11",
       "point_sets": "4",
-      "rows": "401",
-      "table_rows": "455"
+      "rows": "81",
+      "table_rows": "2"
     },
     "is_not_equal_to_fixed": {
       "advice_columns": "9",
@@ -3695,8 +3695,8 @@
       "max_deg": "5",
       "permutations": "11",
       "point_sets": "4",
-      "rows": "205",
-      "table_rows": "455"
+      "rows": "45",
+      "table_rows": "2"
     },
     "is_zero": {
       "advice_columns": "9",
@@ -3706,8 +3706,8 @@
       "max_deg": "5",
       "permutations": "11",
       "point_sets": "4",
-      "rows": "204",
-      "table_rows": "455"
+      "rows": "44",
+      "table_rows": "2"
     },
     "linear_comb": {
       "advice_columns": "9",
@@ -3783,8 +3783,8 @@
       "max_deg": "5",
       "permutations": "11",
       "point_sets": "4",
-      "rows": "380",
-      "table_rows": "455"
+      "rows": "217",
+      "table_rows": "5"
     },
     "sub": {
       "advice_columns": "9",

--- a/circuits/goldenfiles/cost-model.json
+++ b/circuits/goldenfiles/cost-model.json
@@ -3532,6 +3532,294 @@
       "table_rows": "4"
     }
   },
+  "native_ecc_scalar": {
+    "add": {
+      "advice_columns": "9",
+      "column_queries": "51",
+      "fixed_columns": "30",
+      "lookups": "4",
+      "max_deg": "5",
+      "permutations": "10",
+      "point_sets": "4",
+      "rows": "702",
+      "table_rows": "455"
+    },
+    "add_and_mul": {
+      "advice_columns": "9",
+      "column_queries": "51",
+      "fixed_columns": "30",
+      "lookups": "4",
+      "max_deg": "5",
+      "permutations": "10",
+      "point_sets": "4",
+      "rows": "1889",
+      "table_rows": "455"
+    },
+    "add_constant": {
+      "advice_columns": "9",
+      "column_queries": "51",
+      "fixed_columns": "30",
+      "lookups": "4",
+      "max_deg": "5",
+      "permutations": "10",
+      "point_sets": "4",
+      "rows": "522",
+      "table_rows": "455"
+    },
+    "assert_eq": {
+      "advice_columns": "9",
+      "column_queries": "51",
+      "fixed_columns": "30",
+      "lookups": "4",
+      "max_deg": "5",
+      "permutations": "10",
+      "point_sets": "4",
+      "rows": "419",
+      "table_rows": "455"
+    },
+    "assert_eq_fixed": {
+      "advice_columns": "9",
+      "column_queries": "51",
+      "fixed_columns": "30",
+      "lookups": "4",
+      "max_deg": "5",
+      "permutations": "10",
+      "point_sets": "4",
+      "rows": "223",
+      "table_rows": "455"
+    },
+    "assert_neq": {
+      "advice_columns": "9",
+      "column_queries": "51",
+      "fixed_columns": "30",
+      "lookups": "4",
+      "max_deg": "5",
+      "permutations": "10",
+      "point_sets": "4",
+      "rows": "427",
+      "table_rows": "455"
+    },
+    "assert_neq_fixed": {
+      "advice_columns": "9",
+      "column_queries": "51",
+      "fixed_columns": "30",
+      "lookups": "4",
+      "max_deg": "5",
+      "permutations": "10",
+      "point_sets": "4",
+      "rows": "231",
+      "table_rows": "455"
+    },
+    "assert_non_zero": {
+      "advice_columns": "9",
+      "column_queries": "52",
+      "fixed_columns": "32",
+      "lookups": "4",
+      "max_deg": "5",
+      "permutations": "11",
+      "point_sets": "4",
+      "rows": "204",
+      "table_rows": "455"
+    },
+    "assert_zero": {
+      "advice_columns": "9",
+      "column_queries": "52",
+      "fixed_columns": "32",
+      "lookups": "4",
+      "max_deg": "5",
+      "permutations": "11",
+      "point_sets": "4",
+      "rows": "196",
+      "table_rows": "455"
+    },
+    "cond_assert_equal": {
+      "advice_columns": "9",
+      "column_queries": "51",
+      "fixed_columns": "31",
+      "lookups": "4",
+      "max_deg": "5",
+      "permutations": "11",
+      "point_sets": "4",
+      "rows": "898",
+      "table_rows": "455"
+    },
+    "cond_swap": {
+      "advice_columns": "9",
+      "column_queries": "51",
+      "fixed_columns": "31",
+      "lookups": "4",
+      "max_deg": "5",
+      "permutations": "11",
+      "point_sets": "4",
+      "rows": "1400",
+      "table_rows": "455"
+    },
+    "div": {
+      "advice_columns": "9",
+      "column_queries": "51",
+      "fixed_columns": "30",
+      "lookups": "4",
+      "max_deg": "5",
+      "permutations": "10",
+      "point_sets": "4",
+      "rows": "852",
+      "table_rows": "455"
+    },
+    "inv": {
+      "advice_columns": "9",
+      "column_queries": "51",
+      "fixed_columns": "30",
+      "lookups": "4",
+      "max_deg": "5",
+      "permutations": "10",
+      "point_sets": "4",
+      "rows": "844",
+      "table_rows": "455"
+    },
+    "is_equal": {
+      "advice_columns": "9",
+      "column_queries": "52",
+      "fixed_columns": "32",
+      "lookups": "4",
+      "max_deg": "5",
+      "permutations": "11",
+      "point_sets": "4",
+      "rows": "400",
+      "table_rows": "455"
+    },
+    "is_equal_to_fixed": {
+      "advice_columns": "9",
+      "column_queries": "52",
+      "fixed_columns": "32",
+      "lookups": "4",
+      "max_deg": "5",
+      "permutations": "11",
+      "point_sets": "4",
+      "rows": "204",
+      "table_rows": "455"
+    },
+    "is_not_equal": {
+      "advice_columns": "9",
+      "column_queries": "52",
+      "fixed_columns": "32",
+      "lookups": "4",
+      "max_deg": "5",
+      "permutations": "11",
+      "point_sets": "4",
+      "rows": "401",
+      "table_rows": "455"
+    },
+    "is_not_equal_to_fixed": {
+      "advice_columns": "9",
+      "column_queries": "52",
+      "fixed_columns": "32",
+      "lookups": "4",
+      "max_deg": "5",
+      "permutations": "11",
+      "point_sets": "4",
+      "rows": "205",
+      "table_rows": "455"
+    },
+    "is_zero": {
+      "advice_columns": "9",
+      "column_queries": "52",
+      "fixed_columns": "32",
+      "lookups": "4",
+      "max_deg": "5",
+      "permutations": "11",
+      "point_sets": "4",
+      "rows": "204",
+      "table_rows": "455"
+    },
+    "linear_comb": {
+      "advice_columns": "9",
+      "column_queries": "51",
+      "fixed_columns": "30",
+      "lookups": "4",
+      "max_deg": "5",
+      "permutations": "10",
+      "point_sets": "4",
+      "rows": "1032",
+      "table_rows": "487"
+    },
+    "mul": {
+      "advice_columns": "9",
+      "column_queries": "51",
+      "fixed_columns": "30",
+      "lookups": "4",
+      "max_deg": "5",
+      "permutations": "10",
+      "point_sets": "4",
+      "rows": "684",
+      "table_rows": "455"
+    },
+    "mul_by_const": {
+      "advice_columns": "9",
+      "column_queries": "51",
+      "fixed_columns": "30",
+      "lookups": "4",
+      "max_deg": "5",
+      "permutations": "10",
+      "point_sets": "4",
+      "rows": "523",
+      "table_rows": "455"
+    },
+    "neg": {
+      "advice_columns": "9",
+      "column_queries": "51",
+      "fixed_columns": "30",
+      "lookups": "4",
+      "max_deg": "5",
+      "permutations": "10",
+      "point_sets": "4",
+      "rows": "636",
+      "table_rows": "455"
+    },
+    "pow": {
+      "advice_columns": "9",
+      "column_queries": "51",
+      "fixed_columns": "30",
+      "lookups": "4",
+      "max_deg": "5",
+      "permutations": "10",
+      "point_sets": "4",
+      "rows": "798",
+      "table_rows": "455"
+    },
+    "public_inputs": {
+      "advice_columns": "9",
+      "column_queries": "51",
+      "fixed_columns": "30",
+      "lookups": "4",
+      "max_deg": "5",
+      "permutations": "10",
+      "point_sets": "4",
+      "rows": "126",
+      "table_rows": "3"
+    },
+    "select": {
+      "advice_columns": "9",
+      "column_queries": "51",
+      "fixed_columns": "31",
+      "lookups": "4",
+      "max_deg": "5",
+      "permutations": "11",
+      "point_sets": "4",
+      "rows": "700",
+      "table_rows": "455"
+    },
+    "sub": {
+      "advice_columns": "9",
+      "column_queries": "51",
+      "fixed_columns": "30",
+      "lookups": "4",
+      "max_deg": "5",
+      "permutations": "10",
+      "point_sets": "4",
+      "rows": "791",
+      "table_rows": "455"
+    }
+  },
   "native_gadget_bls": {
     "assert_lower_than": {
       "advice_columns": "5",
@@ -3752,19 +4040,6 @@
       "point_sets": "4",
       "rows": "2",
       "table_rows": "257"
-    }
-  },
-  "public_inputs_scalar_var": {
-    "public_inputs": {
-      "advice_columns": "9",
-      "column_queries": "51",
-      "fixed_columns": "30",
-      "lookups": "4",
-      "max_deg": "5",
-      "permutations": "10",
-      "point_sets": "4",
-      "rows": "126",
-      "table_rows": "3"
     }
   }
 }

--- a/circuits/src/ecc/foreign/edwards_chip.rs
+++ b/circuits/src/ecc/foreign/edwards_chip.rs
@@ -233,7 +233,7 @@ where
     /// most significant bit of the final byte of the y-coordinate.
     ///
     /// # Returns
-    /// An array [AssignedByte<F>; 32] constrained to represent a canonical
+    /// An array [`AssignedByte<F>`; 32] constrained to represent a canonical
     /// encoding.
     pub fn to_canonical_compressed_bytes(
         &self,
@@ -287,7 +287,7 @@ where
     ///
     /// # Unsatisfiable Circuit
     /// If the given array of [AssignedByte] is a non-canonical encoding of the
-    /// point provided by [Value<Curve25519Subgroup>].
+    /// point provided by [`Value<Curve25519Subgroup>`].
     pub fn from_canonical_compressed_bytes(
         &self,
         layouter: &mut impl Layouter<F>,

--- a/circuits/src/ecc/native/edwards_chip.rs
+++ b/circuits/src/ecc/native/edwards_chip.rs
@@ -198,7 +198,7 @@ impl<C: CircuitCurve> AssignedScalarOfNativeCurve<C> {
 
     /// Constructs an [`AssignedScalarOfNativeCurve`] from an
     /// [`AssignedBigUint`]. The result is not guaranteed to be canonical but is
-    /// guaranteed to have at most [`C::ScalarField::NUM_BITS`] bits.
+    /// guaranteed to have at most `C::ScalarField::NUM_BITS` bits.
     fn from_biguint(
         layouter: &mut impl Layouter<C::Base>,
         biguint_gadget: &BigUintGadget<C::Base, NG<C::Base>>,

--- a/circuits/src/ecc/native/edwards_chip.rs
+++ b/circuits/src/ecc/native/edwards_chip.rs
@@ -171,32 +171,45 @@ fn reduce_biguint_mod_scalar_order<C: CircuitCurve>(
 }
 
 impl<C: CircuitCurve> AssignedScalarOfNativeCurve<C> {
-    /// Converts the given scalar to a BigUint reduced modulo the scalar field
-    /// order.
-    fn to_reduced_biguint(
+    /// Converts the scalar's bits into an [`AssignedBigUint`].
+    /// The result is not guaranteed to be in canonical form (i.e. it may
+    /// represent a value greater than or equal to the scalar field order).
+    fn into_biguint(
+        &self,
+        layouter: &mut impl Layouter<C::Base>,
+        biguint_gadget: &BigUintGadget<C::Base, NG<C::Base>>,
+    ) -> Result<AssignedBigUint<C::Base>, Error> {
+        biguint_gadget.from_le_bits(layouter, &self.bits)
+    }
+
+    /// Converts the scalar's bits into an [`AssignedBigUint`].
+    /// The result is guaranteed to be in canonical form.
+    fn into_canonical_biguint(
         &self,
         layouter: &mut impl Layouter<C::Base>,
         biguint_gadget: &BigUintGadget<C::Base, NG<C::Base>>,
     ) -> Result<AssignedBigUint<C::Base>, Error> {
         let s = biguint_gadget.from_le_bits(layouter, &self.bits)?;
-        if self.bits.len() < C::ScalarField::NUM_BITS as usize {
-            return Ok(s);
-        }
         reduce_biguint_mod_scalar_order::<C>(layouter, biguint_gadget, &s)
     }
 
     /// Constructs an [`AssignedScalarOfNativeCurve`] from an
-    /// [`AssignedBigUint`], reducing it modulo the scalar field order if
-    /// necessary to ensure the resulting bit representation is canonical.
+    /// [`AssignedBigUint`]. The result is not guaranteed to be canonical but is
+    /// guaranteed to have at most [`C::ScalarField::NUM_BITS`] bits.
     fn from_biguint(
         layouter: &mut impl Layouter<C::Base>,
         biguint_gadget: &BigUintGadget<C::Base, NG<C::Base>>,
         s: &AssignedBigUint<C::Base>,
     ) -> Result<Self, Error> {
-        let s = reduce_biguint_mod_scalar_order::<C>(layouter, biguint_gadget, s)?;
+        let mut s = s.clone();
+        let mut enforced_canonical = false;
+        if s.nb_bits() > C::ScalarField::NUM_BITS {
+            s = reduce_biguint_mod_scalar_order::<C>(layouter, biguint_gadget, &s)?;
+            enforced_canonical = true;
+        }
         Ok(AssignedScalarOfNativeCurve {
             bits: biguint_gadget.to_le_bits(layouter, &s)?,
-            enforced_canonical: true,
+            enforced_canonical,
         })
     }
 }
@@ -904,8 +917,8 @@ impl<C: EdwardsCurve> AssertionInstructions<C::Base, AssignedScalarOfNativeCurve
         r: &AssignedScalarOfNativeCurve<C>,
         s: &AssignedScalarOfNativeCurve<C>,
     ) -> Result<(), Error> {
-        let r = r.to_reduced_biguint(layouter, &self.biguint_gadget)?;
-        let s = s.to_reduced_biguint(layouter, &self.biguint_gadget)?;
+        let r = r.into_canonical_biguint(layouter, &self.biguint_gadget)?;
+        let s = s.into_canonical_biguint(layouter, &self.biguint_gadget)?;
         self.biguint_gadget.assert_equal(layouter, &r, &s)
     }
 
@@ -915,8 +928,8 @@ impl<C: EdwardsCurve> AssertionInstructions<C::Base, AssignedScalarOfNativeCurve
         r: &AssignedScalarOfNativeCurve<C>,
         s: &AssignedScalarOfNativeCurve<C>,
     ) -> Result<(), Error> {
-        let r = r.to_reduced_biguint(layouter, &self.biguint_gadget)?;
-        let s = s.to_reduced_biguint(layouter, &self.biguint_gadget)?;
+        let r = r.into_canonical_biguint(layouter, &self.biguint_gadget)?;
+        let s = s.into_canonical_biguint(layouter, &self.biguint_gadget)?;
         self.biguint_gadget.assert_not_equal(layouter, &r, &s)
     }
 
@@ -926,7 +939,7 @@ impl<C: EdwardsCurve> AssertionInstructions<C::Base, AssignedScalarOfNativeCurve
         s: &AssignedScalarOfNativeCurve<C>,
         constant: C::ScalarField,
     ) -> Result<(), Error> {
-        let s = s.to_reduced_biguint(layouter, &self.biguint_gadget)?;
+        let s = s.into_canonical_biguint(layouter, &self.biguint_gadget)?;
         self.biguint_gadget.assert_equal_to_fixed(layouter, &s, constant.to_biguint())
     }
 
@@ -936,7 +949,7 @@ impl<C: EdwardsCurve> AssertionInstructions<C::Base, AssignedScalarOfNativeCurve
         s: &AssignedScalarOfNativeCurve<C>,
         constant: C::ScalarField,
     ) -> Result<(), Error> {
-        let s = s.to_reduced_biguint(layouter, &self.biguint_gadget)?;
+        let s = s.into_canonical_biguint(layouter, &self.biguint_gadget)?;
         self.biguint_gadget
             .assert_not_equal_to_fixed(layouter, &s, constant.to_biguint())
     }
@@ -1074,8 +1087,8 @@ impl<C: EdwardsCurve> EqualityInstructions<C::Base, AssignedScalarOfNativeCurve<
         r: &AssignedScalarOfNativeCurve<C>,
         s: &AssignedScalarOfNativeCurve<C>,
     ) -> Result<AssignedBit<C::Base>, Error> {
-        let r = r.to_reduced_biguint(layouter, &self.biguint_gadget)?;
-        let s = s.to_reduced_biguint(layouter, &self.biguint_gadget)?;
+        let r = r.into_canonical_biguint(layouter, &self.biguint_gadget)?;
+        let s = s.into_canonical_biguint(layouter, &self.biguint_gadget)?;
         self.biguint_gadget.is_equal(layouter, &r, &s)
     }
 
@@ -1085,8 +1098,8 @@ impl<C: EdwardsCurve> EqualityInstructions<C::Base, AssignedScalarOfNativeCurve<
         r: &AssignedScalarOfNativeCurve<C>,
         s: &AssignedScalarOfNativeCurve<C>,
     ) -> Result<AssignedBit<C::Base>, Error> {
-        let r = r.to_reduced_biguint(layouter, &self.biguint_gadget)?;
-        let s = s.to_reduced_biguint(layouter, &self.biguint_gadget)?;
+        let r = r.into_canonical_biguint(layouter, &self.biguint_gadget)?;
+        let s = s.into_canonical_biguint(layouter, &self.biguint_gadget)?;
         self.biguint_gadget.is_not_equal(layouter, &s, &r)
     }
 
@@ -1096,7 +1109,7 @@ impl<C: EdwardsCurve> EqualityInstructions<C::Base, AssignedScalarOfNativeCurve<
         s: &AssignedScalarOfNativeCurve<C>,
         constant: C::ScalarField,
     ) -> Result<AssignedBit<C::Base>, Error> {
-        let s = s.to_reduced_biguint(layouter, &self.biguint_gadget)?;
+        let s = s.into_canonical_biguint(layouter, &self.biguint_gadget)?;
         self.biguint_gadget.is_equal_to_fixed(layouter, &s, constant.to_biguint())
     }
 
@@ -1106,7 +1119,7 @@ impl<C: EdwardsCurve> EqualityInstructions<C::Base, AssignedScalarOfNativeCurve<
         s: &AssignedScalarOfNativeCurve<C>,
         constant: C::ScalarField,
     ) -> Result<AssignedBit<C::Base>, Error> {
-        let s = s.to_reduced_biguint(layouter, &self.biguint_gadget)?;
+        let s = s.into_canonical_biguint(layouter, &self.biguint_gadget)?;
         self.biguint_gadget.is_not_equal_to_fixed(layouter, &s, constant.to_biguint())
     }
 }
@@ -1124,7 +1137,7 @@ impl<C: EdwardsCurve> ArithInstructions<C::Base, AssignedScalarOfNativeCurve<C>>
         let mut acc = self.biguint_gadget.assign_fixed_biguint(layouter, constant.to_biguint())?;
 
         for (c, s) in terms {
-            let s = s.to_reduced_biguint(layouter, &self.biguint_gadget)?;
+            let s = s.into_biguint(layouter, &self.biguint_gadget)?;
             let c = self.biguint_gadget.assign_fixed_biguint(layouter, c.to_biguint())?;
             let c_times_s = self.biguint_gadget.mul(layouter, &c, &s)?;
             acc = self.biguint_gadget.add(layouter, &acc, &c_times_s)?;
@@ -1139,8 +1152,8 @@ impl<C: EdwardsCurve> ArithInstructions<C::Base, AssignedScalarOfNativeCurve<C>>
         r: &AssignedScalarOfNativeCurve<C>,
         s: &AssignedScalarOfNativeCurve<C>,
     ) -> Result<AssignedScalarOfNativeCurve<C>, Error> {
-        let r = r.to_reduced_biguint(layouter, &self.biguint_gadget)?;
-        let s = s.to_reduced_biguint(layouter, &self.biguint_gadget)?;
+        let r = r.into_biguint(layouter, &self.biguint_gadget)?;
+        let s = s.into_biguint(layouter, &self.biguint_gadget)?;
         let res = self.biguint_gadget.add(layouter, &r, &s)?;
         AssignedScalarOfNativeCurve::from_biguint(layouter, &self.biguint_gadget, &res)
     }
@@ -1152,8 +1165,8 @@ impl<C: EdwardsCurve> ArithInstructions<C::Base, AssignedScalarOfNativeCurve<C>>
         s: &AssignedScalarOfNativeCurve<C>,
         multiplying_constant: Option<C::ScalarField>,
     ) -> Result<AssignedScalarOfNativeCurve<C>, Error> {
-        let r = r.to_reduced_biguint(layouter, &self.biguint_gadget)?;
-        let s = s.to_reduced_biguint(layouter, &self.biguint_gadget)?;
+        let r = r.into_biguint(layouter, &self.biguint_gadget)?;
+        let s = s.into_biguint(layouter, &self.biguint_gadget)?;
         let mut res = self.biguint_gadget.mul(layouter, &r, &s)?;
 
         if let Some(c) = multiplying_constant {
@@ -1179,8 +1192,8 @@ impl<C: EdwardsCurve> ArithInstructions<C::Base, AssignedScalarOfNativeCurve<C>>
             C::ScalarField::NUM_BITS,
         )?;
 
-        let r = r.to_reduced_biguint(layouter, &self.biguint_gadget)?;
-        let s = s.to_reduced_biguint(layouter, &self.biguint_gadget)?;
+        let r = r.into_biguint(layouter, &self.biguint_gadget)?;
+        let s = s.into_biguint(layouter, &self.biguint_gadget)?;
         let res_times_s = self.biguint_gadget.mul(layouter, &res, &s)?;
         let reduced_res_times_s =
             reduce_biguint_mod_scalar_order::<C>(layouter, &self.biguint_gadget, &res_times_s)?;
@@ -1246,8 +1259,8 @@ impl<C: EdwardsCurve> ControlFlowInstructions<C::Base, AssignedScalarOfNativeCur
         a: &AssignedScalarOfNativeCurve<C>,
         b: &AssignedScalarOfNativeCurve<C>,
     ) -> Result<AssignedScalarOfNativeCurve<C>, Error> {
-        let a_as_big = a.to_reduced_biguint(layouter, &self.biguint_gadget)?;
-        let b_as_big = b.to_reduced_biguint(layouter, &self.biguint_gadget)?;
+        let a_as_big = a.into_biguint(layouter, &self.biguint_gadget)?;
+        let b_as_big = b.into_biguint(layouter, &self.biguint_gadget)?;
         let selected = self.biguint_gadget.select(layouter, cond, &a_as_big, &b_as_big)?;
         Ok(AssignedScalarOfNativeCurve {
             bits: self.biguint_gadget.to_le_bits(layouter, &selected)?,

--- a/circuits/src/ecc/native/edwards_chip.rs
+++ b/circuits/src/ecc/native/edwards_chip.rs
@@ -190,6 +190,9 @@ impl<C: CircuitCurve> AssignedScalarOfNativeCurve<C> {
         biguint_gadget: &BigUintGadget<C::Base, NG<C::Base>>,
     ) -> Result<AssignedBigUint<C::Base>, Error> {
         let s = biguint_gadget.from_le_bits(layouter, &self.bits)?;
+        if self.enforced_canonical {
+            return Ok(s);
+        }
         reduce_biguint_mod_scalar_order::<C>(layouter, biguint_gadget, &s)
     }
 

--- a/circuits/src/ecc/native/edwards_chip.rs
+++ b/circuits/src/ecc/native/edwards_chip.rs
@@ -174,7 +174,7 @@ impl<C: CircuitCurve> AssignedScalarOfNativeCurve<C> {
     /// Converts the scalar's bits into an [`AssignedBigUint`].
     /// The result is not guaranteed to be in canonical form (i.e. it may
     /// represent a value greater than or equal to the scalar field order).
-    fn into_biguint(
+    fn to_biguint(
         &self,
         layouter: &mut impl Layouter<C::Base>,
         biguint_gadget: &BigUintGadget<C::Base, NG<C::Base>>,
@@ -184,7 +184,7 @@ impl<C: CircuitCurve> AssignedScalarOfNativeCurve<C> {
 
     /// Converts the scalar's bits into an [`AssignedBigUint`].
     /// The result is guaranteed to be in canonical form.
-    fn into_canonical_biguint(
+    fn to_canonical_biguint(
         &self,
         layouter: &mut impl Layouter<C::Base>,
         biguint_gadget: &BigUintGadget<C::Base, NG<C::Base>>,
@@ -917,8 +917,8 @@ impl<C: EdwardsCurve> AssertionInstructions<C::Base, AssignedScalarOfNativeCurve
         r: &AssignedScalarOfNativeCurve<C>,
         s: &AssignedScalarOfNativeCurve<C>,
     ) -> Result<(), Error> {
-        let r = r.into_canonical_biguint(layouter, &self.biguint_gadget)?;
-        let s = s.into_canonical_biguint(layouter, &self.biguint_gadget)?;
+        let r = r.to_canonical_biguint(layouter, &self.biguint_gadget)?;
+        let s = s.to_canonical_biguint(layouter, &self.biguint_gadget)?;
         self.biguint_gadget.assert_equal(layouter, &r, &s)
     }
 
@@ -928,8 +928,8 @@ impl<C: EdwardsCurve> AssertionInstructions<C::Base, AssignedScalarOfNativeCurve
         r: &AssignedScalarOfNativeCurve<C>,
         s: &AssignedScalarOfNativeCurve<C>,
     ) -> Result<(), Error> {
-        let r = r.into_canonical_biguint(layouter, &self.biguint_gadget)?;
-        let s = s.into_canonical_biguint(layouter, &self.biguint_gadget)?;
+        let r = r.to_canonical_biguint(layouter, &self.biguint_gadget)?;
+        let s = s.to_canonical_biguint(layouter, &self.biguint_gadget)?;
         self.biguint_gadget.assert_not_equal(layouter, &r, &s)
     }
 
@@ -939,7 +939,7 @@ impl<C: EdwardsCurve> AssertionInstructions<C::Base, AssignedScalarOfNativeCurve
         s: &AssignedScalarOfNativeCurve<C>,
         constant: C::ScalarField,
     ) -> Result<(), Error> {
-        let s = s.into_canonical_biguint(layouter, &self.biguint_gadget)?;
+        let s = s.to_canonical_biguint(layouter, &self.biguint_gadget)?;
         self.biguint_gadget.assert_equal_to_fixed(layouter, &s, constant.to_biguint())
     }
 
@@ -949,7 +949,7 @@ impl<C: EdwardsCurve> AssertionInstructions<C::Base, AssignedScalarOfNativeCurve
         s: &AssignedScalarOfNativeCurve<C>,
         constant: C::ScalarField,
     ) -> Result<(), Error> {
-        let s = s.into_canonical_biguint(layouter, &self.biguint_gadget)?;
+        let s = s.to_canonical_biguint(layouter, &self.biguint_gadget)?;
         self.biguint_gadget
             .assert_not_equal_to_fixed(layouter, &s, constant.to_biguint())
     }
@@ -1087,8 +1087,8 @@ impl<C: EdwardsCurve> EqualityInstructions<C::Base, AssignedScalarOfNativeCurve<
         r: &AssignedScalarOfNativeCurve<C>,
         s: &AssignedScalarOfNativeCurve<C>,
     ) -> Result<AssignedBit<C::Base>, Error> {
-        let r = r.into_canonical_biguint(layouter, &self.biguint_gadget)?;
-        let s = s.into_canonical_biguint(layouter, &self.biguint_gadget)?;
+        let r = r.to_canonical_biguint(layouter, &self.biguint_gadget)?;
+        let s = s.to_canonical_biguint(layouter, &self.biguint_gadget)?;
         self.biguint_gadget.is_equal(layouter, &r, &s)
     }
 
@@ -1098,8 +1098,8 @@ impl<C: EdwardsCurve> EqualityInstructions<C::Base, AssignedScalarOfNativeCurve<
         r: &AssignedScalarOfNativeCurve<C>,
         s: &AssignedScalarOfNativeCurve<C>,
     ) -> Result<AssignedBit<C::Base>, Error> {
-        let r = r.into_canonical_biguint(layouter, &self.biguint_gadget)?;
-        let s = s.into_canonical_biguint(layouter, &self.biguint_gadget)?;
+        let r = r.to_canonical_biguint(layouter, &self.biguint_gadget)?;
+        let s = s.to_canonical_biguint(layouter, &self.biguint_gadget)?;
         self.biguint_gadget.is_not_equal(layouter, &s, &r)
     }
 
@@ -1109,7 +1109,7 @@ impl<C: EdwardsCurve> EqualityInstructions<C::Base, AssignedScalarOfNativeCurve<
         s: &AssignedScalarOfNativeCurve<C>,
         constant: C::ScalarField,
     ) -> Result<AssignedBit<C::Base>, Error> {
-        let s = s.into_canonical_biguint(layouter, &self.biguint_gadget)?;
+        let s = s.to_canonical_biguint(layouter, &self.biguint_gadget)?;
         self.biguint_gadget.is_equal_to_fixed(layouter, &s, constant.to_biguint())
     }
 
@@ -1119,7 +1119,7 @@ impl<C: EdwardsCurve> EqualityInstructions<C::Base, AssignedScalarOfNativeCurve<
         s: &AssignedScalarOfNativeCurve<C>,
         constant: C::ScalarField,
     ) -> Result<AssignedBit<C::Base>, Error> {
-        let s = s.into_canonical_biguint(layouter, &self.biguint_gadget)?;
+        let s = s.to_canonical_biguint(layouter, &self.biguint_gadget)?;
         self.biguint_gadget.is_not_equal_to_fixed(layouter, &s, constant.to_biguint())
     }
 }
@@ -1137,7 +1137,7 @@ impl<C: EdwardsCurve> ArithInstructions<C::Base, AssignedScalarOfNativeCurve<C>>
         let mut acc = self.biguint_gadget.assign_fixed_biguint(layouter, constant.to_biguint())?;
 
         for (c, s) in terms {
-            let s = s.into_biguint(layouter, &self.biguint_gadget)?;
+            let s = s.to_biguint(layouter, &self.biguint_gadget)?;
             let c = self.biguint_gadget.assign_fixed_biguint(layouter, c.to_biguint())?;
             let c_times_s = self.biguint_gadget.mul(layouter, &c, &s)?;
             acc = self.biguint_gadget.add(layouter, &acc, &c_times_s)?;
@@ -1152,8 +1152,8 @@ impl<C: EdwardsCurve> ArithInstructions<C::Base, AssignedScalarOfNativeCurve<C>>
         r: &AssignedScalarOfNativeCurve<C>,
         s: &AssignedScalarOfNativeCurve<C>,
     ) -> Result<AssignedScalarOfNativeCurve<C>, Error> {
-        let r = r.into_biguint(layouter, &self.biguint_gadget)?;
-        let s = s.into_biguint(layouter, &self.biguint_gadget)?;
+        let r = r.to_biguint(layouter, &self.biguint_gadget)?;
+        let s = s.to_biguint(layouter, &self.biguint_gadget)?;
         let res = self.biguint_gadget.add(layouter, &r, &s)?;
         AssignedScalarOfNativeCurve::from_biguint(layouter, &self.biguint_gadget, &res)
     }
@@ -1165,8 +1165,8 @@ impl<C: EdwardsCurve> ArithInstructions<C::Base, AssignedScalarOfNativeCurve<C>>
         s: &AssignedScalarOfNativeCurve<C>,
         multiplying_constant: Option<C::ScalarField>,
     ) -> Result<AssignedScalarOfNativeCurve<C>, Error> {
-        let r = r.into_biguint(layouter, &self.biguint_gadget)?;
-        let s = s.into_biguint(layouter, &self.biguint_gadget)?;
+        let r = r.to_biguint(layouter, &self.biguint_gadget)?;
+        let s = s.to_biguint(layouter, &self.biguint_gadget)?;
         let mut res = self.biguint_gadget.mul(layouter, &r, &s)?;
 
         if let Some(c) = multiplying_constant {
@@ -1192,8 +1192,8 @@ impl<C: EdwardsCurve> ArithInstructions<C::Base, AssignedScalarOfNativeCurve<C>>
             C::ScalarField::NUM_BITS,
         )?;
 
-        let r = r.into_biguint(layouter, &self.biguint_gadget)?;
-        let s = s.into_biguint(layouter, &self.biguint_gadget)?;
+        let r = r.to_biguint(layouter, &self.biguint_gadget)?;
+        let s = s.to_biguint(layouter, &self.biguint_gadget)?;
         let res_times_s = self.biguint_gadget.mul(layouter, &res, &s)?;
         let reduced_res_times_s =
             reduce_biguint_mod_scalar_order::<C>(layouter, &self.biguint_gadget, &res_times_s)?;
@@ -1259,8 +1259,8 @@ impl<C: EdwardsCurve> ControlFlowInstructions<C::Base, AssignedScalarOfNativeCur
         a: &AssignedScalarOfNativeCurve<C>,
         b: &AssignedScalarOfNativeCurve<C>,
     ) -> Result<AssignedScalarOfNativeCurve<C>, Error> {
-        let a_as_big = a.into_biguint(layouter, &self.biguint_gadget)?;
-        let b_as_big = b.into_biguint(layouter, &self.biguint_gadget)?;
+        let a_as_big = a.to_biguint(layouter, &self.biguint_gadget)?;
+        let b_as_big = b.to_biguint(layouter, &self.biguint_gadget)?;
         let selected = self.biguint_gadget.select(layouter, cond, &a_as_big, &b_as_big)?;
         Ok(AssignedScalarOfNativeCurve {
             bits: self.biguint_gadget.to_le_bits(layouter, &selected)?,

--- a/circuits/src/ecc/native/edwards_chip.rs
+++ b/circuits/src/ecc/native/edwards_chip.rs
@@ -23,6 +23,7 @@ use midnight_proofs::{
     plonk::{Advice, Column, ConstraintSystem, Constraints, Error, Expression, Selector},
     poly::Rotation,
 };
+use num_bigint::ToBigUint;
 #[cfg(any(test, feature = "testing"))]
 use {
     crate::field::decomposition::chip::P2RDecompositionConfig,
@@ -32,10 +33,14 @@ use {
 };
 
 use crate::{
+    biguint::BigUintGadget,
     ecc::curves::{CircuitCurve, EdwardsCurve},
     field::{decomposition::chip::P2RDecompositionChip, NativeChip, NativeGadget},
     instructions::*,
-    types::{AssignedBit, AssignedByte, AssignedNative, InnerConstants, InnerValue, Instantiable},
+    types::{
+        AssignedBigUint, AssignedBit, AssignedByte, AssignedNative, InnerConstants, InnerValue,
+        Instantiable,
+    },
     utils::ComposableChip,
     CircuitField,
 };
@@ -141,6 +146,46 @@ impl<C: EdwardsCurve> InnerConstants for AssignedScalarOfNativeCurve<C> {
 impl<C: EdwardsCurve> Sampleable for AssignedScalarOfNativeCurve<C> {
     fn sample_inner(rng: impl RngCore) -> C::ScalarField {
         C::ScalarField::random(rng)
+    }
+}
+
+impl<C: CircuitCurve> AssignedScalarOfNativeCurve<C> {
+    /// Converts the given scalar to a BigUint reduced modulo the scalar field
+    /// order.
+    fn to_reduced_biguint(
+        &self,
+        layouter: &mut impl Layouter<C::Base>,
+        biguint_gadget: &BigUintGadget<C::Base, NG<C::Base>>,
+    ) -> Result<AssignedBigUint<C::Base>, Error> {
+        let modulus = C::ScalarField::modulus().to_biguint().unwrap();
+        let s = biguint_gadget.from_le_bits(layouter, &self.0)?;
+        let m = biguint_gadget.assign_fixed_biguint(layouter, modulus)?;
+        let (_q, r) = biguint_gadget.div_rem(layouter, &s, &m)?;
+        Ok(r)
+    }
+
+    /// Constructs an [`AssignedScalarOfNativeCurve`] from an
+    /// [`AssignedBigUint`], reducing it modulo the scalar field order if
+    /// necessary to ensure the resulting bit representation is canonical.
+    fn from_biguint(
+        layouter: &mut impl Layouter<C::Base>,
+        biguint_gadget: &BigUintGadget<C::Base, NG<C::Base>>,
+        s: &AssignedBigUint<C::Base>,
+    ) -> Result<Self, Error> {
+        let modulus = C::ScalarField::modulus().to_biguint().unwrap();
+        let m = biguint_gadget.assign_fixed_biguint(layouter, modulus)?;
+        let (_q, r) = biguint_gadget.div_rem(layouter, s, &m)?;
+        AssignedScalarOfNativeCurve::from_biguint_without_reduction(layouter, biguint_gadget, &r)
+    }
+
+    fn from_biguint_without_reduction(
+        layouter: &mut impl Layouter<C::Base>,
+        biguint_gadget: &BigUintGadget<C::Base, NG<C::Base>>,
+        s: &AssignedBigUint<C::Base>,
+    ) -> Result<Self, Error> {
+        Ok(AssignedScalarOfNativeCurve(
+            biguint_gadget.to_le_bits(layouter, s)?,
+        ))
     }
 }
 
@@ -323,6 +368,7 @@ type NG<F> = NativeGadget<F, P2RDecompositionChip<F>, NativeChip<F>>;
 pub struct EccChip<C: EdwardsCurve> {
     config: EccConfig,
     native_gadget: NG<C::Base>,
+    biguint_gadget: BigUintGadget<C::Base, NG<C::Base>>,
 }
 
 impl<C: EdwardsCurve> Chip<C::Base> for EccChip<C> {
@@ -342,10 +388,11 @@ impl<C: EdwardsCurve> ComposableChip<C::Base> for EccChip<C> {
     type SharedResources = [Column<Advice>; NB_EDWARDS_COLS];
     type InstructionDeps = NG<C::Base>;
 
-    fn new(config: &Self::Config, sub_chips: &Self::InstructionDeps) -> Self {
+    fn new(config: &Self::Config, native_gadget: &Self::InstructionDeps) -> Self {
         Self {
             config: config.clone(),
-            native_gadget: sub_chips.clone(),
+            native_gadget: native_gadget.clone(),
+            biguint_gadget: BigUintGadget::new(native_gadget),
         }
     }
 
@@ -556,7 +603,12 @@ impl<C: EdwardsCurve> EccChip<C> {
         if point.checked_in_subgroup {
             return Err(Error::Synthesis("clear_cofactor() should not be called in a point that is already guaranteed to be in the prime-order subgroup.".to_owned()));
         }
-        let r = self.mul_by_constant(layouter, C::ScalarField::from_u128(C::COFACTOR), point)?;
+        let r = EccInstructions::mul_by_constant(
+            self,
+            layouter,
+            C::ScalarField::from_u128(C::COFACTOR),
+            point,
+        )?;
         Ok(AssignedNativePoint {
             x: r.x,
             y: r.y,
@@ -621,7 +673,7 @@ impl<C: EdwardsCurve> EccInstructions<C::Base, C> for EccChip<C> {
         layouter: &mut impl Layouter<C::Base>,
         p: &Self::Point,
     ) -> Result<Self::Point, Error> {
-        self.add(layouter, p, p)
+        EccInstructions::add(self, layouter, p, p)
     }
 
     fn negate(
@@ -649,7 +701,7 @@ impl<C: EdwardsCurve> EccInstructions<C::Base, C> for EccChip<C> {
             .collect::<Result<Vec<Self::Point>, Error>>()?;
 
         scaled_points[1..].iter().try_fold(scaled_points[0].clone(), |acc, e| {
-            self.add(layouter, &acc, e)
+            EccInstructions::add(self, layouter, &acc, e)
         })
     }
 
@@ -827,6 +879,53 @@ impl<C: EdwardsCurve> AssertionInstructions<C::Base, AssignedNativePoint<C>> for
     }
 }
 
+impl<C: EdwardsCurve> AssertionInstructions<C::Base, AssignedScalarOfNativeCurve<C>>
+    for EccChip<C>
+{
+    fn assert_equal(
+        &self,
+        layouter: &mut impl Layouter<C::Base>,
+        r: &AssignedScalarOfNativeCurve<C>,
+        s: &AssignedScalarOfNativeCurve<C>,
+    ) -> Result<(), Error> {
+        let r = r.to_reduced_biguint(layouter, &self.biguint_gadget)?;
+        let s = s.to_reduced_biguint(layouter, &self.biguint_gadget)?;
+        self.biguint_gadget.assert_equal(layouter, &r, &s)
+    }
+
+    fn assert_not_equal(
+        &self,
+        layouter: &mut impl Layouter<C::Base>,
+        r: &AssignedScalarOfNativeCurve<C>,
+        s: &AssignedScalarOfNativeCurve<C>,
+    ) -> Result<(), Error> {
+        let r = r.to_reduced_biguint(layouter, &self.biguint_gadget)?;
+        let s = s.to_reduced_biguint(layouter, &self.biguint_gadget)?;
+        self.biguint_gadget.assert_not_equal(layouter, &r, &s)
+    }
+
+    fn assert_equal_to_fixed(
+        &self,
+        layouter: &mut impl Layouter<C::Base>,
+        s: &AssignedScalarOfNativeCurve<C>,
+        constant: C::ScalarField,
+    ) -> Result<(), Error> {
+        let s = s.to_reduced_biguint(layouter, &self.biguint_gadget)?;
+        self.biguint_gadget.assert_equal_to_fixed(layouter, &s, constant.to_biguint())
+    }
+
+    fn assert_not_equal_to_fixed(
+        &self,
+        layouter: &mut impl Layouter<C::Base>,
+        s: &AssignedScalarOfNativeCurve<C>,
+        constant: C::ScalarField,
+    ) -> Result<(), Error> {
+        let s = s.to_reduced_biguint(layouter, &self.biguint_gadget)?;
+        self.biguint_gadget
+            .assert_not_equal_to_fixed(layouter, &s, constant.to_biguint())
+    }
+}
+
 impl<C: EdwardsCurve> PublicInputInstructions<C::Base, AssignedNativePoint<C>> for EccChip<C> {
     fn as_public_input(
         &self,
@@ -952,7 +1051,145 @@ impl<C: EdwardsCurve> EqualityInstructions<C::Base, AssignedNativePoint<C>> for 
     }
 }
 
+impl<C: EdwardsCurve> EqualityInstructions<C::Base, AssignedScalarOfNativeCurve<C>> for EccChip<C> {
+    fn is_equal(
+        &self,
+        layouter: &mut impl Layouter<C::Base>,
+        r: &AssignedScalarOfNativeCurve<C>,
+        s: &AssignedScalarOfNativeCurve<C>,
+    ) -> Result<AssignedBit<C::Base>, Error> {
+        let r = r.to_reduced_biguint(layouter, &self.biguint_gadget)?;
+        let s = s.to_reduced_biguint(layouter, &self.biguint_gadget)?;
+        self.biguint_gadget.is_equal(layouter, &r, &s)
+    }
+
+    fn is_not_equal(
+        &self,
+        layouter: &mut impl Layouter<C::Base>,
+        r: &AssignedScalarOfNativeCurve<C>,
+        s: &AssignedScalarOfNativeCurve<C>,
+    ) -> Result<AssignedBit<C::Base>, Error> {
+        let r = r.to_reduced_biguint(layouter, &self.biguint_gadget)?;
+        let s = s.to_reduced_biguint(layouter, &self.biguint_gadget)?;
+        self.biguint_gadget.is_not_equal(layouter, &s, &r)
+    }
+
+    fn is_equal_to_fixed(
+        &self,
+        layouter: &mut impl Layouter<C::Base>,
+        s: &AssignedScalarOfNativeCurve<C>,
+        constant: C::ScalarField,
+    ) -> Result<AssignedBit<C::Base>, Error> {
+        let s = s.to_reduced_biguint(layouter, &self.biguint_gadget)?;
+        self.biguint_gadget.is_equal_to_fixed(layouter, &s, constant.to_biguint())
+    }
+
+    fn is_not_equal_to_fixed(
+        &self,
+        layouter: &mut impl Layouter<C::Base>,
+        s: &AssignedScalarOfNativeCurve<C>,
+        constant: C::ScalarField,
+    ) -> Result<AssignedBit<C::Base>, Error> {
+        let s = s.to_reduced_biguint(layouter, &self.biguint_gadget)?;
+        self.biguint_gadget.is_not_equal_to_fixed(layouter, &s, constant.to_biguint())
+    }
+}
+
+impl<C: EdwardsCurve> ArithInstructions<C::Base, AssignedScalarOfNativeCurve<C>> for EccChip<C> {
+    fn linear_combination(
+        &self,
+        layouter: &mut impl Layouter<C::Base>,
+        terms: &[(
+            <AssignedScalarOfNativeCurve<C> as InnerValue>::Element,
+            AssignedScalarOfNativeCurve<C>,
+        )],
+        constant: <AssignedScalarOfNativeCurve<C> as InnerValue>::Element,
+    ) -> Result<AssignedScalarOfNativeCurve<C>, Error> {
+        let mut acc = self.biguint_gadget.assign_fixed_biguint(layouter, constant.to_biguint())?;
+
+        for (c, s) in terms {
+            let s = s.to_reduced_biguint(layouter, &self.biguint_gadget)?;
+            let c = self.biguint_gadget.assign_fixed_biguint(layouter, c.to_biguint())?;
+            let c_times_s = self.biguint_gadget.mul(layouter, &c, &s)?;
+            acc = self.biguint_gadget.add(layouter, &acc, &c_times_s)?;
+        }
+
+        AssignedScalarOfNativeCurve::from_biguint(layouter, &self.biguint_gadget, &acc)
+    }
+
+    fn mul(
+        &self,
+        layouter: &mut impl Layouter<C::Base>,
+        r: &AssignedScalarOfNativeCurve<C>,
+        s: &AssignedScalarOfNativeCurve<C>,
+        multiplying_constant: Option<C::ScalarField>,
+    ) -> Result<AssignedScalarOfNativeCurve<C>, Error> {
+        let r = r.to_reduced_biguint(layouter, &self.biguint_gadget)?;
+        let s = s.to_reduced_biguint(layouter, &self.biguint_gadget)?;
+        let mut res = self.biguint_gadget.mul(layouter, &r, &s)?;
+
+        if let Some(c) = multiplying_constant {
+            let c = self.biguint_gadget.assign_fixed_biguint(layouter, c.to_biguint())?;
+            res = self.biguint_gadget.mul(layouter, &res, &c)?;
+        }
+
+        AssignedScalarOfNativeCurve::from_biguint(layouter, &self.biguint_gadget, &res)
+    }
+
+    fn div(
+        &self,
+        layouter: &mut impl Layouter<C::Base>,
+        r: &AssignedScalarOfNativeCurve<C>,
+        s: &AssignedScalarOfNativeCurve<C>,
+    ) -> Result<AssignedScalarOfNativeCurve<C>, Error> {
+        s.value().error_if_known_and(|s| s.is_zero_vartime())?;
+
+        let res_val = r.value().zip(s.value()).map(|(r, s)| r * s.invert().unwrap());
+        let res = self.biguint_gadget.assign_biguint(
+            layouter,
+            res_val.map(|a| a.to_biguint()),
+            C::ScalarField::NUM_BITS,
+        )?;
+
+        let r = r.to_reduced_biguint(layouter, &self.biguint_gadget)?;
+        let s = s.to_reduced_biguint(layouter, &self.biguint_gadget)?;
+        let res_times_s = self.biguint_gadget.mul(layouter, &res, &s)?;
+
+        let modulus = C::ScalarField::modulus().to_biguint().unwrap();
+        let m = self.biguint_gadget.assign_fixed_biguint(layouter, modulus)?;
+        let (_q, reduced_res_times_s) = self.biguint_gadget.div_rem(layouter, &res_times_s, &m)?;
+
+        self.biguint_gadget.assert_equal(layouter, &r, &reduced_res_times_s)?;
+
+        AssignedScalarOfNativeCurve::from_biguint(layouter, &self.biguint_gadget, &res)
+    }
+
+    fn inv(
+        &self,
+        layouter: &mut impl Layouter<C::Base>,
+        s: &AssignedScalarOfNativeCurve<C>,
+    ) -> Result<AssignedScalarOfNativeCurve<C>, Error> {
+        let one = self.assign_fixed(layouter, C::ScalarField::ONE)?;
+        self.div(layouter, &one, s)
+    }
+
+    fn inv0(
+        &self,
+        layouter: &mut impl Layouter<C::Base>,
+        x: &AssignedScalarOfNativeCurve<C>,
+    ) -> Result<AssignedScalarOfNativeCurve<C>, Error> {
+        let is_zero = self.is_zero(layouter, x)?;
+        let zero = self.assign_fixed(layouter, C::ScalarField::ZERO)?;
+        let one = self.assign_fixed(layouter, C::ScalarField::ONE)?;
+        let invertible = self.select(layouter, &is_zero, &one, x)?;
+        let inverse = self.inv(layouter, &invertible)?;
+        self.select(layouter, &is_zero, &zero, &inverse)
+    }
+}
+
 impl<C: EdwardsCurve> ZeroInstructions<C::Base, AssignedNativePoint<C>> for EccChip<C> {}
+
+impl<C: EdwardsCurve> ZeroInstructions<C::Base, AssignedScalarOfNativeCurve<C>> for EccChip<C> {}
 
 impl<C: EdwardsCurve> ControlFlowInstructions<C::Base, AssignedNativePoint<C>> for EccChip<C> {
     fn select(
@@ -973,6 +1210,27 @@ impl<C: EdwardsCurve> ControlFlowInstructions<C::Base, AssignedNativePoint<C>> f
     }
 }
 
+impl<C: EdwardsCurve> ControlFlowInstructions<C::Base, AssignedScalarOfNativeCurve<C>>
+    for EccChip<C>
+{
+    fn select(
+        &self,
+        layouter: &mut impl Layouter<C::Base>,
+        cond: &AssignedBit<C::Base>,
+        a: &AssignedScalarOfNativeCurve<C>,
+        b: &AssignedScalarOfNativeCurve<C>,
+    ) -> Result<AssignedScalarOfNativeCurve<C>, Error> {
+        let a = a.to_reduced_biguint(layouter, &self.biguint_gadget)?;
+        let b = b.to_reduced_biguint(layouter, &self.biguint_gadget)?;
+        let selected = self.biguint_gadget.select(layouter, cond, &a, &b)?;
+        AssignedScalarOfNativeCurve::from_biguint_without_reduction(
+            layouter,
+            &self.biguint_gadget,
+            &selected,
+        )
+    }
+}
+
 #[cfg(any(test, feature = "testing"))]
 impl<C: EdwardsCurve> FromScratch<C::Base> for EccChip<C> {
     type Config = (EccConfig, P2RDecompositionConfig);
@@ -983,9 +1241,11 @@ impl<C: EdwardsCurve> FromScratch<C::Base> for EccChip<C> {
         let native_chip = NativeChip::new_from_scratch(&p2r_decomp_config.native_config);
         let core_decomposition_chip = P2RDecompositionChip::new(p2r_decomp_config, &max_bit_len);
         let native_gadget = NativeGadget::new(core_decomposition_chip, native_chip);
+        let biguint_gadget = BigUintGadget::new(&native_gadget);
         Self {
-            native_gadget,
             config: config.0.clone(),
+            native_gadget,
+            biguint_gadget,
         }
     }
 
@@ -1097,15 +1357,6 @@ mod tests {
 
     test!(public_input, test_public_inputs);
 
-    #[test]
-    fn test_scalarvar_public_inputs() {
-        public_input::tests::test_public_inputs::<
-            JubjubBase,
-            AssignedScalarOfNativeCurve<JubjubExtended>,
-            EccChip<JubjubExtended>,
-        >("public_inputs_scalar_var");
-    }
-
     test!(equality, test_is_equal);
 
     test!(zero, test_zero_assertions);
@@ -1114,6 +1365,46 @@ mod tests {
     test!(control_flow, test_select);
     test!(control_flow, test_cond_assert_equal);
     test!(control_flow, test_cond_swap);
+
+    macro_rules! test_scalar {
+        ($mod:ident, $op:ident, $name:ident) => {
+            #[test]
+            fn $name() {
+                $mod::tests::$op::<
+                    JubjubBase,
+                    AssignedScalarOfNativeCurve<JubjubExtended>,
+                    EccChip<JubjubExtended>,
+                >("native_ecc_scalar");
+            }
+        };
+    }
+
+    test_scalar!(assertions, test_assertions, scalar_assertions);
+
+    test_scalar!(public_input, test_public_inputs, scalar_public_inputs);
+
+    test_scalar!(equality, test_is_equal, scalar_is_equal);
+
+    test_scalar!(zero, test_zero_assertions, scalar_zero_assertions);
+    test_scalar!(zero, test_is_zero, scalar_is_zero);
+
+    test_scalar!(control_flow, test_select, scalar_select);
+    test_scalar!(control_flow, test_cond_assert_equal, scalar_cond_assert_eq);
+    test_scalar!(control_flow, test_cond_swap, scalar_test_cond_swap);
+
+    test_scalar!(arithmetic, test_add, scalar_add);
+    test_scalar!(arithmetic, test_sub, scalar_sub);
+    test_scalar!(arithmetic, test_mul, scalar_mul);
+    test_scalar!(arithmetic, test_div, scalar_div);
+    test_scalar!(arithmetic, test_neg, scalar_neg);
+    test_scalar!(arithmetic, test_inv, scalar_inv);
+    test_scalar!(arithmetic, test_pow, scalar_pow);
+    test_scalar!(
+        arithmetic,
+        test_linear_combination,
+        scalar_linear_combination
+    );
+    test_scalar!(arithmetic, test_add_and_mul, scalar_add_and_mul);
 
     macro_rules! ecc_tests {
         ($op:ident) => {

--- a/circuits/src/ecc/native/edwards_chip.rs
+++ b/circuits/src/ecc/native/edwards_chip.rs
@@ -109,13 +109,16 @@ impl<C: EdwardsCurve> InnerConstants for AssignedNativePoint<C> {
 
 /// Scalars are represented as a vector of assigned bits in little endian.
 #[derive(Clone, Debug)]
-pub struct AssignedScalarOfNativeCurve<C: CircuitCurve>(Vec<AssignedBit<C::Base>>);
+pub struct AssignedScalarOfNativeCurve<C: CircuitCurve> {
+    bits: Vec<AssignedBit<C::Base>>,
+    enforced_canonical: bool,
+}
 
 impl<C: CircuitCurve> InnerValue for AssignedScalarOfNativeCurve<C> {
     type Element = C::ScalarField;
 
     fn value(&self) -> Value<Self::Element> {
-        let bools = self.0.iter().map(|b| b.value());
+        let bools = self.bits.iter().map(|b| b.value());
         let value_bools: Value<Vec<bool>> = Value::from_iter(bools);
         value_bools.map(|le_bits| C::ScalarField::from_bits_le(&le_bits))
     }
@@ -149,6 +152,24 @@ impl<C: EdwardsCurve> Sampleable for AssignedScalarOfNativeCurve<C> {
     }
 }
 
+/// Reduces the given [`AssignedBigUint`] modulo the scalar field order of `C`,
+/// in-circuit. If the input is known to have fewer bits than the scalar field
+/// modulus, it is already in reduced form and is returned as-is.
+fn reduce_biguint_mod_scalar_order<C: CircuitCurve>(
+    layouter: &mut impl Layouter<C::Base>,
+    biguint_gadget: &BigUintGadget<C::Base, NG<C::Base>>,
+    input: &AssignedBigUint<C::Base>,
+) -> Result<AssignedBigUint<C::Base>, Error> {
+    if input.nb_bits() < C::ScalarField::NUM_BITS {
+        return Ok(input.clone());
+    }
+
+    let modulus = C::ScalarField::modulus().to_biguint().unwrap();
+    let m = biguint_gadget.assign_fixed_biguint(layouter, modulus)?;
+    let (_q, r) = biguint_gadget.div_rem(layouter, input, &m)?;
+    Ok(r)
+}
+
 impl<C: CircuitCurve> AssignedScalarOfNativeCurve<C> {
     /// Converts the given scalar to a BigUint reduced modulo the scalar field
     /// order.
@@ -157,11 +178,11 @@ impl<C: CircuitCurve> AssignedScalarOfNativeCurve<C> {
         layouter: &mut impl Layouter<C::Base>,
         biguint_gadget: &BigUintGadget<C::Base, NG<C::Base>>,
     ) -> Result<AssignedBigUint<C::Base>, Error> {
-        let modulus = C::ScalarField::modulus().to_biguint().unwrap();
-        let s = biguint_gadget.from_le_bits(layouter, &self.0)?;
-        let m = biguint_gadget.assign_fixed_biguint(layouter, modulus)?;
-        let (_q, r) = biguint_gadget.div_rem(layouter, &s, &m)?;
-        Ok(r)
+        let s = biguint_gadget.from_le_bits(layouter, &self.bits)?;
+        if self.bits.len() < C::ScalarField::NUM_BITS as usize {
+            return Ok(s);
+        }
+        reduce_biguint_mod_scalar_order::<C>(layouter, biguint_gadget, &s)
     }
 
     /// Constructs an [`AssignedScalarOfNativeCurve`] from an
@@ -172,20 +193,11 @@ impl<C: CircuitCurve> AssignedScalarOfNativeCurve<C> {
         biguint_gadget: &BigUintGadget<C::Base, NG<C::Base>>,
         s: &AssignedBigUint<C::Base>,
     ) -> Result<Self, Error> {
-        let modulus = C::ScalarField::modulus().to_biguint().unwrap();
-        let m = biguint_gadget.assign_fixed_biguint(layouter, modulus)?;
-        let (_q, r) = biguint_gadget.div_rem(layouter, s, &m)?;
-        AssignedScalarOfNativeCurve::from_biguint_without_reduction(layouter, biguint_gadget, &r)
-    }
-
-    fn from_biguint_without_reduction(
-        layouter: &mut impl Layouter<C::Base>,
-        biguint_gadget: &BigUintGadget<C::Base, NG<C::Base>>,
-        s: &AssignedBigUint<C::Base>,
-    ) -> Result<Self, Error> {
-        Ok(AssignedScalarOfNativeCurve(
-            biguint_gadget.to_le_bits(layouter, s)?,
-        ))
+        let s = reduce_biguint_mod_scalar_order::<C>(layouter, biguint_gadget, s)?;
+        Ok(AssignedScalarOfNativeCurve {
+            bits: biguint_gadget.to_le_bits(layouter, &s)?,
+            enforced_canonical: true,
+        })
     }
 }
 
@@ -544,7 +556,7 @@ impl<C: EdwardsCurve> EccChip<C> {
         let config = &self.config();
 
         // Convert to big-endian.
-        let scalar_be_bits = &mut scalar.0.clone();
+        let scalar_be_bits = &mut scalar.bits.clone();
         scalar_be_bits.reverse();
 
         let id_point: AssignedNativePoint<C> =
@@ -822,7 +834,10 @@ impl<C: EdwardsCurve> AssignmentInstructions<C::Base, AssignedScalarOfNativeCurv
         let bits = value
             .map(|s| s.to_bits_le(Some(C::ScalarField::NUM_BITS as usize)))
             .transpose_vec(<C::ScalarField as PrimeField>::NUM_BITS as usize);
-        self.native_gadget.assign_many(layouter, &bits).map(AssignedScalarOfNativeCurve)
+        Ok(AssignedScalarOfNativeCurve {
+            bits: self.native_gadget.assign_many(layouter, &bits)?,
+            enforced_canonical: false,
+        })
     }
 
     fn assign_fixed(
@@ -830,9 +845,10 @@ impl<C: EdwardsCurve> AssignmentInstructions<C::Base, AssignedScalarOfNativeCurv
         layouter: &mut impl Layouter<C::Base>,
         constant: C::ScalarField,
     ) -> Result<AssignedScalarOfNativeCurve<C>, Error> {
-        self.native_gadget
-            .assign_many_fixed(layouter, &constant.to_bits_le(None))
-            .map(AssignedScalarOfNativeCurve)
+        Ok(AssignedScalarOfNativeCurve {
+            bits: self.native_gadget.assign_many_fixed(layouter, &constant.to_bits_le(None))?,
+            enforced_canonical: true,
+        })
     }
 }
 
@@ -976,7 +992,7 @@ impl<C: EdwardsCurve> PublicInputInstructions<C::Base, AssignedScalarOfNativeCur
         // We aggregate the bits while they fit in a single `AssignedNative`.
         let nb_bits_per_batch = C::Base::NUM_BITS as usize - 1;
         assigned
-            .0
+            .bits
             .chunks(nb_bits_per_batch)
             .map(|chunk| self.native_gadget.assigned_from_le_bits(layouter, chunk))
             .collect()
@@ -1117,6 +1133,18 @@ impl<C: EdwardsCurve> ArithInstructions<C::Base, AssignedScalarOfNativeCurve<C>>
         AssignedScalarOfNativeCurve::from_biguint(layouter, &self.biguint_gadget, &acc)
     }
 
+    fn add(
+        &self,
+        layouter: &mut impl Layouter<C::Base>,
+        r: &AssignedScalarOfNativeCurve<C>,
+        s: &AssignedScalarOfNativeCurve<C>,
+    ) -> Result<AssignedScalarOfNativeCurve<C>, Error> {
+        let r = r.to_reduced_biguint(layouter, &self.biguint_gadget)?;
+        let s = s.to_reduced_biguint(layouter, &self.biguint_gadget)?;
+        let res = self.biguint_gadget.add(layouter, &r, &s)?;
+        AssignedScalarOfNativeCurve::from_biguint(layouter, &self.biguint_gadget, &res)
+    }
+
     fn mul(
         &self,
         layouter: &mut impl Layouter<C::Base>,
@@ -1154,10 +1182,8 @@ impl<C: EdwardsCurve> ArithInstructions<C::Base, AssignedScalarOfNativeCurve<C>>
         let r = r.to_reduced_biguint(layouter, &self.biguint_gadget)?;
         let s = s.to_reduced_biguint(layouter, &self.biguint_gadget)?;
         let res_times_s = self.biguint_gadget.mul(layouter, &res, &s)?;
-
-        let modulus = C::ScalarField::modulus().to_biguint().unwrap();
-        let m = self.biguint_gadget.assign_fixed_biguint(layouter, modulus)?;
-        let (_q, reduced_res_times_s) = self.biguint_gadget.div_rem(layouter, &res_times_s, &m)?;
+        let reduced_res_times_s =
+            reduce_biguint_mod_scalar_order::<C>(layouter, &self.biguint_gadget, &res_times_s)?;
 
         self.biguint_gadget.assert_equal(layouter, &r, &reduced_res_times_s)?;
 
@@ -1220,14 +1246,13 @@ impl<C: EdwardsCurve> ControlFlowInstructions<C::Base, AssignedScalarOfNativeCur
         a: &AssignedScalarOfNativeCurve<C>,
         b: &AssignedScalarOfNativeCurve<C>,
     ) -> Result<AssignedScalarOfNativeCurve<C>, Error> {
-        let a = a.to_reduced_biguint(layouter, &self.biguint_gadget)?;
-        let b = b.to_reduced_biguint(layouter, &self.biguint_gadget)?;
-        let selected = self.biguint_gadget.select(layouter, cond, &a, &b)?;
-        AssignedScalarOfNativeCurve::from_biguint_without_reduction(
-            layouter,
-            &self.biguint_gadget,
-            &selected,
-        )
+        let a_as_big = a.to_reduced_biguint(layouter, &self.biguint_gadget)?;
+        let b_as_big = b.to_reduced_biguint(layouter, &self.biguint_gadget)?;
+        let selected = self.biguint_gadget.select(layouter, cond, &a_as_big, &b_as_big)?;
+        Ok(AssignedScalarOfNativeCurve {
+            bits: self.biguint_gadget.to_le_bits(layouter, &selected)?,
+            enforced_canonical: a.enforced_canonical && b.enforced_canonical,
+        })
     }
 }
 
@@ -1301,7 +1326,10 @@ impl<C: EdwardsCurve> EccChip<C> {
                 true,
             )?)
         }
-        Ok(AssignedScalarOfNativeCurve(bits))
+        Ok(AssignedScalarOfNativeCurve {
+            bits,
+            enforced_canonical: false,
+        })
     }
 }
 
@@ -1321,9 +1349,10 @@ impl<C: EdwardsCurve>
         layouter: &mut impl Layouter<C::Base>,
         x: &AssignedNative<C::Base>,
     ) -> Result<AssignedScalarOfNativeCurve<C>, Error> {
-        Ok(AssignedScalarOfNativeCurve(
-            self.native_gadget.assigned_to_le_bits(layouter, x, None, true)?,
-        ))
+        Ok(AssignedScalarOfNativeCurve {
+            bits: self.native_gadget.assigned_to_le_bits(layouter, x, None, true)?,
+            enforced_canonical: false,
+        })
     }
 }
 

--- a/circuits/src/parsing/scanner/automaton_chip.rs
+++ b/circuits/src/parsing/scanner/automaton_chip.rs
@@ -433,8 +433,8 @@ where
     ///
     /// The returned vector has the same length as `input`'s buffer (`M`
     /// elements). It inherits the same
-    /// [`get_limits`](`ScannerVec::get_limits`), and
-    /// [`padding_flags`](`ScannerVec::padding_flags`) as `input`. Filler
+    /// `get_limits`, and
+    /// `padding_flags` as `input`. Filler
     /// positions in the output are constrained to 0 (the self-loop transitions
     /// on initial/final states output marker 0).
     pub fn parse_varlen<const M: usize, const A: usize>(

--- a/circuits/src/parsing/scanner/varlen.rs
+++ b/circuits/src/parsing/scanner/varlen.rs
@@ -92,7 +92,7 @@ impl<F> ScannerChip<F>
 where
     F: CircuitField + Ord,
 {
-    /// Converts a [`ScannerVec`] into an `AssignedVector` of [`AssignedByte`]s.
+    /// Converts a `ScannerVec` into an `AssignedVector` of [`AssignedByte`]s.
     ///
     /// Filler positions (value 256) are replaced with 0 so that all buffer
     /// elements are valid bytes. The resulting vector can be passed to
@@ -100,7 +100,7 @@ where
     /// SHA-256.
     ///
     /// No range-check constraints are added: payload bytes were already
-    /// range-checked during [`ScannerVec`] construction, and fillers are
+    /// range-checked during `ScannerVec` construction, and fillers are
     /// replaced by a known constant (0).
     pub fn scanner_vec_to_byte_vector<const M: usize, const A: usize>(
         &self,
@@ -124,11 +124,11 @@ where
         })
     }
 
-    /// Assigns a variable-length byte vector as a [`ScannerVec`].
+    /// Assigns a variable-length byte vector as a `ScannerVec`.
     ///
     /// The input bytes are assigned as [`AssignedByte`]s (range-checked to
     /// `[0, 255]`), promoted to [`AssignedNative`] elements, and filler
-    /// positions are constrained to [`ALPHABET_MAX_SIZE`] in-circuit.
+    /// positions are constrained to `ALPHABET_MAX_SIZE` in-circuit.
     pub fn assign_scanner_vec<const M: usize, const A: usize>(
         &self,
         layouter: &mut impl Layouter<F>,
@@ -140,7 +140,7 @@ where
     }
 
     /// Converts an existing [`AssignedVector`] of [`AssignedByte`]s into a
-    /// [`ScannerVec`], constraining filler positions to [`ALPHABET_MAX_SIZE`]
+    /// `ScannerVec`, constraining filler positions to `ALPHABET_MAX_SIZE`
     /// and anchoring the length.
     ///
     /// The input elements are already range-checked (they are

--- a/proofs/src/dev/cost_model.rs
+++ b/proofs/src/dev/cost_model.rs
@@ -268,7 +268,7 @@ pub fn circuit_model<
 /// Place this marker in `synthesize` (via `layouter.namespace(||
 /// COST_MEASURE_START)`) immediately before the operation whose cost you want
 /// to isolate.  Pair it with [`COST_MEASURE_END`].  When both markers are
-/// present, [`cost_model_options`] reports `rows` as the span of the rows
+/// present, `cost_model_options` reports `rows` as the span of the rows
 /// assigned between the two markers rather than the full circuit row count.
 pub const COST_MEASURE_START: &str = "__cost_model_measure_start__";
 


### PR DESCRIPTION
These are implemented through the BigUint gadget (instead of foreign field emulation) so that there is no overhead in the architecture of circuits using Jubjub.

These new traits are necessary for ZKIRv3 after we agreed on that Compact will allow arithmetic operations on Jubjub scalars.