### PR TITLE
Fix cost-model

### DIFF
--- a/proofs/CHANGELOG.md
+++ b/proofs/CHANGELOG.md
@@ -22,6 +22,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * Fix cost model to account for committed instance column evaluations [#280](https://github.com/midnightntwrk/midnight-zk/pull/280)
 * Increase number of blinding factors to account for logup helper polynomials [#312](https://github.com/midnightntwrk/midnight-zk/pull/312)
 * Blind logup multiplicities polynomial on non-usable rows for ZK [#312](https://github.com/midnightntwrk/midnight-zk/pull/312)
+* Fix cost-model [#435](https://github.com/midnightntwrk/midnight-zk/pull/435)
 
 ### Changed
 * Rename `PolynomialPointer` to `PolynomialReference` in `ProverQuery`; rename `poly` field to `poly_ref`; change `poly_inner_product` to accept `&[&Polynomial<F, Coeff>]` to avoid cloning [#411](https://github.com/midnightntwrk/midnight-zk/pull/411)

--- a/proofs/src/dev/cost_model.rs
+++ b/proofs/src/dev/cost_model.rs
@@ -785,7 +785,7 @@ mod tests {
                             || format!("row {row}"),
                             config.table,
                             row as usize,
-                            || Value::known(Fq::from(row + 1)),
+                            || Value::known(Fq::from(row)),
                         )?;
                     }
 


### PR DESCRIPTION
## Summary

Fix off-by-one bug in 8-bit lookup table in cost-model.
The table contained `[1, 256]` values when it should contain `[0, 255]`.

This affects only the cost-model and causes tests to fail with 1/256 probability (when the random byte in the test is 0).