### PR TITLE
fix(templates): drop audience:public from issue forms

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/bug-report.yml
@@ -6,7 +6,6 @@ labels:
   - type:bug
   - status:untriaged
   - component:zk
-  - audience:public
 body:
   - type: input
     id: version

--- a/.github/ISSUE_TEMPLATE/documentation-improvement.yml
+++ b/.github/ISSUE_TEMPLATE/documentation-improvement.yml
@@ -7,7 +7,6 @@ labels:
   - status:untriaged
   - area:documentation
   - component:zk
-  - audience:public
 body:
   - type: input
     id: url

--- a/.github/ISSUE_TEMPLATE/feature-request.yml
+++ b/.github/ISSUE_TEMPLATE/feature-request.yml
@@ -6,7 +6,6 @@ labels:
   - type:feature
   - status:untriaged
   - component:zk
-  - audience:public
 body:
   - type: textarea
     id: feature


### PR DESCRIPTION
Removes `audience:public` from the bug/feature/docs templates. audience is a shieldedtech-only label; origin-of-ticket is now the native `Origin` issue field set at triage. Templates keep type:*, status:untriaged, component:zk (+ area:documentation for docs).