### PR TITLE
ci: default Origin to Public on issue open

### DIFF
--- a/.github/workflows/default-origin-on-open.yml
+++ b/.github/workflows/default-origin-on-open.yml
@@ -1,0 +1,18 @@
+name: Default Origin on issue open
+
+# Dispatcher — calls the reusable workflow in midnightntwrk/.github.
+# Sets the Origin field to Public on new issues when unset.
+on:
+  issues:
+    types: [opened]
+
+permissions:
+  issues: write
+
+concurrency:
+  group: default-origin-${{ github.event.issue.number }}
+  cancel-in-progress: true
+
+jobs:
+  apply:
+    uses: midnightntwrk/.github/.github/workflows/default-origin-on-open.yml@3e2720c308e44f8406657a391a12b62acc2dd3de

--- a/.github/workflows/default-origin-on-open.yml
+++ b/.github/workflows/default-origin-on-open.yml
@@ -15,4 +15,4 @@ concurrency:
 
 jobs:
   apply:
-    uses: midnightntwrk/.github/.github/workflows/default-origin-on-open.yml@3e2720c308e44f8406657a391a12b62acc2dd3de
+    uses: midnightntwrk/.github/.github/workflows/default-origin-on-open.yml@f8dc1fe275748124b842edefa6bd863df6f33f27


### PR DESCRIPTION
Closes the Origin-default gap. Dispatcher for the new `default-origin-on-open` reusable in midnightntwrk/.github#3 — sets Origin=Public on new issues when unset (native fields can't have a built-in default). Add-only, never overwrites. Depends on #3; SHA re-pinned to main after it merges.