### PR TITLE
Remove `Query` trait

### DIFF
--- a/proofs/CHANGELOG.md
+++ b/proofs/CHANGELOG.md
@@ -24,6 +24,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * Blind logup multiplicities polynomial on non-usable rows for ZK [#312](https://github.com/midnightntwrk/midnight-zk/pull/312)
 
 ### Changed
+* Rename `PolynomialPointer` to `PolynomialReference` in `ProverQuery`; rename `poly` field to `poly_ref`; change `poly_inner_product` to accept `&[&Polynomial<F, Coeff>]` to avoid cloning [#411](https://github.com/midnightntwrk/midnight-zk/pull/411)
 * Rename `CommitmentLabel` to `PolynomialLabel`; add `NoLabel` variant for freshly deserialized commitments; introduce `Labelable` trait so every call site attaches the correct label after deserialization [#392](https://github.com/midnightntwrk/midnight-zk/pull/392)
 * Introduce `KZGCommitment` enum with `Simple` and `Linear` variants; attach `CommitmentLabel` at `commit` time and propagate it homomorphically through arithmetic [#381](https://github.com/midnightntwrk/midnight-zk/pull/381)
 * Simplify `CommitmentReference` to a pointer wrapper with identity-based equality; remove `commitment_label` from `VerifierQuery` [#381](https://github.com/midnightntwrk/midnight-zk/pull/381)
@@ -41,6 +42,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * unifying `commit` and `commit_lagrange` [#368](https://github.com/midnightntwrk/midnight-zk/pull/368)
 
 ### Removed
+* Remove `Query<F>` trait; `construct_intermediate_sets` now accepts `&[(T, F, F)]` (commitment reference, point, eval) tuples with `T: PartialEq + Copy` [#411](https://github.com/midnightntwrk/midnight-zk/pull/411)
 * Remove multi-phase PLONK support: `Phase`, `Challenge`, `FirstPhase`, and `Layouter::get_challenge()` are removed; `Any::Advice` is no longer phase-parameterized; the prover and dev tools synthesize in a single pass [#376](https://github.com/midnightntwrk/midnight-zk/pull/376)
 * Remove multi-proof support; `create_proof` and `prepare` now operate on a single circuit and take `instances: &[&[F]]` instead of `&[&[&[F]]]` [#375](https://github.com/midnightntwrk/midnight-zk/pull/375)
 

--- a/proofs/src/plonk/logup/prover.rs
+++ b/proofs/src/plonk/logup/prover.rs
@@ -359,26 +359,14 @@ impl<F: WithSmallOrderMulGroup<3>> Evaluated<F> {
     ) -> impl Iterator<Item = ProverQuery<'a, F>> + Clone {
         let x_next = pk.vk.domain.rotate_omega(x, Rotation::next());
 
-        let m_query = iter::once(ProverQuery {
-            point: x,
-            poly: &self.constructed.multiplicities,
-        });
+        let m_query = iter::once(ProverQuery::new(x, &self.constructed.multiplicities));
 
-        let helper_queries = self
-            .constructed
-            .helper_polys
-            .iter()
-            .map(move |h| ProverQuery { point: x, poly: h });
+        let helper_queries =
+            self.constructed.helper_polys.iter().map(move |h| ProverQuery::new(x, h));
 
         let z_queries = [
-            ProverQuery {
-                point: x,
-                poly: &self.constructed.aggregator_poly,
-            },
-            ProverQuery {
-                point: x_next,
-                poly: &self.constructed.aggregator_poly,
-            },
+            ProverQuery::new(x, &self.constructed.aggregator_poly),
+            ProverQuery::new(x_next, &self.constructed.aggregator_poly),
         ];
 
         m_query.chain(helper_queries).chain(z_queries)

--- a/proofs/src/plonk/permutation/prover.rs
+++ b/proofs/src/plonk/permutation/prover.rs
@@ -257,7 +257,7 @@ impl Argument {
 
 impl<F: PrimeField> super::ProvingKey<F> {
     pub(crate) fn open(&self, x: F) -> impl Iterator<Item = ProverQuery<'_, F>> + Clone {
-        self.polys.iter().map(move |poly| ProverQuery { point: x, poly })
+        self.polys.iter().map(move |poly| ProverQuery::new(x, poly))
     }
 
     pub(crate) fn evaluate<T: Transcript>(
@@ -348,24 +348,18 @@ impl<F: WithSmallOrderMulGroup<3>> Evaluated<F> {
             .chain(self.constructed.sets.iter().flat_map(move |set| {
                 iter::empty()
                     // Open permutation product commitments at x and \omega x
-                    .chain(Some(ProverQuery {
-                        point: x,
-                        poly: &set.permutation_product_poly,
-                    }))
-                    .chain(Some(ProverQuery {
-                        point: x_next,
-                        poly: &set.permutation_product_poly,
-                    }))
+                    .chain(Some(ProverQuery::new(x, &set.permutation_product_poly)))
+                    .chain(Some(ProverQuery::new(
+                        x_next,
+                        &set.permutation_product_poly,
+                    )))
             }))
             // Open it at \omega^{last} x for all but the last set. This rotation is only
             // sensical for the first row, but we only use this rotation in a constraint
             // that is gated on l_0.
             .chain(
                 self.constructed.sets.iter().rev().skip(1).flat_map(move |set| {
-                    Some(ProverQuery {
-                        point: x_last,
-                        poly: &set.permutation_product_poly,
-                    })
+                    Some(ProverQuery::new(x_last, &set.permutation_product_poly))
                 }),
             )
     }

--- a/proofs/src/plonk/prover.rs
+++ b/proofs/src/plonk/prover.rs
@@ -879,19 +879,16 @@ pub(super) fn compute_queries<
 ) -> Vec<ProverQuery<'a, F>> {
     let domain = pk.vk.get_domain();
     iter::empty()
-        .chain(
-            pk.vk.cs.advice_queries.iter().map(move |&(column, at)| ProverQuery {
-                point: domain.rotate_omega(x, at),
-                poly: &advice_polys[column.index()],
-            }),
-        )
+        .chain(pk.vk.cs.advice_queries.iter().map(move |&(column, at)| {
+            ProverQuery::new(domain.rotate_omega(x, at), &advice_polys[column.index()])
+        }))
         .chain(
             pk.vk.cs.instance_queries.iter().filter_map(move |&(column, at)| {
                 if column.index() < nb_committed_instances {
-                    Some(ProverQuery {
-                        point: domain.rotate_omega(x, at),
-                        poly: &instance_polys[column.index()],
-                    })
+                    Some(ProverQuery::new(
+                        domain.rotate_omega(x, at),
+                        &instance_polys[column.index()],
+                    ))
                 } else {
                     None
                 }
@@ -907,16 +904,15 @@ pub(super) fn compute_queries<
                 .iter()
                 // Filter out queries for simple, multiplicative selectors
                 .filter(|(col, _)| !pk.vk.cs.has_simple_selector_col(col.index()))
-                .map(|&(column, at)| ProverQuery {
-                    point: domain.rotate_omega(x, at),
-                    poly: &pk.fixed_polys[column.index()],
+                .map(|&(column, at)| {
+                    ProverQuery::new(domain.rotate_omega(x, at), &pk.fixed_polys[column.index()])
                 }),
         )
         .chain(pk.permutation.open(x))
-        .chain(iter::once(ProverQuery {
-            point: domain.rotate_omega(x, Rotation::cur()),
-            poly: lin_poly_non_constant_part,
-        }))
+        .chain(iter::once(ProverQuery::new(
+            domain.rotate_omega(x, Rotation::cur()),
+            lin_poly_non_constant_part,
+        )))
         .collect()
 }
 

--- a/proofs/src/plonk/trash/prover.rs
+++ b/proofs/src/plonk/trash/prover.rs
@@ -89,10 +89,6 @@ impl<F: WithSmallOrderMulGroup<3>> Committed<F> {
 
 impl<F: WithSmallOrderMulGroup<3>> Evaluated<F> {
     pub(crate) fn open(&self, x: F) -> impl Iterator<Item = ProverQuery<'_, F>> + Clone {
-        vec![ProverQuery {
-            point: x,
-            poly: &self.committed.trash_poly,
-        }]
-        .into_iter()
+        vec![ProverQuery::new(x, &self.committed.trash_poly)].into_iter()
     }
 }

--- a/proofs/src/poly/kzg/mod.rs
+++ b/proofs/src/poly/kzg/mod.rs
@@ -14,9 +14,6 @@ use rayon::iter::{
     IndexedParallelIterator, IntoParallelIterator, IntoParallelRefIterator, ParallelIterator,
 };
 
-#[cfg(feature = "fewer-point-sets")]
-use super::query::Query;
-
 /// KZG commitment type
 pub mod commitment;
 /// Multiscalar multiplication engines
@@ -113,7 +110,7 @@ where
         /// scaled contributions directly into the output buffer, avoiding
         /// M intermediate allocations and the sequential reduce chain.
         fn poly_inner_product<F: ff::PrimeField>(
-            polys: &[Polynomial<F, Coeff>],
+            polys: &[&Polynomial<F, Coeff>],
             scalars: impl IntoIterator<Item = F>,
         ) -> Polynomial<F, Coeff> {
             let scalars: Vec<F> = scalars.into_iter().take(polys.len()).collect();
@@ -140,13 +137,13 @@ where
         #[cfg(feature = "fewer-point-sets")]
         let queries = &{
             let mut queries = queries.to_vec();
-            let pairs: Vec<_> = queries.iter().map(|q| (q.get_commitment(), q.point)).collect();
+            let pairs: Vec<_> = queries.iter().map(|q| (q.poly_ref, q.point)).collect();
             for (idx, point) in compute_dummy_queries(&pairs) {
-                let poly = queries[idx].poly;
+                let poly_ref = queries[idx].poly_ref;
                 transcript
-                    .write(&eval_polynomial(poly, point))
+                    .write(&eval_polynomial(&poly_ref.0[..], queries[idx].point))
                     .map_err(|_| Error::OpeningError)?;
-                queries.push(ProverQuery::new(point, poly));
+                queries.push(ProverQuery { point, poly_ref });
             }
             queries
         };
@@ -156,12 +153,22 @@ where
         let x1: E::Fr = transcript.squeeze_challenge();
         let x2: E::Fr = transcript.squeeze_challenge();
 
-        let (poly_map, point_sets) = construct_intermediate_sets(queries)?;
+        let kzg_queries = queries
+            .iter()
+            .map(|query| {
+                (
+                    query.poly_ref,
+                    query.point,
+                    eval_polynomial(&query.poly_ref.0[..], query.point),
+                )
+            })
+            .collect::<Vec<_>>();
+        let (poly_map, point_sets) = construct_intermediate_sets(&kzg_queries)?;
 
         let mut q_polys = vec![vec![]; point_sets.len()];
 
         for com_data in poly_map.iter() {
-            q_polys[com_data.set_index].push(com_data.commitment.poly.clone());
+            q_polys[com_data.set_index].push(com_data.commitment_ref.0);
         }
 
         let q_polys: Vec<_> = q_polys
@@ -188,7 +195,7 @@ where
         let (q_polys, point_sets) = {
             let mut order: Vec<usize> = (0..point_sets.len()).collect();
             order.sort_by_key(|&i| (point_sets[i].len(), i));
-            let q_polys: Vec<_> = order.iter().map(|&i| q_polys[i].clone()).collect();
+            let q_polys: Vec<_> = order.iter().map(|&i| &q_polys[i]).collect();
             let point_sets: Vec<_> = order.iter().map(|&i| point_sets[i].clone()).collect();
             (q_polys, point_sets)
         };
@@ -198,16 +205,16 @@ where
                 .into_par_iter()
                 .zip(q_polys.clone().into_par_iter())
                 .map(|(points, q_poly)| {
-                    let poly = points
-                        .iter()
-                        .fold(q_poly.values, |poly, point| kate_division(&poly, *point));
+                    let poly = points.iter().fold(q_poly.values.clone(), |poly, point| {
+                        kate_division(&poly, *point)
+                    });
                     Polynomial {
                         values: poly,
                         _marker: PhantomData,
                     }
                 })
                 .collect();
-            poly_inner_product(&f_polys, powers(x2))
+            poly_inner_product(&f_polys.iter().collect::<Vec<_>>(), powers(x2))
         };
 
         let f_com = Self::commit(
@@ -232,7 +239,7 @@ where
 
         let final_poly = {
             let mut polys = q_polys;
-            polys.push(f_poly);
+            polys.push(&f_poly);
             #[cfg(feature = "truncated-challenges")]
             let powers = truncated_powers(x4);
 
@@ -271,14 +278,15 @@ where
         #[cfg(feature = "fewer-point-sets")]
         let queries = &{
             let mut queries = queries.to_vec();
-            let pairs: Vec<_> =
-                queries.iter().map(|q| (q.get_commitment(), q.get_point())).collect();
+            let pairs: Vec<_> = queries.iter().map(|q| (q.commitment_ref, q.point)).collect();
             for (idx, point) in compute_dummy_queries(&pairs) {
-                queries.push(VerifierQuery::new(
+                let commitment_ref = queries[idx].commitment_ref;
+                let eval = transcript.read().map_err(|_| Error::SamplingError)?;
+                queries.push(VerifierQuery {
                     point,
-                    queries[idx].commitment.0,
-                    transcript.read().map_err(|_| Error::SamplingError)?,
-                ));
+                    commitment_ref,
+                    eval,
+                });
             }
             queries
         };
@@ -288,14 +296,18 @@ where
         let x1: E::Fr = transcript.squeeze_challenge();
         let x2: E::Fr = transcript.squeeze_challenge();
 
-        let (commitment_map, point_sets) = construct_intermediate_sets(queries)?;
+        let kzg_queries = queries
+            .iter()
+            .map(|query| (query.commitment_ref, query.point, query.eval))
+            .collect::<Vec<_>>();
+        let (commitment_map, point_sets) = construct_intermediate_sets(&kzg_queries)?;
 
         let mut q_coms: Vec<_> = vec![vec![]; point_sets.len()];
         let mut q_eval_sets = vec![vec![]; point_sets.len()];
 
         for com_data in commitment_map.into_iter() {
             let mut msm = MSMKZG::init();
-            match com_data.commitment.0 {
+            match com_data.commitment_ref.0 {
                 KZGCommitment::Simple(p, label) => msm.append_term(E::Fr::ONE, *p, label.clone()),
                 KZGCommitment::Linear(points, scalars, labels) => {
                     for ((p, s), label) in points.iter().zip(scalars).zip(labels) {
@@ -461,7 +473,7 @@ mod tests {
                 params::{ParamsKZG, ParamsVerifierKZG},
                 KZGCommitmentScheme,
             },
-            query::{ProverQuery, VerifierQuery},
+            query::{PolynomialReference, ProverQuery, VerifierQuery},
             EvaluationDomain, PolynomialLabel,
         },
         transcript::{CircuitTranscript, Hashable, Sampleable, Transcript},
@@ -583,15 +595,15 @@ mod tests {
         let queries = [
             ProverQuery {
                 point: x,
-                poly: &ax,
+                poly_ref: PolynomialReference(&ax),
             },
             ProverQuery {
                 point: x,
-                poly: &bx,
+                poly_ref: PolynomialReference(&bx),
             },
             ProverQuery {
                 point: y,
-                poly: &cx,
+                poly_ref: PolynomialReference(&cx),
             },
         ]
         .into_iter();

--- a/proofs/src/poly/kzg/utils.rs
+++ b/proofs/src/poly/kzg/utils.rs
@@ -6,20 +6,20 @@ use std::{
 
 use ff::Field;
 
-use crate::poly::{query::Query, Error};
+use crate::poly::Error;
 
 #[derive(Clone, Debug)]
 pub(super) struct CommitmentData<F, T: PartialEq> {
-    pub(super) commitment: T,
+    pub(super) commitment_ref: T,
     pub(super) set_index: usize,
     pub(super) point_indices: Vec<usize>,
     pub(super) evals: Vec<F>,
 }
 
 impl<F, T: PartialEq> CommitmentData<F, T> {
-    fn new(commitment: T) -> Self {
+    fn new(commitment_ref: T) -> Self {
         CommitmentData {
-            commitment,
+            commitment_ref,
             set_index: 0,
             point_indices: vec![],
             evals: vec![],
@@ -27,17 +27,24 @@ impl<F, T: PartialEq> CommitmentData<F, T> {
     }
 }
 
-pub(super) type IntermediateSets<F, Q> = (
-    Vec<CommitmentData<<Q as Query<F>>::Eval, <Q as Query<F>>::Commitment>>,
-    Vec<Vec<F>>,
-);
+pub(super) type IntermediateSets<F, T> = (Vec<CommitmentData<F, T>>, Vec<Vec<F>>);
 
-pub fn construct_intermediate_sets<F: Field + Hash + Ord, Q: Query<F>>(
-    queries: &[Q],
-) -> Result<IntermediateSets<F, Q>, Error> {
+/// Groups a list of `(commitment_ref, point, eval)` queries into per-commitment
+/// data and point sets for multi-open batching.
+///
+/// `T` is a commitment reference (a reference to a polynomial in the prover,
+/// a reference to a curve point in the verifier); its [`PartialEq`] must
+/// reflect equality between references.
+/// Queries are grouped by commitment reference and point set.
+///
+/// Returns [`Error::DuplicatedQuery`] if the same `(commitment_ref, point)`
+/// pair appears more than once.
+pub fn construct_intermediate_sets<F: Field + Hash + Ord, T: PartialEq + Copy>(
+    queries: &[(T, F, F)],
+) -> Result<IntermediateSets<F, T>, Error> {
     // Construct sets of unique commitments and corresponding information about
     // their queries.
-    let mut commitment_map: Vec<CommitmentData<Q::Eval, Q::Commitment>> = vec![];
+    let mut commitment_map: Vec<CommitmentData<F, T>> = vec![];
 
     // Also construct mapping from a unique point to a point_index. This defines
     // an ordering on the points.
@@ -45,19 +52,19 @@ pub fn construct_intermediate_sets<F: Field + Hash + Ord, Q: Query<F>>(
 
     // Iterate over all of the queries, computing the ordering of the points
     // while also creating new commitment data.
-    for query in queries {
+    for (query_com_ref, query_point, _query_eval) in queries {
         let num_points = point_index_map.len();
-        let point_idx = point_index_map.entry(query.get_point()).or_insert(num_points);
+        let point_idx = point_index_map.entry(*query_point).or_insert(num_points);
 
         if let Some(pos) =
-            commitment_map.iter().position(|comm| comm.commitment == query.get_commitment())
+            commitment_map.iter().position(|comm| &comm.commitment_ref == query_com_ref)
         {
             if commitment_map[pos].point_indices.contains(point_idx) {
                 return Err(Error::DuplicatedQuery);
             }
             commitment_map[pos].point_indices.push(*point_idx);
         } else {
-            let mut tmp = CommitmentData::new(query.get_commitment());
+            let mut tmp = CommitmentData::new(*query_com_ref);
             tmp.point_indices.push(*point_idx);
             commitment_map.push(tmp);
         }
@@ -76,7 +83,7 @@ pub fn construct_intermediate_sets<F: Field + Hash + Ord, Q: Query<F>>(
         let point_index_set: BTreeSet<_> = commitment_data.point_indices.iter().cloned().collect();
 
         // Push point_index_set to CommitmentData for the relevant commitment
-        commitment_set_map.push((commitment_data.commitment.clone(), point_index_set.clone()));
+        commitment_set_map.push((commitment_data.commitment_ref, point_index_set.clone()));
 
         let num_sets = point_idx_sets.len();
         point_idx_sets.entry(point_index_set).or_insert(num_sets);
@@ -85,18 +92,18 @@ pub fn construct_intermediate_sets<F: Field + Hash + Ord, Q: Query<F>>(
     // Initialise empty evals vec for each unique commitment
     for commitment_data in commitment_map.iter_mut() {
         let len = commitment_data.point_indices.len();
-        commitment_data.evals = vec![Q::Eval::default(); len];
+        commitment_data.evals = vec![F::default(); len];
     }
 
     // Populate set_index, evals and points for each commitment using point_idx_sets
-    for query in queries {
+    for (query_com_ref, query_point, query_eval) in queries {
         // The index of the point at which the commitment is queried
-        let point_index = point_index_map.get(&query.get_point()).unwrap();
+        let point_index = point_index_map.get(query_point).unwrap();
 
         // The point_index_set at which the commitment was queried
         let point_index_set = commitment_set_map
             .iter()
-            .find(|(c, _)| *c == query.get_commitment())
+            .find(|(c, _)| c == query_com_ref)
             .map(|(_, s)| s)
             .unwrap();
         assert!(!point_index_set.is_empty());
@@ -110,10 +117,10 @@ pub fn construct_intermediate_sets<F: Field + Hash + Ord, Q: Query<F>>(
         let point_index_in_set = point_index_set.iter().position(|i| i == point_index).unwrap();
 
         for commitment_data in commitment_map.iter_mut() {
-            if query.get_commitment() == commitment_data.commitment {
+            if *query_com_ref == commitment_data.commitment_ref {
                 commitment_data.set_index = *set_index;
                 // Insert the eval using the ordering of the point_index_set
-                commitment_data.evals[point_index_in_set] = query.get_eval();
+                commitment_data.evals[point_index_in_set] = *query_eval;
             }
         }
     }

--- a/proofs/src/poly/query.rs
+++ b/proofs/src/poly/query.rs
@@ -2,10 +2,7 @@ use std::fmt::{self, Debug};
 
 use ff::PrimeField;
 
-use crate::{
-    poly::{commitment::PolynomialCommitmentScheme, Coeff, Polynomial},
-    utils::arithmetic::eval_polynomial,
-};
+use crate::poly::{commitment::PolynomialCommitmentScheme, Coeff, Polynomial};
 
 /// A structured label for polynomial commitments in verifier queries.
 #[derive(Clone, Debug, PartialEq, Eq, Hash)]
@@ -65,22 +62,13 @@ impl fmt::Display for PolynomialLabel {
     }
 }
 
-pub trait Query<F>: Debug + Sized + Clone + Send + Sync {
-    type Commitment: Debug + PartialEq + Clone + Send + Sync;
-    type Eval: Clone + Default + Debug;
-
-    fn get_point(&self) -> F;
-    fn get_eval(&self) -> Self::Eval;
-    fn get_commitment(&self) -> Self::Commitment;
-}
-
 /// A polynomial query at a point
 #[derive(Debug, Clone, Copy)]
 pub struct ProverQuery<'com, F: PrimeField> {
     /// Point at which polynomial is queried
     pub(crate) point: F,
-    /// Coefficients of polynomial
-    pub(crate) poly: &'com Polynomial<F, Coeff>,
+    /// Reference to a polynomial
+    pub(crate) poly_ref: PolynomialReference<'com, F>,
 }
 
 impl<'com, F> ProverQuery<'com, F>
@@ -89,34 +77,20 @@ where
 {
     /// Create a new prover query based on a polynomial
     pub fn new(point: F, poly: &'com Polynomial<F, Coeff>) -> Self {
-        ProverQuery { point, poly }
+        ProverQuery {
+            point,
+            poly_ref: PolynomialReference(poly),
+        }
     }
 }
 
 #[doc(hidden)]
 #[derive(Copy, Clone, Debug)]
-pub struct PolynomialPointer<'com, F: PrimeField> {
-    pub(crate) poly: &'com Polynomial<F, Coeff>,
-}
+pub struct PolynomialReference<'com, F: PrimeField>(pub(crate) &'com Polynomial<F, Coeff>);
 
-impl<F: PrimeField> PartialEq for PolynomialPointer<'_, F> {
+impl<F: PrimeField> PartialEq for PolynomialReference<'_, F> {
     fn eq(&self, other: &Self) -> bool {
-        std::ptr::eq(self.poly, other.poly)
-    }
-}
-
-impl<'com, F: PrimeField> Query<F> for ProverQuery<'com, F> {
-    type Commitment = PolynomialPointer<'com, F>;
-    type Eval = F;
-
-    fn get_point(&self) -> F {
-        self.point
-    }
-    fn get_eval(&self) -> Self::Eval {
-        eval_polynomial(&self.poly[..], self.get_point())
-    }
-    fn get_commitment(&self) -> Self::Commitment {
-        PolynomialPointer { poly: self.poly }
+        std::ptr::eq(self.0, other.0)
     }
 }
 
@@ -151,7 +125,7 @@ pub struct VerifierQuery<'com, F: PrimeField, CS: PolynomialCommitmentScheme<F>>
     /// Point at which polynomial is queried.
     pub(crate) point: F,
     /// Commitment to polynomial.
-    pub(crate) commitment: CommitmentReference<'com, F, CS>,
+    pub(crate) commitment_ref: CommitmentReference<'com, F, CS>,
     /// Evaluation of polynomial at query point.
     pub(crate) eval: F,
 }
@@ -165,25 +139,8 @@ where
     pub fn new(point: F, commitment: &'com CS::Commitment, eval: F) -> Self {
         VerifierQuery {
             point,
-            commitment: CommitmentReference(commitment),
+            commitment_ref: CommitmentReference(commitment),
             eval,
         }
-    }
-}
-
-impl<'com, F: PrimeField, CS: PolynomialCommitmentScheme<F>> Query<F>
-    for VerifierQuery<'com, F, CS>
-{
-    type Commitment = CommitmentReference<'com, F, CS>;
-    type Eval = F;
-
-    fn get_point(&self) -> F {
-        self.point
-    }
-    fn get_eval(&self) -> F {
-        self.eval
-    }
-    fn get_commitment(&self) -> Self::Commitment {
-        self.commitment
     }
 }


### PR DESCRIPTION
Removes the `Query` trait from `poly/query.rs` and replaces its role in `construct_intermediate_sets` with a concrete `&[(T, F, F)]` tuple interface (commitment reference, point, eval).