### PR TITLE
Generalize `cost_model` to depend on a `PCS`

### DIFF
--- a/circuits/CHANGELOG.md
+++ b/circuits/CHANGELOG.md
@@ -15,6 +15,7 @@ We use [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 * Fix cost model to pass correct number of committed instances [#280](https://github.com/midnightntwrk/midnight-zk/pull/280)
 
 ### Changed
+* `circuit_modeling` derives the commitment byte length from `KZGCommitmentScheme` via `circuit_model_with` instead of hard-coded sizes [#440](https://github.com/midnightntwrk/midnight-zk/pull/440)
 * Panic loudly in `from_dual_msm` when a `NoLabel` commitment reaches the MSM layer [#392](https://github.com/midnightntwrk/midnight-zk/pull/392)
 * Adapt verifier gadget to single-proof prover API [#375](https://github.com/midnightntwrk/midnight-zk/pull/375)
 * Split linearization commitment into non-constant and constant parts, removing the generator point from the MSM [#313](https://github.com/midnightntwrk/midnight-zk/pull/313)

--- a/circuits/src/utils/circuit_modeling.rs
+++ b/circuits/src/utils/circuit_modeling.rs
@@ -20,11 +20,12 @@ use std::{
 
 use ff::{Field, FromUniformBytes, PrimeField};
 use goldenfile::Mint;
-use midnight_curves::Fq;
+use midnight_curves::{Bls12, Fq};
 use midnight_proofs::{
     circuit::Layouter,
-    dev::cost_model::{circuit_model, CircuitModel, COST_MEASURE_END, COST_MEASURE_START},
+    dev::cost_model::{circuit_model_with, CircuitModel, COST_MEASURE_END, COST_MEASURE_START},
     plonk::Circuit,
+    poly::{commitment::PolynomialCommitmentScheme, kzg::KZGCommitmentScheme},
 };
 use serde_json::{json, Map, Value};
 
@@ -76,9 +77,14 @@ where
     F: FromUniformBytes<64> + Ord,
 {
     // Store model only when tests are run in BLS12-381 (i.e. when the
-    // native scalar is BLS's scalar
+    // native scalar is BLS's scalar.  F is generic so we can't name the CS
+    // type directly; instead we derive the commitment size from it statically.
     if F::MODULUS == Fq::MODULUS {
-        let model = circuit_model::<F, 48, 32>(&circuit, 0);
+        let model = circuit_model_with::<F>(
+            &circuit,
+            0,
+            <KZGCommitmentScheme<Bls12> as PolynomialCommitmentScheme<Fq>>::commitment_byte_length,
+        );
         update_json(chip_name, op_name, model).expect("csv generation failed");
     }
 }

--- a/proofs/CHANGELOG.md
+++ b/proofs/CHANGELOG.md
@@ -18,6 +18,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * `MSMKZG::new` constructor taking parallel slices of scalars, bases, and labels [#430](https://github.com/midnightntwrk/midnight-zk/pull/430)
 * `KZGCommitment::collapse()` method and `From<KZGCommitment>` impl for `MSMKZG` [#430](https://github.com/midnightntwrk/midnight-zk/pull/430)
 * Derive `Ord` on `PolynomialLabel`, making it usable as a `BTreeMap` key [#430](https://github.com/midnightntwrk/midnight-zk/pull/430)
+* `commitment_byte_length` method on the `PolynomialCommitmentScheme` trait, defaulting to the per-commitment size times `n` and overridable for schemes that fold polynomials into a single proof element [#440](https://github.com/midnightntwrk/midnight-zk/pull/440)
+* `circuit_model_with` taking an explicit commitment-size closure [#440](https://github.com/midnightntwrk/midnight-zk/pull/440)
 
 ### Fixed
 * Fix verifier evals bug [#356](https://github.com/midnightntwrk/midnight-zk/pull/356)
@@ -28,6 +30,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * Fix cost-model [#435](https://github.com/midnightntwrk/midnight-zk/pull/435)
 
 ### Changed
+* `circuit_model` is now parameterized by a `PolynomialCommitmentScheme` (`circuit_model::<_, CS>`) instead of const `COMM`/`SCALAR` byte-size generics [#440](https://github.com/midnightntwrk/midnight-zk/pull/440)
 * Rename `PolynomialPointer` to `PolynomialReference` in `ProverQuery`; rename `poly` field to `poly_ref`; change `poly_inner_product` to accept `&[&Polynomial<F, Coeff>]` to avoid cloning [#411](https://github.com/midnightntwrk/midnight-zk/pull/411)
 * Rename `CommitmentLabel` to `PolynomialLabel`; add `NoLabel` variant for freshly deserialized commitments; introduce `Labelable` trait so every call site attaches the correct label after deserialization [#392](https://github.com/midnightntwrk/midnight-zk/pull/392)
 * Introduce `KZGCommitment` enum with `Simple` and `Linear` variants; attach `CommitmentLabel` at `commit` time and propagate it homomorphically through arithmetic [#381](https://github.com/midnightntwrk/midnight-zk/pull/381)

--- a/proofs/examples/proof-size.rs
+++ b/proofs/examples/proof-size.rs
@@ -1,9 +1,9 @@
-use midnight_curves::Fq as Scalar;
+use midnight_curves::{Bls12, Fq as Scalar};
 use midnight_proofs::{
     circuit::{Layouter, SimpleFloorPlanner, Value},
     dev::cost_model::circuit_model,
     plonk::{Advice, Circuit, Column, ConstraintSystem, Error, Expression, Selector, TableColumn},
-    poly::Rotation,
+    poly::{kzg::KZGCommitmentScheme, Rotation},
 };
 
 // We use a lookup example
@@ -87,7 +87,7 @@ impl Circuit<Scalar> for TestCircuit {
 fn main() {
     let circuit = TestCircuit {};
 
-    let model = circuit_model::<_, 32, 32>(&circuit, 0);
+    let model = circuit_model::<_, KZGCommitmentScheme<Bls12>>(&circuit, 0);
     println!(
         "Cost of circuit with 8 bit lookup table: \n{}",
         serde_json::to_string_pretty(&model).unwrap()

--- a/proofs/src/dev/cost_model.rs
+++ b/proofs/src/dev/cost_model.rs
@@ -285,8 +285,7 @@ pub fn circuit_model_with<F: Ord + Field + FromUniformBytes<64>>(
 
 /// Given a Plonk circuit, this function returns a [CircuitModel].
 ///
-/// Commitment byte sizes and scalar field element sizes are both derived from
-/// `CS`; no size constants need to be supplied.
+/// Commitment and scalar field sizes (in bytes) are both derived from `CS`.
 pub fn circuit_model<F: Ord + Field + FromUniformBytes<64>, CS: PolynomialCommitmentScheme<F>>(
     circuit: &impl Circuit<F>,
     nb_committed_instances: usize,

--- a/proofs/src/dev/cost_model.rs
+++ b/proofs/src/dev/cost_model.rs
@@ -22,6 +22,7 @@ use crate::{
         Any::{self, Fixed},
         Assignment, Circuit, Column, ConstraintSystem, Error, FloorPlanner, Instance, Selector,
     },
+    poly::commitment::PolynomialCommitmentScheme,
     utils::rational::Rational,
 };
 
@@ -193,120 +194,104 @@ pub struct CircuitModel {
     pub size: usize,
 }
 
-impl CostOptions {
-    /// Convert [CostOptions] to [CircuitModel]. The proof sizè is computed
-    /// depending on the base and scalar field size of the curve used.
-    fn into_circuit_model<const COMM: usize, const SCALAR: usize>(self) -> CircuitModel {
-        let mut queries: Vec<_> = iter::empty()
-            .chain(self.advice.iter())
-            .chain(self.instance.iter().take(self.nb_committed_instances))
-            .chain(self.fixed.iter())
-            .cloned()
-            .chain(self.lookup.iter().flat_map(|l| l.queries()))
-            .chain(self.permutation.queries())
-            .chain(iter::repeat("0".parse().unwrap()).take(self.trash.len()))
-            .chain(iter::once("0".parse().unwrap())) // Linearization polynomial query at x
-            .filter(|p| !p.rotations.is_empty())
-            .collect();
+/// Given a Plonk circuit, this function returns a [CircuitModel].
+///
+/// `commit(n)` returns the total byte length of committing to `n` polynomials.
+/// For schemes where each polynomial is committed independently (e.g. KZG),
+/// this is `n * per_commitment_size`. For schemes that fold multiple
+/// polynomials into one proof element, it may be sub-linear in `n`.
+///
+/// See [`circuit_model`] for the variant that derives `commit` automatically
+/// from a `PolynomialCommitmentScheme`.
+pub fn circuit_model_with<F: Ord + Field + FromUniformBytes<64>>(
+    circuit: &impl Circuit<F>,
+    nb_committed_instances: usize,
+    commit: impl Fn(usize) -> usize,
+) -> CircuitModel {
+    let o = cost_model_options(circuit, nb_committed_instances);
+    let scalar = (F::NUM_BITS as usize).div_ceil(8);
 
-        let column_queries = queries.len();
-        queries.iter_mut().for_each(|p| p.rotations.sort());
-        queries.sort_unstable();
-        queries.dedup();
-        let point_sets = queries.len();
+    let mut queries: Vec<_> = iter::empty()
+        .chain(o.advice.iter())
+        .chain(o.instance.iter().take(o.nb_committed_instances))
+        .chain(o.fixed.iter())
+        .cloned()
+        .chain(o.lookup.iter().flat_map(|l| l.queries()))
+        .chain(o.permutation.queries())
+        .chain(iter::repeat("0".parse().unwrap()).take(o.trash.len()))
+        .chain(iter::once("0".parse().unwrap())) // Linearization polynomial query at x
+        .filter(|p| !p.rotations.is_empty())
+        .collect();
 
-        let comp_bytes = |points: usize, scalars: usize| points * COMM + scalars * SCALAR;
+    let column_queries = queries.len();
+    queries.iter_mut().for_each(|p| p.rotations.sort());
+    queries.sort_unstable();
+    queries.dedup();
+    let point_sets = queries.len();
 
-        // PLONK:
-        // - COMM bytes per advice column
-        // - SCALAR bytes per advice column per query
-        // - SCALAR bytes per committed instance column per query
-        // - SCALAR bytes per fixed column per query
-        // - SCALAR bytes per permutation column
-        // - Per permutation chunk: 1 COMM + 3 SCALAR (last chunk has 2 SCALAR)
-        // - Per lookup argument: (num_chunks + 2) COMM + (num_chunks + 3) SCALAR
-        // - Per trash argument: 1 COMM + 1 SCALAR
-        let nb_perm_chunks =
-            (self.permutation.columns.saturating_sub(1) / self.max_degree.saturating_sub(2)) + 1;
-        let plonk = comp_bytes(1, 0) * self.advice.len()
-            + self
-                .advice
-                .iter()
-                .map(|polys| comp_bytes(0, polys.rotations.len()))
-                .sum::<usize>()
-            + self
-                .instance
-                .iter()
-                .take(self.nb_committed_instances)
-                .map(|polys| comp_bytes(0, polys.rotations.len()))
-                .sum::<usize>()
-            + self
-                .fixed
-                .iter()
-                .map(|polys| comp_bytes(0, polys.rotations.len()))
-                .sum::<usize>()
-            + comp_bytes(0, 1) * self.permutation.columns
-            + (comp_bytes(1, 3) * nb_perm_chunks).saturating_sub(comp_bytes(0, 1)) // we don't need the permutation_product_last_eval of the last chunk
-            + self
-                .lookup
-                .iter()
-                .map(|l| comp_bytes(l.num_commitments(), l.num_evaluations()))
-                .sum::<usize>()
-            + comp_bytes(1, 1) * self.trash.len();
+    // PLONK:
+    // - commit(advice.len()) bytes for all advice commitments
+    // - scalar bytes per advice column per query
+    // - scalar bytes per committed instance column per query
+    // - scalar bytes per fixed column per query
+    // - scalar bytes per permutation column
+    // - Per permutation batch: commit(nb_chunks) + 3*scalar per chunk (last chunk
+    //   has 2 scalar)
+    // - Per lookup argument: commit(num_commitments) + num_evaluations * scalar
+    // - Per trash argument: commit(1) + scalar
+    let nb_perm_chunks =
+        (o.permutation.columns.saturating_sub(1) / o.max_degree.saturating_sub(2)) + 1;
+    let plonk = commit(o.advice.len())
+        + o.advice.iter().map(|p| p.rotations.len() * scalar).sum::<usize>()
+        + o.instance
+            .iter()
+            .take(o.nb_committed_instances)
+            .map(|p| p.rotations.len() * scalar)
+            .sum::<usize>()
+        + o.fixed.iter().map(|p| p.rotations.len() * scalar).sum::<usize>()
+        + scalar * o.permutation.columns
+        + (commit(nb_perm_chunks) + scalar * 3 * nb_perm_chunks).saturating_sub(scalar) // last chunk has 2 evals
+        + o.lookup
+            .iter()
+            .map(|l| commit(l.num_commitments()) + scalar * l.num_evaluations())
+            .sum::<usize>()
+        + o.trash.len() * (commit(1) + scalar);
 
-        // Commitments to quotient limbs:
-        // - (max_deg - 1) COMM bytes for the limbs
-        let limbs = comp_bytes(self.max_degree - 1, 0);
+    // Commitments to quotient limbs: one per limb.
+    let limbs = commit(o.max_degree - 1);
 
-        // Multiopening argument:
-        // - COMM bytes for f_commitment
-        // - SCALAR bytes per set of points in multiopen argument
-        // - COMM bytes for proof
-        let multiopen = comp_bytes(2, point_sets);
+    // Multiopening argument:
+    // - commit(2) bytes for f_commitment and opening proof
+    // - scalar bytes per set of points
+    let multiopen = commit(2) + scalar * point_sets;
 
-        let mut nr_rotations = HashSet::new();
-        for poly in self.advice.iter() {
-            nr_rotations.extend(poly.rotations.clone());
-        }
-        for poly in self.fixed.iter() {
-            nr_rotations.extend(poly.rotations.clone());
-        }
-        for poly in self.instance.iter() {
-            nr_rotations.extend(poly.rotations.clone());
-        }
-
-        let size = plonk + multiopen + limbs;
-
-        CircuitModel {
-            k: self.min_k,
-            rows: self.rows_count,
-            table_rows: self.table_rows_count,
-            nb_unusable_rows: self.nb_unusable_rows,
-            max_deg: self.max_degree,
-            advice_columns: self.advice.len(),
-            // Note that we have one fixed commitment per column in the permutation argument
-            fixed_columns: self.fixed.len() + self.permutation.columns,
-            lookups: self.lookup.len(),
-            trashcans: self.trash.len(),
-            permutations: self.permutation.columns,
-            column_queries,
-            point_sets,
-            size,
-        }
+    CircuitModel {
+        k: o.min_k,
+        rows: o.rows_count,
+        table_rows: o.table_rows_count,
+        nb_unusable_rows: o.nb_unusable_rows,
+        max_deg: o.max_degree,
+        advice_columns: o.advice.len(),
+        // Note that we have one fixed commitment per column in the permutation argument
+        fixed_columns: o.fixed.len() + o.permutation.columns,
+        lookups: o.lookup.len(),
+        trashcans: o.trash.len(),
+        permutations: o.permutation.columns,
+        column_queries,
+        point_sets,
+        size: plonk + multiopen + limbs,
     }
 }
 
-/// Given a Plonk circuit, this function returns a [CircuitModel]
-pub fn circuit_model<
-    F: Ord + Field + FromUniformBytes<64>,
-    const COMM: usize,
-    const SCALAR: usize,
->(
+/// Given a Plonk circuit, this function returns a [CircuitModel].
+///
+/// Commitment byte sizes and scalar field element sizes are both derived from
+/// `CS`; no size constants need to be supplied.
+pub fn circuit_model<F: Ord + Field + FromUniformBytes<64>, CS: PolynomialCommitmentScheme<F>>(
     circuit: &impl Circuit<F>,
     nb_committed_instances: usize,
 ) -> CircuitModel {
-    let options = cost_model_options(circuit, nb_committed_instances);
-    options.into_circuit_model::<COMM, SCALAR>()
+    circuit_model_with(circuit, nb_committed_instances, CS::commitment_byte_length)
 }
 
 /// Namespace marker that signals the start of the region to measure.
@@ -867,7 +852,10 @@ mod tests {
 
         let proof = transcript.finalize();
 
-        assert_eq!(circuit_model::<_, 48, 32>(&circuit, 0).size, proof.len());
+        assert_eq!(
+            circuit_model::<_, KZGCommitmentScheme<Bls12>>(&circuit, 0).size,
+            proof.len()
+        );
     }
 
     #[cfg(feature = "committed-instances")]
@@ -899,7 +887,10 @@ mod tests {
 
         let proof = transcript.finalize();
 
-        assert_eq!(circuit_model::<_, 48, 32>(&circuit, 1).size, proof.len());
+        assert_eq!(
+            circuit_model::<_, KZGCommitmentScheme<Bls12>>(&circuit, 1).size,
+            proof.len()
+        );
     }
 
     #[test]

--- a/proofs/src/poly/commitment.rs
+++ b/proofs/src/poly/commitment.rs
@@ -11,7 +11,7 @@ use crate::{
         VerifierQuery,
     },
     transcript::{Hashable, Sampleable, Transcript},
-    utils::helpers::ProcessedSerdeObject,
+    utils::helpers::{ProcessedSerdeObject, SerdeFormat},
 };
 
 /// Public interface for a additively homomorphic Polynomial Commitment Scheme
@@ -61,6 +61,15 @@ pub trait PolynomialCommitmentScheme<F: PrimeField>: Clone + Debug {
     where
         F: Sampleable<T::Hash> + Hash + Ord + Hashable<T::Hash>,
         Self::Commitment: Hashable<T::Hash>;
+
+    /// Total byte length when committing to `n` polynomials.
+    ///
+    /// For schemes that commit each polynomial independently (e.g. KZG), this
+    /// equals `n` times the per-commitment size. Override for schemes that fold
+    /// `n` polynomials into a single proof element (e.g. fflonk).
+    fn commitment_byte_length(n: usize) -> usize {
+        n * Self::Commitment::default().byte_length(SerdeFormat::Processed)
+    }
 
     /// Verify an multi-opening proof for a given set of [VerifierQuery]'s.
     /// The function fails if the transcript has trailing bytes.

--- a/zk_stdlib/CHANGELOG.md
+++ b/zk_stdlib/CHANGELOG.md
@@ -20,6 +20,7 @@ We use [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 * Fix cost model proof size check to account for committed instance columns [#280](https://github.com/midnightntwrk/midnight-zk/pull/280)
 
 ### Changed
+* `cost_model` passes `KZGCommitmentScheme<Bls12>` to `circuit_model`, removing the `COMMITMENT_BYTE_SIZE`/`SCALAR_BYTE_SIZE` constants [#440](https://github.com/midnightntwrk/midnight-zk/pull/440)
 * Adapt to new `KZGCommitment` API [#381](https://github.com/midnightntwrk/midnight-zk/pull/381)
 * Adapt to single-proof prover API [#375](https://github.com/midnightntwrk/midnight-zk/pull/375)
 * Add `nb_arith_cols` field to `ZkStdLibArch` for configurable arithmetic columns (requires `ZKSTD_VERSION` bump before release) [#287](https://github.com/midnightntwrk/midnight-zk/pull/287)

--- a/zk_stdlib/src/lib.rs
+++ b/zk_stdlib/src/lib.rs
@@ -147,12 +147,6 @@ type Curve25519Chip = ForeignEdwardsEccChip<F, Curve25519, MEP, Curve25519Scalar
 
 const ZKSTD_VERSION: u32 = 2;
 
-/// Byte size of a serialized BLS12-381 G1 commitment (compressed).
-const COMMITMENT_BYTE_SIZE: usize = 48;
-
-/// Byte size of a serialized BLS12-381 scalar.
-const SCALAR_BYTE_SIZE: usize = 32;
-
 /// Number of instance columns given in committed form in a ZK stdlib proof.
 const NB_COMMITTED_INSTANCES: usize = 1;
 
@@ -2146,7 +2140,10 @@ pub fn cs_degree(arch: ZkStdLibArch) -> usize {
 /// computed automatically.
 pub fn cost_model<R: Relation>(relation: &R, k: Option<u32>) -> CircuitModel {
     let circuit = MidnightCircuit::from_relation(relation, k);
-    circuit_model::<_, COMMITMENT_BYTE_SIZE, SCALAR_BYTE_SIZE>(&circuit, NB_COMMITTED_INSTANCES)
+    circuit_model::<_, KZGCommitmentScheme<midnight_curves::Bls12>>(
+        &circuit,
+        NB_COMMITTED_INSTANCES,
+    )
 }
 
 /// Finds the optimal `k` (log2 of the circuit size) for the given relation.


### PR DESCRIPTION
`CircuitModel` and its associated cost functions now take the polynomial commitment scheme as a type parameter instead of a hardcoded commitment byte-length.

A commitment_byte_length method is added to `PolynomialCommitmentScheme`.