### PR TITLE
Bump `sha3-circuit`, `blake2b_halo2` version

### DIFF
--- a/zk_stdlib/CHANGELOG.md
+++ b/zk_stdlib/CHANGELOG.md
@@ -28,6 +28,7 @@ We use [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 * Changed logup to use the selector variant [#220](https://github.com/midnightntwrk/midnight-zk/pull/220)
 * Replace `secp256k1` with `k256`  [#192](https://github.com/midnightntwrk/midnight-zk/pull/192)
 * Parallelise batch_verifier [#236](https://github.com/midnightntwrk/midnight-zk/pull/236)
+* Bumped `blake2b_halo2`, `sha3-circuit` deps [#417](https://github.com/midnightntwrk/midnight-zk/pull/417)
 
 ### Removed
 
@@ -85,7 +86,7 @@ We use [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 ### Changed
 * Update `prove` to accept `impl RngCore + CryptoRng` by value [#307](https://github.com/midnightntwrk/midnight-zk/pull/307)
 
-## [1.0.0] 
+## [1.0.0]
 ### Added
 - Initial release of zk_stdlib extracted from circuits crate
 

--- a/zk_stdlib/Cargo.toml
+++ b/zk_stdlib/Cargo.toml
@@ -18,8 +18,8 @@ midnight-proofs = { version = "0.8.0", default-features = false, features = [
     "committed-instances",
 ] }
 
-keccak_sha3 = { package = "sha3-circuit", git = "https://github.com/alexandroszacharakis8/sha3-circuit", rev = "1a3ef7d" }
-blake2b = { package = "blake2b_halo2", git = "https://github.com/eryxcoop/blake2b_halo2", rev = "257ae18" }
+keccak_sha3 = { package = "sha3-circuit",  version = "0.2.0" }
+blake2b     = { package = "blake2b_halo2", version = "0.2.0" }
 
 serde = { workspace = true, optional = true }
 sha2 = { workspace = true }


### PR DESCRIPTION
External crates dependencies `blake2b_halo2` and `sha3-circuit` have been updated from the previous pinned github rev, to the current crates.io latest version.


WIP: There is an issue with `proofs` and `curves` patches and breaking compilation