### PR TITLE
Generalize the verifier gadget to any PCS

### DIFF
--- a/aggregation/examples/single_circuit_aggregation.rs
+++ b/aggregation/examples/single_circuit_aggregation.rs
@@ -28,8 +28,8 @@ use midnight_circuits::{
     instructions::{hash::HashCPU, *},
     types::{AssignedNative, Instantiable},
     verifier::{
-        self, Accumulator, AssignedAccumulator, AssignedKZGCommitment, BlstrsEmulation,
-        SelfEmulation,
+        self, Accumulator, AssignedAccumulator, AssignedKZGCommitment, AssignedVk, BlstrsEmulation,
+        InCircuitKZG, SelfEmulation,
     },
 };
 use midnight_proofs::{
@@ -288,7 +288,7 @@ impl IvcTransition for ProofAggregation {
         witness: Value<Self::Witness>,
     ) -> Result<Self::AssignedState, Error> {
         // Assign inner VK as a hard-coded constant.
-        let inner_vk = self.std_lib.verifier().assign_fixed_vk(
+        let inner_vk: AssignedVk<S, InCircuitKZG<S>> = self.std_lib.verifier().assign_fixed_vk(
             layouter,
             &self.inner_ctx.domain,
             &self.inner_ctx.cs,
@@ -305,7 +305,7 @@ impl IvcTransition for ProofAggregation {
         )?;
 
         // Verify the inner proof in-circuit.
-        let instance_com = AssignedKZGCommitment::simple(
+        let instance_com = AssignedKZGCommitment::<S>::simple(
             self.std_lib.bls12_381().assign_fixed(layouter, C::identity())?,
             PolynomialLabel::CommittedInstance(0),
         );

--- a/aggregation/src/ivc/circuit.rs
+++ b/aggregation/src/ivc/circuit.rs
@@ -13,7 +13,7 @@ use group::Group;
 use midnight_circuits::{
     instructions::{AssignmentInstructions, BinaryInstructions, PublicInputInstructions},
     types::Instantiable,
-    verifier::{Accumulator, AssignedAccumulator, AssignedKZGCommitment, AssignedVk},
+    verifier::{Accumulator, AssignedAccumulator, AssignedKZGCommitment, AssignedVk, InCircuitKZG},
 };
 use midnight_proofs::{
     circuit::{Layouter, Value},
@@ -143,12 +143,13 @@ impl<T: Ivc> Relation for IvcCircuit<T> {
         let verifier_gadget = std_lib.verifier();
         let ivc_gadget = T::new(std_lib.clone(), &self.ctx);
 
-        let assigned_self_vk: AssignedVk<S> = verifier_gadget.assign_vk_as_public_input(
-            layouter,
-            &self.domain,
-            &self.cs,
-            instance.as_ref().map(|x| x.vk_repr),
-        )?;
+        let assigned_self_vk: AssignedVk<S, InCircuitKZG<S>> = verifier_gadget
+            .assign_vk_as_public_input(
+                layouter,
+                &self.domain,
+                &self.cs,
+                instance.as_ref().map(|x| x.vk_repr),
+            )?;
 
         let prev_state_val = witness.as_ref().map(|w| w.prev_state.clone());
         let prev_state = ivc_gadget.assign(layouter, prev_state_val)?;
@@ -179,7 +180,7 @@ impl<T: Ivc> Relation for IvcCircuit<T> {
         ]
         .concat();
 
-        let instance_com = AssignedKZGCommitment::simple(
+        let instance_com = AssignedKZGCommitment::<S>::simple(
             std_lib.bls12_381().assign_fixed(layouter, C::identity())?,
             PolynomialLabel::CommittedInstance(0),
         );

--- a/aggregation/src/ivc/prover.rs
+++ b/aggregation/src/ivc/prover.rs
@@ -11,7 +11,7 @@ use group::Group;
 use midnight_circuits::{
     hash::poseidon::PoseidonState,
     types::Instantiable,
-    verifier::{Accumulator, AssignedAccumulator, AssignedVk},
+    verifier::{Accumulator, AssignedAccumulator, AssignedVk, InCircuitKZG},
 };
 use midnight_proofs::{
     plonk::{self},
@@ -89,7 +89,7 @@ impl<T: Ivc> IvcProver<T> {
         } else {
             // Construct the public inputs of the previous proof.
             let prev_pi = [
-                AssignedVk::<S>::as_public_input(vk),
+                AssignedVk::<S, InCircuitKZG<S>>::as_public_input(vk),
                 T::format_public_input(&self.state),
                 AssignedAccumulator::<S>::as_public_input(&self.acc),
             ]

--- a/aggregation/src/multi_circuit_aggregator/circuit.rs
+++ b/aggregation/src/multi_circuit_aggregator/circuit.rs
@@ -329,7 +329,7 @@ impl IvcTransition for ProofAggregation {
 
         // 3. Verify the inner proof in-circuit against the witnessed VK and statement.
         let inner_proof_acc = {
-            let instance_com = AssignedKZGCommitment::simple(
+            let instance_com = AssignedKZGCommitment::<S>::simple(
                 self.std_lib.bls12_381().assign_fixed(layouter, C::identity())?,
                 PolynomialLabel::CommittedInstance(0),
             );

--- a/aggregation/src/multi_circuit_aggregator/utils.rs
+++ b/aggregation/src/multi_circuit_aggregator/utils.rs
@@ -15,7 +15,7 @@ use midnight_circuits::{
     hash::poseidon::{PoseidonChip, PoseidonState},
     instructions::{hash::HashCPU, *},
     types::AssignedNative,
-    verifier::{AssignedVk, SelfEmulation},
+    verifier::{AssignedVk, InCircuitKZG, SelfEmulation},
 };
 use midnight_proofs::{
     circuit::{Layouter, Value},
@@ -32,7 +32,7 @@ use crate::ivc::{C, F, S};
 /// is verified against the same VK that was hashed), its VK hash, and a named
 /// map of assigned base points for resolving fixed-base scalars.
 pub type VkHashAndBases = (
-    AssignedVk<S>,
+    AssignedVk<S, InCircuitKZG<S>>,
     AssignedNative<F>,
     BTreeMap<PolynomialLabel, <S as SelfEmulation>::AssignedPoint>,
 );

--- a/circuits/src/verifier/expressions/permutation.rs
+++ b/circuits/src/verifier/expressions/permutation.rs
@@ -26,17 +26,18 @@ use crate::{
     field::AssignedNative,
     instructions::ArithInstructions,
     verifier::{
+        pcs::InCircuitPCS,
         permutation::{CommonEvaluated, Evaluated},
         SelfEmulation,
     },
 };
 
 #[allow(clippy::too_many_arguments)]
-pub(crate) fn permutation_expressions<S: SelfEmulation>(
+pub(crate) fn permutation_expressions<S: SelfEmulation, PCS: InCircuitPCS<S>>(
     layouter: &mut impl Layouter<S::F>,
     scalar_chip: &S::ScalarChip,
     cs: &ConstraintSystem<S::F>,
-    permutation_evals: &Evaluated<S>,
+    permutation_evals: &Evaluated<S, PCS>,
     permutations_common: &CommonEvaluated<S>,
     advice_evals: &[AssignedNative<S::F>],
     fixed_evals: &[AssignedNative<S::F>],

--- a/circuits/src/verifier/kzg.rs
+++ b/circuits/src/verifier/kzg.rs
@@ -23,7 +23,7 @@
 
 use std::{
     collections::{BTreeSet, HashMap},
-    fmt::Debug,
+    marker::PhantomData,
 };
 
 use ff::Field;
@@ -41,6 +41,7 @@ use crate::{
     types::InnerValue,
     verifier::{
         msm::{AssignedMsm, AssignedPoint},
+        pcs::{CommitmentReference, InCircuitHomomorphicCommitment, InCircuitPCS, VerifierQuery},
         transcript_gadget::TranscriptGadget,
         utils::{
             evaluate_interpolated_polynomial, inner_product, mul_add, mul_bounded_scalars,
@@ -155,54 +156,6 @@ impl<S: SelfEmulation> Labelable for AssignedKZGCommitment<S> {
     }
 }
 
-impl<S: SelfEmulation> AssignedKZGCommitment<S> {
-    /// Scales this commitment by a scalar.
-    ///
-    /// `Simple(p, l)` becomes `Linear([p], [scalar], [l])`.
-    /// For `Linear`, all existing scalars are multiplied by `scalar`.
-    pub fn mul(
-        self,
-        layouter: &mut impl Layouter<S::F>,
-        scalar_chip: &S::ScalarChip,
-        scalar: &AssignedNative<S::F>,
-    ) -> Result<Self, Error> {
-        let scalar = AssignedBoundedScalar::new(scalar, None);
-        match self {
-            Self::Simple(p, label) => Ok(Self::Linear(vec![p], vec![scalar], vec![label])),
-            Self::Linear(points, scalars, labels) => Ok(Self::Linear(
-                points,
-                scalars
-                    .iter()
-                    .map(|s| mul_bounded_scalars(layouter, scalar_chip, s, &scalar))
-                    .collect::<Result<Vec<_>, _>>()?,
-                labels,
-            )),
-        }
-    }
-
-    /// Adds two commitments, merging them into a `Linear` combination.
-    pub fn add(
-        self,
-        layouter: &mut impl Layouter<S::F>,
-        scalar_chip: &S::ScalarChip,
-        other: Self,
-    ) -> Result<Self, Error> {
-        let one = AssignedBoundedScalar::one(layouter, scalar_chip)?;
-        let (mut points, mut scalars, mut labels) = match self {
-            Self::Simple(p, label) => (vec![p], vec![one.clone()], vec![label]),
-            Self::Linear(points, scalars, labels) => (points, scalars, labels),
-        };
-        let (other_points, other_scalars, other_labels) = match other {
-            Self::Simple(p, label) => (vec![p], vec![one.clone()], vec![label]),
-            Self::Linear(points, scalars, labels) => (points, scalars, labels),
-        };
-        points.extend(other_points);
-        scalars.extend(other_scalars);
-        labels.extend(other_labels);
-        Ok(Self::Linear(points, scalars, labels))
-    }
-}
-
 // --------------------------------
 // See proofs/src/poly/kzg/utils.rs
 // --------------------------------
@@ -223,17 +176,6 @@ impl<S: SelfEmulation, T: PartialEq> CommitmentData<S, T> {
             point_indices: vec![],
             evals: vec![],
         }
-    }
-}
-
-#[derive(Clone, Debug)]
-struct CommitmentReference<'a, S: SelfEmulation>(&'a AssignedKZGCommitment<S>);
-
-impl<S: SelfEmulation> Copy for CommitmentReference<'_, S> {}
-
-impl<S: SelfEmulation> PartialEq for CommitmentReference<'_, S> {
-    fn eq(&self, other: &Self) -> bool {
-        std::ptr::eq(self.0, other.0)
     }
 }
 
@@ -356,36 +298,6 @@ fn construct_intermediate_sets<S: SelfEmulation, T: PartialEq + Copy>(
     Ok((commitment_map, point_sets))
 }
 
-// ----------------------------
-// See proofs/src/poly/query.rs
-// ----------------------------
-
-#[derive(Clone, Debug)]
-/// Structure to store a VerifierQuery.
-pub(crate) struct VerifierQuery<'a, S: SelfEmulation> {
-    /// Point at which polynomial is queried.
-    point: AssignedNative<S::F>,
-    /// Commitment to the polynomial.
-    commitment_ref: CommitmentReference<'a, S>,
-    /// Evaluation of polynomial at query point.
-    eval: AssignedNative<S::F>,
-}
-
-impl<'a, S: SelfEmulation> VerifierQuery<'a, S> {
-    /// Create a verifier query on a commitment (represented as an MSM).
-    pub(crate) fn new(
-        point: &AssignedNative<S::F>,
-        commitment: &'a AssignedKZGCommitment<S>,
-        eval: &AssignedNative<S::F>,
-    ) -> Self {
-        Self {
-            point: point.clone(),
-            commitment_ref: CommitmentReference(commitment),
-            eval: eval.clone(),
-        }
-    }
-}
-
 // ----------------------------------
 // See proofs/src/utils/arithmetic.rs
 // ----------------------------------
@@ -433,12 +345,12 @@ fn evals_inner_product<F: CircuitField>(
 
 /// Verifies a bunch of KZG queries in a multi-open argument.
 /// The resulting accumulator satisfies the invariant iff all queries are valid.
-pub(crate) fn multi_prepare<S: SelfEmulation>(
+pub(crate) fn multi_prepare_kzg<S: SelfEmulation>(
     layouter: &mut impl Layouter<S::F>,
     #[cfg(feature = "truncated-challenges")] curve_chip: &S::CurveChip,
     scalar_chip: &S::ScalarChip,
     transcript_gadget: &mut TranscriptGadget<S>,
-    queries: &[VerifierQuery<S>],
+    queries: &[VerifierQuery<S, InCircuitKZG<S>>],
 ) -> Result<AssignedAccumulator<S>, Error> {
     let one = AssignedBoundedScalar::one(layouter, scalar_chip)?;
 
@@ -472,8 +384,10 @@ pub(crate) fn multi_prepare<S: SelfEmulation>(
             )
         })
         .collect::<Vec<_>>();
-    let (commitment_map, point_sets) =
-        construct_intermediate_sets::<S, CommitmentReference<S>>(&kzg_queries, default_eval)?;
+    let (commitment_map, point_sets) = construct_intermediate_sets::<
+        S,
+        CommitmentReference<AssignedKZGCommitment<S>>,
+    >(&kzg_queries, default_eval)?;
 
     let mut q_coms: Vec<_> = vec![vec![]; point_sets.len()];
     let mut q_eval_sets = vec![vec![]; point_sets.len()];
@@ -622,4 +536,109 @@ pub(crate) fn multi_prepare<S: SelfEmulation>(
     };
 
     Ok(AssignedAccumulator::new(left, right))
+}
+
+// -----------------------------------------------------------------------
+// InCircuitHomomorphicCommitment impl  (trait defined in pcs.rs)
+// -----------------------------------------------------------------------
+
+impl<S: SelfEmulation> InCircuitHomomorphicCommitment<S> for AssignedKZGCommitment<S> {
+    /// Scales this commitment by a scalar.
+    ///
+    /// `Simple(p, l)` becomes `Linear([p], [scalar], [l])`.
+    /// For `Linear`, all existing scalars are multiplied by `scalar`.
+    fn mul(
+        self,
+        layouter: &mut impl Layouter<S::F>,
+        scalar_chip: &S::ScalarChip,
+        scalar: &AssignedNative<S::F>,
+    ) -> Result<Self, Error> {
+        let scalar = AssignedBoundedScalar::new(scalar, None);
+        match self {
+            Self::Simple(p, label) => Ok(Self::Linear(vec![p], vec![scalar], vec![label])),
+            Self::Linear(points, scalars, labels) => Ok(Self::Linear(
+                points,
+                scalars
+                    .iter()
+                    .map(|s| mul_bounded_scalars(layouter, scalar_chip, s, &scalar))
+                    .collect::<Result<Vec<_>, _>>()?,
+                labels,
+            )),
+        }
+    }
+
+    /// Adds two commitments, merging them into a `Linear` combination.
+    fn add(
+        self,
+        layouter: &mut impl Layouter<S::F>,
+        scalar_chip: &S::ScalarChip,
+        other: Self,
+    ) -> Result<Self, Error> {
+        let one = AssignedBoundedScalar::one(layouter, scalar_chip)?;
+        let (mut points, mut scalars, mut labels) = match self {
+            Self::Simple(p, label) => (vec![p], vec![one.clone()], vec![label]),
+            Self::Linear(points, scalars, labels) => (points, scalars, labels),
+        };
+        let (other_points, other_scalars, other_labels) = match other {
+            Self::Simple(p, label) => (vec![p], vec![one.clone()], vec![label]),
+            Self::Linear(points, scalars, labels) => (points, scalars, labels),
+        };
+        points.extend(other_points);
+        scalars.extend(other_scalars);
+        labels.extend(other_labels);
+        Ok(Self::Linear(points, scalars, labels))
+    }
+}
+
+/// KZG instantiation of [`InCircuitPCS`].
+#[derive(Clone, Copy, Debug)]
+pub struct InCircuitKZG<S: SelfEmulation>(PhantomData<S>);
+
+impl<S: SelfEmulation> InCircuitPCS<S> for InCircuitKZG<S> {
+    type AssignedCommitment = AssignedKZGCommitment<S>;
+
+    fn fixed_commitment(label: PolynomialLabel) -> Self::AssignedCommitment {
+        AssignedKZGCommitment::fixed(label)
+    }
+
+    fn read_commitment(
+        transcript: &mut TranscriptGadget<S>,
+        layouter: &mut impl Layouter<S::F>,
+    ) -> Result<Self::AssignedCommitment, Error> {
+        transcript.read_commitment(layouter)
+    }
+
+    fn assign_commitment(
+        layouter: &mut impl Layouter<S::F>,
+        curve_chip: &S::CurveChip,
+        value: Value<S::C>,
+        label: PolynomialLabel,
+    ) -> Result<Self::AssignedCommitment, Error> {
+        AssignedKZGCommitment::assign(layouter, curve_chip, value, label)
+    }
+
+    fn common_commitment(
+        transcript: &mut TranscriptGadget<S>,
+        layouter: &mut impl Layouter<S::F>,
+        commitment: &AssignedKZGCommitment<S>,
+    ) -> Result<(), Error> {
+        transcript.common_commitment(layouter, commitment)
+    }
+
+    fn multi_prepare(
+        layouter: &mut impl Layouter<S::F>,
+        _curve_chip: &S::CurveChip,
+        scalar_chip: &S::ScalarChip,
+        transcript: &mut TranscriptGadget<S>,
+        queries: &[VerifierQuery<'_, S, Self>],
+    ) -> Result<AssignedAccumulator<S>, Error> {
+        multi_prepare_kzg(
+            layouter,
+            #[cfg(feature = "truncated-challenges")]
+            _curve_chip,
+            scalar_chip,
+            transcript,
+            queries,
+        )
+    }
 }

--- a/circuits/src/verifier/lookup.rs
+++ b/circuits/src/verifier/lookup.rs
@@ -25,7 +25,7 @@ use midnight_proofs::{
 use crate::{
     field::AssignedNative,
     verifier::{
-        kzg::{AssignedKZGCommitment, VerifierQuery},
+        pcs::{InCircuitPCS, VerifierQuery},
         transcript_gadget::TranscriptGadget,
         SelfEmulation,
     },
@@ -33,8 +33,8 @@ use crate::{
 
 /// Commitment to the multiplicity columns, read from the transcript.
 #[derive(Clone, Debug)]
-pub(crate) struct CommittedMultiplicities<S: SelfEmulation> {
-    multiplicities: AssignedKZGCommitment<S>,
+pub(crate) struct CommittedMultiplicities<S: SelfEmulation, PCS: InCircuitPCS<S>> {
+    multiplicities: PCS::AssignedCommitment,
 }
 
 #[derive(Clone, Debug)]
@@ -47,49 +47,45 @@ pub(crate) struct LookupEvaluated<S: SelfEmulation> {
 
 /// Commitments to the LogUp polynomials, read from the transcript.
 #[derive(Clone, Debug)]
-pub(crate) struct Committed<S: SelfEmulation> {
-    multiplicities: AssignedKZGCommitment<S>,
-    helper_polys: Vec<AssignedKZGCommitment<S>>,
-    accumulator: AssignedKZGCommitment<S>,
+pub(crate) struct Committed<S: SelfEmulation, PCS: InCircuitPCS<S>> {
+    multiplicities: PCS::AssignedCommitment,
+    helper_polys: Vec<PCS::AssignedCommitment>,
+    accumulator: PCS::AssignedCommitment,
 }
 
 /// Commitments plus evaluations at challenge point.
 #[derive(Clone, Debug)]
-pub(crate) struct Evaluated<S: SelfEmulation> {
-    committed: Committed<S>,
+pub(crate) struct Evaluated<S: SelfEmulation, PCS: InCircuitPCS<S>> {
+    committed: Committed<S, PCS>,
     pub(crate) evaluated: LookupEvaluated<S>,
 }
 
 /// Reads the prover's multiplicities commitment from the transcript.
-pub(crate) fn read_multiplicities<S: SelfEmulation>(
+pub(crate) fn read_multiplicities<S: SelfEmulation, PCS: InCircuitPCS<S>>(
     name: &str,
     layouter: &mut impl Layouter<S::F>,
     transcript_gadget: &mut TranscriptGadget<S>,
-) -> Result<CommittedMultiplicities<S>, Error> {
-    let multiplicities =
-        transcript_gadget.read_commitment(layouter).map(|c: AssignedKZGCommitment<S>| {
-            c.label(PolynomialLabel::LogupMultiplicities(name.to_owned()))
-        })?;
+) -> Result<CommittedMultiplicities<S, PCS>, Error> {
+    let multiplicities = PCS::read_commitment(transcript_gadget, layouter)
+        .map(|c| c.label(PolynomialLabel::LogupMultiplicities(name.to_owned())))?;
     Ok(CommittedMultiplicities { multiplicities })
 }
 
-impl<S: SelfEmulation> CommittedMultiplicities<S> {
+impl<S: SelfEmulation, PCS: InCircuitPCS<S>> CommittedMultiplicities<S, PCS> {
     pub(crate) fn read_commitment(
         self,
         name: &str,
         nb_flattened: usize,
         layouter: &mut impl Layouter<S::F>,
         transcript_gadget: &mut TranscriptGadget<S>,
-    ) -> Result<Committed<S>, Error> {
+    ) -> Result<Committed<S, PCS>, Error> {
         let helper_polys = (0..nb_flattened)
             .map(|_| {
-                transcript_gadget
-                    .read_commitment(layouter)
+                PCS::read_commitment(transcript_gadget, layouter)
                     .map(|c| c.label(PolynomialLabel::LogupHelper(name.to_owned())))
             })
             .collect::<Result<Vec<_>, Error>>()?;
-        let accumulator = transcript_gadget
-            .read_commitment(layouter)
+        let accumulator = PCS::read_commitment(transcript_gadget, layouter)
             .map(|c| c.label(PolynomialLabel::LogupAggregator(name.to_owned())))?;
 
         Ok(Committed {
@@ -100,12 +96,12 @@ impl<S: SelfEmulation> CommittedMultiplicities<S> {
     }
 }
 
-impl<S: SelfEmulation> Committed<S> {
+impl<S: SelfEmulation, PCS: InCircuitPCS<S>> Committed<S, PCS> {
     pub(crate) fn evaluate(
         self,
         layouter: &mut impl Layouter<S::F>,
         transcript_gadget: &mut TranscriptGadget<S>,
-    ) -> Result<Evaluated<S>, Error> {
+    ) -> Result<Evaluated<S, PCS>, Error> {
         let nb_flattened = self.helper_polys.len();
         let multiplicities_eval = transcript_gadget.read_scalar(layouter)?;
         let helper_evals = (0..nb_flattened)
@@ -128,12 +124,12 @@ impl<S: SelfEmulation> Committed<S> {
 
 // "expressions" is implemented in `expressions/lookup.rs`
 
-impl<'a, S: SelfEmulation> Evaluated<S> {
+impl<'a, S: SelfEmulation, PCS: InCircuitPCS<S>> Evaluated<S, PCS> {
     pub(crate) fn queries(
         &'a self,
         x: &AssignedNative<S::F>,      // evaluation point x
         x_next: &AssignedNative<S::F>, // ωx
-    ) -> Vec<VerifierQuery<'a, S>> {
+    ) -> Vec<VerifierQuery<'a, S, PCS>> {
         let mut queries = vec![
             // Open lookup product commitment at x
             VerifierQuery::new(

--- a/circuits/src/verifier/mod.rs
+++ b/circuits/src/verifier/mod.rs
@@ -33,6 +33,7 @@ mod expressions;
 mod kzg;
 mod lookup;
 mod msm;
+pub(crate) mod pcs;
 mod permutation;
 mod traces;
 mod transcript_gadget;
@@ -42,8 +43,9 @@ mod utils;
 mod verifier_gadget;
 
 pub use accumulator::{Accumulator, AssignedAccumulator};
-pub use kzg::AssignedKZGCommitment;
+pub use kzg::{AssignedKZGCommitment, InCircuitKZG};
 pub use msm::{AssignedMsm, AssignedPoint, Msm, Point};
+pub use pcs::{InCircuitHomomorphicCommitment, InCircuitPCS};
 #[cfg(feature = "dev-curves")]
 pub use types::BnEmulation;
 pub use types::{BlstrsEmulation, SelfEmulation};
@@ -63,16 +65,16 @@ type VerifyingKey<S> =
 /// [VerifierGadget::prepare] contains the scalars of the
 /// fixed-commitments, in the `fixed_base_scalars` field (of its RHS).
 #[derive(Clone, Debug)]
-pub struct AssignedVk<S: SelfEmulation> {
+pub struct AssignedVk<S: SelfEmulation, PCS: InCircuitPCS<S>> {
     domain: EvaluationDomain<S::F>,
-    fixed_commitments: Vec<AssignedKZGCommitment<S>>,
-    perm_commitments: Vec<AssignedKZGCommitment<S>>,
+    fixed_commitments: Vec<PCS::AssignedCommitment>,
+    perm_commitments: Vec<PCS::AssignedCommitment>,
     cs: ConstraintSystem<S::F>,
     cs_degree: usize,
     transcript_repr: AssignedNative<S::F>,
 }
 
-impl<S: SelfEmulation> InnerValue for AssignedVk<S> {
+impl<S: SelfEmulation, PCS: InCircuitPCS<S>> InnerValue for AssignedVk<S, PCS> {
     type Element = VerifyingKey<S>;
 
     fn value(&self) -> Value<VerifyingKey<S>> {
@@ -83,7 +85,7 @@ impl<S: SelfEmulation> InnerValue for AssignedVk<S> {
     }
 }
 
-impl<S: SelfEmulation> Instantiable<S::F> for AssignedVk<S> {
+impl<S: SelfEmulation, PCS: InCircuitPCS<S>> Instantiable<S::F> for AssignedVk<S, PCS> {
     fn as_public_input(vk: &VerifyingKey<S>) -> Vec<S::F> {
         AssignedNative::<S::F>::as_public_input(&vk.transcript_repr())
     }
@@ -94,7 +96,7 @@ impl<S: SelfEmulation> Instantiable<S::F> for AssignedVk<S> {
     }
 }
 
-impl<S: SelfEmulation> AssignedVk<S> {
+impl<S: SelfEmulation, PCS: InCircuitPCS<S>> AssignedVk<S, PCS> {
     /// The assigned `transcript_repr` cell of this verifying key.
     pub fn transcript_repr(&self) -> &AssignedNative<S::F> {
         &self.transcript_repr

--- a/circuits/src/verifier/pcs.rs
+++ b/circuits/src/verifier/pcs.rs
@@ -1,0 +1,149 @@
+// This file is part of MIDNIGHT-ZK.
+// Copyright (C) Midnight Foundation
+// SPDX-License-Identifier: Apache-2.0
+// Licensed under the Apache License, Version 2.0 (the "License");
+// You may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// http://www.apache.org/licenses/LICENSE-2.0
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! In-circuit abstraction layer for Polynomial Commitment Schemes.
+//!
+//! Mirrors [`midnight_proofs::poly::commitment`] for the in-circuit setting.
+
+use std::fmt::Debug;
+
+use midnight_proofs::{
+    circuit::{Layouter, Value},
+    plonk::Error,
+    poly::{commitment::Labelable, PolynomialLabel},
+};
+
+use crate::{
+    field::AssignedNative,
+    verifier::{transcript_gadget::TranscriptGadget, AssignedAccumulator, SelfEmulation},
+};
+
+// ---------------------------------------------------------------------------
+// CommitmentReference  (mirrors proofs/src/poly/query.rs)
+// ---------------------------------------------------------------------------
+
+/// A pointer to an in-circuit commitment, with pointer-based equality.
+///
+/// Two references are equal iff they point to the same allocation, so
+/// commitments are grouped by identity rather than by value.
+pub(crate) struct CommitmentReference<'a, C>(pub(crate) &'a C);
+
+impl<C> Clone for CommitmentReference<'_, C> {
+    fn clone(&self) -> Self {
+        *self
+    }
+}
+impl<C> Copy for CommitmentReference<'_, C> {}
+impl<C: Debug> Debug for CommitmentReference<'_, C> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        self.0.fmt(f)
+    }
+}
+impl<C> PartialEq for CommitmentReference<'_, C> {
+    fn eq(&self, other: &Self) -> bool {
+        std::ptr::eq(self.0, other.0)
+    }
+}
+
+// ---------------------------------------------------------------------------
+// VerifierQuery  (mirrors proofs/src/poly/query.rs)
+// ---------------------------------------------------------------------------
+
+/// An in-circuit verifier query: a commitment evaluated at a point.
+#[derive(Clone, Debug)]
+pub struct VerifierQuery<'a, S: SelfEmulation, PCS: InCircuitPCS<S>> {
+    pub(crate) point: AssignedNative<S::F>,
+    pub(crate) commitment_ref: CommitmentReference<'a, PCS::AssignedCommitment>,
+    pub(crate) eval: AssignedNative<S::F>,
+}
+
+impl<'a, S: SelfEmulation, PCS: InCircuitPCS<S>> VerifierQuery<'a, S, PCS> {
+    pub fn new(
+        point: &AssignedNative<S::F>,
+        commitment: &'a PCS::AssignedCommitment,
+        eval: &AssignedNative<S::F>,
+    ) -> Self {
+        Self {
+            point: point.clone(),
+            commitment_ref: CommitmentReference(commitment),
+            eval: eval.clone(),
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Traits
+// ---------------------------------------------------------------------------
+
+/// In-circuit operations on an additively homomorphic commitment.
+pub trait InCircuitHomomorphicCommitment<S: SelfEmulation>:
+    Clone + Debug + Labelable + Sized
+{
+    /// Scales this commitment by an assigned scalar.
+    fn mul(
+        self,
+        layouter: &mut impl Layouter<S::F>,
+        scalar_chip: &S::ScalarChip,
+        scalar: &AssignedNative<S::F>,
+    ) -> Result<Self, Error>;
+
+    /// Adds another commitment to this one.
+    fn add(
+        self,
+        layouter: &mut impl Layouter<S::F>,
+        scalar_chip: &S::ScalarChip,
+        other: Self,
+    ) -> Result<Self, Error>;
+}
+
+/// In-circuit abstraction over a Polynomial Commitment Scheme.
+///
+/// Mirrors [`midnight_proofs::poly::commitment::PolynomialCommitmentScheme`]
+/// for the in-circuit verifier.
+pub trait InCircuitPCS<S: SelfEmulation>: Sized + Clone + Debug {
+    /// The in-circuit type representing a committed polynomial.
+    type AssignedCommitment: InCircuitHomomorphicCommitment<S>;
+
+    /// Creates a fixed (VK-embedded) commitment identified by `label`.
+    fn fixed_commitment(label: PolynomialLabel) -> Self::AssignedCommitment;
+
+    /// Assigns a commitment from an off-circuit curve point.
+    fn assign_commitment(
+        layouter: &mut impl Layouter<S::F>,
+        curve_chip: &S::CurveChip,
+        value: Value<S::C>,
+        label: PolynomialLabel,
+    ) -> Result<Self::AssignedCommitment, Error>;
+
+    /// Reads one commitment from the proof transcript.
+    fn read_commitment(
+        transcript: &mut TranscriptGadget<S>,
+        layouter: &mut impl Layouter<S::F>,
+    ) -> Result<Self::AssignedCommitment, Error>;
+
+    /// Absorbs a commitment into the proof transcript.
+    fn common_commitment(
+        transcript: &mut TranscriptGadget<S>,
+        layouter: &mut impl Layouter<S::F>,
+        commitment: &Self::AssignedCommitment,
+    ) -> Result<(), Error>;
+
+    /// In-circuit multi-open verification; produces an accumulator.
+    fn multi_prepare(
+        layouter: &mut impl Layouter<S::F>,
+        curve_chip: &S::CurveChip,
+        scalar_chip: &S::ScalarChip,
+        transcript: &mut TranscriptGadget<S>,
+        queries: &[VerifierQuery<'_, S, Self>],
+    ) -> Result<AssignedAccumulator<S>, Error>;
+}

--- a/circuits/src/verifier/pcs.rs
+++ b/circuits/src/verifier/pcs.rs
@@ -108,7 +108,7 @@ pub trait InCircuitHomomorphicCommitment<S: SelfEmulation>:
 
 /// In-circuit abstraction over a Polynomial Commitment Scheme.
 ///
-/// Mirrors [`midnight_proofs::poly::commitment::PolynomialCommitmentScheme`]
+/// Analog of [`midnight_proofs::poly::commitment::PolynomialCommitmentScheme`]
 /// for the in-circuit verifier.
 pub trait InCircuitPCS<S: SelfEmulation>: Sized + Clone + Debug {
     /// The in-circuit type representing a committed polynomial.

--- a/circuits/src/verifier/permutation.rs
+++ b/circuits/src/verifier/permutation.rs
@@ -25,15 +25,15 @@ use midnight_proofs::{
 use crate::{
     field::AssignedNative,
     verifier::{
-        kzg::{AssignedKZGCommitment, VerifierQuery},
+        pcs::{InCircuitPCS, VerifierQuery},
         transcript_gadget::TranscriptGadget,
         SelfEmulation,
     },
 };
 
 #[derive(Clone, Debug)]
-pub(crate) struct Committed<S: SelfEmulation> {
-    permutation_product_commitments: Vec<AssignedKZGCommitment<S>>,
+pub(crate) struct Committed<S: SelfEmulation, PCS: InCircuitPCS<S>> {
+    permutation_product_commitments: Vec<PCS::AssignedCommitment>,
 }
 
 #[derive(Clone, Debug)]
@@ -49,23 +49,23 @@ pub(crate) struct CommonEvaluated<S: SelfEmulation> {
 }
 
 #[derive(Clone, Debug)]
-pub(crate) struct Evaluated<S: SelfEmulation> {
-    coms: Committed<S>,
+pub(crate) struct Evaluated<S: SelfEmulation, PCS: InCircuitPCS<S>> {
+    coms: Committed<S, PCS>,
     pub(crate) sets: Vec<EvaluatedSet<S>>,
 }
 
-pub(crate) fn read_product_commitments<S: SelfEmulation>(
+pub(crate) fn read_product_commitments<S: SelfEmulation, PCS: InCircuitPCS<S>>(
     layouter: &mut impl Layouter<S::F>,
     transcript_gadget: &mut TranscriptGadget<S>,
     cs: &ConstraintSystem<S::F>,
-) -> Result<Committed<S>, Error> {
+) -> Result<Committed<S, PCS>, Error> {
     let chunk_len = cs.degree() - 2;
 
     let permutation_product_commitments = cs
         .permutation()
         .get_columns()
         .chunks(chunk_len)
-        .map(|_| transcript_gadget.read_commitment(layouter))
+        .map(|_| PCS::read_commitment(transcript_gadget, layouter))
         .collect::<Result<Vec<_>, _>>()?
         .into_iter()
         .enumerate()
@@ -94,12 +94,12 @@ pub(crate) fn evaluate_permutation_common<S: SelfEmulation>(
     Ok(CommonEvaluated { permutation_evals })
 }
 
-impl<S: SelfEmulation> Committed<S> {
+impl<S: SelfEmulation, PCS: InCircuitPCS<S>> Committed<S, PCS> {
     pub(crate) fn evaluate(
         self,
         layouter: &mut impl Layouter<S::F>,
         transcript_gadget: &mut TranscriptGadget<S>,
-    ) -> Result<Evaluated<S>, Error> {
+    ) -> Result<Evaluated<S, PCS>, Error> {
         let mut sets = vec![];
 
         let mut iter = self.permutation_product_commitments.iter();
@@ -126,13 +126,13 @@ impl<S: SelfEmulation> Committed<S> {
 
 // "expressions" is implemented in `expressions/permutation.rs`
 
-impl<'a, S: SelfEmulation> Evaluated<S> {
+impl<'a, S: SelfEmulation, PCS: InCircuitPCS<S>> Evaluated<S, PCS> {
     pub(crate) fn queries(
         &'a self,
         x: &AssignedNative<S::F>,      // evaluation point x
         x_next: &AssignedNative<S::F>, // x * \omega
         x_last: &AssignedNative<S::F>, // x * \omega^(-blinding_factors + 1)
-    ) -> Vec<VerifierQuery<'a, S>> {
+    ) -> Vec<VerifierQuery<'a, S, PCS>> {
         let mut queries = vec![];
         for (i, set) in self.sets.iter().enumerate() {
             // Open permutation product commitments at x and \omega x
@@ -161,18 +161,18 @@ impl<'a, S: SelfEmulation> Evaluated<S> {
     }
 }
 
-impl<'a, S: SelfEmulation> CommonEvaluated<S> {
-    pub(crate) fn queries(
+impl<S: SelfEmulation> CommonEvaluated<S> {
+    pub(crate) fn queries<'a, PCS: InCircuitPCS<S>>(
         &self,
-        vkey_commitments: &[&'a AssignedKZGCommitment<S>],
+        vkey_commitments: &[&'a PCS::AssignedCommitment],
         x: &AssignedNative<S::F>, // evaluation point x
-    ) -> Vec<VerifierQuery<'a, S>> {
+    ) -> Vec<VerifierQuery<'a, S, PCS>> {
         assert_eq!(vkey_commitments.len(), self.permutation_evals.len());
 
         vkey_commitments
             .iter()
             .zip(self.permutation_evals.iter())
-            .map(|(commitment, eval)| VerifierQuery::new(x, commitment, eval))
+            .map(|(commitment, eval)| VerifierQuery::new(x, *commitment, eval))
             .collect()
     }
 }

--- a/circuits/src/verifier/traces.rs
+++ b/circuits/src/verifier/traces.rs
@@ -1,15 +1,15 @@
 use crate::{
     field::AssignedNative,
-    verifier::{kzg::AssignedKZGCommitment, SelfEmulation},
+    verifier::{pcs::InCircuitPCS, SelfEmulation},
 };
 
 /// In-circuit verifier trace of a proof.
 #[derive(Debug)]
-pub struct VerifierTrace<S: SelfEmulation> {
-    pub(crate) advice_commitments: Vec<AssignedKZGCommitment<S>>,
-    pub(crate) lookups: Vec<super::lookup::Committed<S>>,
-    pub(crate) trashcans: Vec<super::trash::Committed<S>>,
-    pub(crate) permutations: super::permutation::Committed<S>,
+pub struct VerifierTrace<S: SelfEmulation, PCS: InCircuitPCS<S>> {
+    pub(crate) advice_commitments: Vec<PCS::AssignedCommitment>,
+    pub(crate) lookups: Vec<super::lookup::Committed<S, PCS>>,
+    pub(crate) trashcans: Vec<super::trash::Committed<S, PCS>>,
+    pub(crate) permutations: super::permutation::Committed<S, PCS>,
     pub(crate) beta: AssignedNative<S::F>,
     pub(crate) gamma: AssignedNative<S::F>,
     pub(crate) theta: AssignedNative<S::F>,

--- a/circuits/src/verifier/trash.rs
+++ b/circuits/src/verifier/trash.rs
@@ -25,7 +25,7 @@ use midnight_proofs::{
 use crate::{
     field::AssignedNative,
     verifier::{
-        kzg::{AssignedKZGCommitment, VerifierQuery},
+        pcs::{InCircuitPCS, VerifierQuery},
         transcript_gadget::TranscriptGadget,
         SelfEmulation,
     },
@@ -37,34 +37,33 @@ pub(crate) struct TrashEvaluated<S: SelfEmulation> {
 }
 
 #[derive(Clone, Debug)]
-pub(crate) struct Committed<S: SelfEmulation> {
-    trash_commitment: AssignedKZGCommitment<S>,
+pub(crate) struct Committed<S: SelfEmulation, PCS: InCircuitPCS<S>> {
+    trash_commitment: PCS::AssignedCommitment,
 }
 
 #[derive(Clone, Debug)]
-pub(crate) struct Evaluated<S: SelfEmulation> {
-    committed: Committed<S>,
+pub(crate) struct Evaluated<S: SelfEmulation, PCS: InCircuitPCS<S>> {
+    committed: Committed<S, PCS>,
     pub(crate) evaluated: TrashEvaluated<S>,
 }
 
-pub(crate) fn read_committed<S: SelfEmulation>(
+pub(crate) fn read_committed<S: SelfEmulation, PCS: InCircuitPCS<S>>(
     argument_name: &str,
     layouter: &mut impl Layouter<S::F>,
     transcript_gadget: &mut TranscriptGadget<S>,
-) -> Result<Committed<S>, Error> {
-    let trash_commitment = transcript_gadget
-        .read_commitment(layouter)
+) -> Result<Committed<S, PCS>, Error> {
+    let trash_commitment = PCS::read_commitment(transcript_gadget, layouter)
         .map(|c| c.label(PolynomialLabel::Trash(argument_name.to_owned())))?;
 
     Ok(Committed { trash_commitment })
 }
 
-impl<S: SelfEmulation> Committed<S> {
+impl<S: SelfEmulation, PCS: InCircuitPCS<S>> Committed<S, PCS> {
     pub(crate) fn evaluate(
         self,
         layouter: &mut impl Layouter<S::F>,
         transcript_gadget: &mut TranscriptGadget<S>,
-    ) -> Result<Evaluated<S>, Error> {
+    ) -> Result<Evaluated<S, PCS>, Error> {
         let trash_eval = transcript_gadget.read_scalar(layouter)?;
 
         Ok(Evaluated {
@@ -76,11 +75,11 @@ impl<S: SelfEmulation> Committed<S> {
 
 // "expressions" is implemented in `expressions/trash.rs`
 
-impl<'a, S: SelfEmulation> Evaluated<S> {
+impl<'a, S: SelfEmulation, PCS: InCircuitPCS<S>> Evaluated<S, PCS> {
     pub(crate) fn queries(
         &'a self,
         x: &AssignedNative<S::F>, // evaluation point x
-    ) -> Vec<VerifierQuery<'a, S>> {
+    ) -> Vec<VerifierQuery<'a, S, PCS>> {
         vec![VerifierQuery::new(
             x,
             &self.committed.trash_commitment,

--- a/circuits/src/verifier/verifier_gadget.rs
+++ b/circuits/src/verifier/verifier_gadget.rs
@@ -38,8 +38,8 @@ use crate::{
             eval_expression, lookup::lookup_expressions, permutation::permutation_expressions,
             trash::trash_expressions,
         },
-        kzg::{self, AssignedKZGCommitment, VerifierQuery},
         lookup,
+        pcs::{InCircuitHomomorphicCommitment, InCircuitPCS, VerifierQuery},
         permutation::{self, evaluate_permutation_common},
         traces::VerifierTrace,
         transcript_gadget::TranscriptGadget,
@@ -86,11 +86,13 @@ impl<S: SelfEmulation> VerifierGadget<S> {
     }
 }
 
-impl<S: SelfEmulation> PublicInputInstructions<S::F, AssignedVk<S>> for VerifierGadget<S> {
+impl<S: SelfEmulation, PCS: InCircuitPCS<S>> PublicInputInstructions<S::F, AssignedVk<S, PCS>>
+    for VerifierGadget<S>
+{
     fn as_public_input(
         &self,
         layouter: &mut impl Layouter<S::F>,
-        assigned_vk: &AssignedVk<S>,
+        assigned_vk: &AssignedVk<S, PCS>,
     ) -> Result<Vec<AssignedNative<S::F>>, Error> {
         self.scalar_chip.as_public_input(layouter, &assigned_vk.transcript_repr)
     }
@@ -98,10 +100,10 @@ impl<S: SelfEmulation> PublicInputInstructions<S::F, AssignedVk<S>> for Verifier
     fn constrain_as_public_input(
         &self,
         _layouter: &mut impl Layouter<S::F>,
-        _assigned_vk: &AssignedVk<S>,
+        _assigned_vk: &AssignedVk<S, PCS>,
     ) -> Result<(), Error> {
         unimplemented!(
-            "We intend [assign_vk_as_public_input] to be the only entry point 
+            "We intend [assign_vk_as_public_input] to be the only entry point
              for assigned verifying keys."
         )
     }
@@ -110,7 +112,7 @@ impl<S: SelfEmulation> PublicInputInstructions<S::F, AssignedVk<S>> for Verifier
         &self,
         _layouter: &mut impl Layouter<S::F>,
         _value: Value<VerifyingKey<S>>,
-    ) -> Result<AssignedVk<S>, Error> {
+    ) -> Result<AssignedVk<S, PCS>, Error> {
         unimplemented!(
             "We intend [assign_vk_as_public_input] to be the only entry point
             for assigned verifying keys. (Note that its signature is more complex
@@ -226,13 +228,13 @@ impl<S: SelfEmulation> VerifierGadget<S> {
 impl<S: SelfEmulation> VerifierGadget<S> {
     /// Assigns a verifying key as a public input. All the necessary information
     /// is required off-circuit, except for the `transcript_repr` value.
-    pub fn assign_vk_as_public_input(
+    pub fn assign_vk_as_public_input<PCS: InCircuitPCS<S>>(
         &self,
         layouter: &mut impl Layouter<S::F>,
         domain: &EvaluationDomain<S::F>,
         cs: &ConstraintSystem<S::F>,
         transcript_repr_value: Value<S::F>,
-    ) -> Result<AssignedVk<S>, Error> {
+    ) -> Result<AssignedVk<S, PCS>, Error> {
         let transcript_repr: AssignedNative<S::F> =
             self.scalar_chip.assign_as_public_input(layouter, transcript_repr_value)?;
 
@@ -247,11 +249,11 @@ impl<S: SelfEmulation> VerifierGadget<S> {
         };
 
         let fixed_commitments = (0..cs.num_fixed_columns() + cs.num_selectors())
-            .map(|i| AssignedKZGCommitment::fixed(PolynomialLabel::Fixed(i)))
+            .map(|i| PCS::fixed_commitment(PolynomialLabel::Fixed(i)))
             .collect();
 
         let perm_commitments = (0..cs.permutation().columns.len())
-            .map(|i| AssignedKZGCommitment::fixed(PolynomialLabel::PermutationFixed(i)))
+            .map(|i| PCS::fixed_commitment(PolynomialLabel::PermutationFixed(i)))
             .collect();
 
         let assigned_vk = AssignedVk {
@@ -269,21 +271,21 @@ impl<S: SelfEmulation> VerifierGadget<S> {
     /// Assigns a verifying key as a constant. All the necessary information is
     /// available off-circuit, except for the `transcript_repr` which is
     /// "assigned fixed".
-    pub fn assign_fixed_vk(
+    pub fn assign_fixed_vk<PCS: InCircuitPCS<S>>(
         &self,
         layouter: &mut impl Layouter<S::F>,
         domain: &EvaluationDomain<S::F>,
         cs: &ConstraintSystem<S::F>,
         transcript_repr_constant: S::F,
-    ) -> Result<AssignedVk<S>, Error> {
+    ) -> Result<AssignedVk<S, PCS>, Error> {
         let transcript_repr = self.scalar_chip.assign_fixed(layouter, transcript_repr_constant)?;
 
         let fixed_commitments = (0..cs.num_fixed_columns() + cs.num_selectors())
-            .map(|i| AssignedKZGCommitment::fixed(PolynomialLabel::Fixed(i)))
+            .map(|i| PCS::fixed_commitment(PolynomialLabel::Fixed(i)))
             .collect();
 
         let perm_commitments = (0..cs.permutation().columns.len())
-            .map(|i| AssignedKZGCommitment::fixed(PolynomialLabel::PermutationFixed(i)))
+            .map(|i| PCS::fixed_commitment(PolynomialLabel::PermutationFixed(i)))
             .collect();
 
         let assigned_vk = AssignedVk {
@@ -312,14 +314,14 @@ impl<S: SelfEmulation> VerifierGadget<S> {
     /// constraints](crate::verifier::VerifierGadget::verify_algebraic_constraints),
     /// and the resulting accumulator satisfies the
     /// [invariant](crate::verifier::Accumulator::check).
-    pub fn parse_trace(
+    pub fn parse_trace<PCS: InCircuitPCS<S>>(
         &self,
         layouter: &mut impl Layouter<S::F>,
-        assigned_vk: &AssignedVk<S>,
-        assigned_committed_instances: &[AssignedKZGCommitment<S>],
+        assigned_vk: &AssignedVk<S, PCS>,
+        assigned_committed_instances: &[PCS::AssignedCommitment],
         assigned_instances: &[&[AssignedNative<S::F>]],
         proof: Value<Vec<u8>>,
-    ) -> Result<(VerifierTrace<S>, TranscriptGadget<S>), Error> {
+    ) -> Result<(VerifierTrace<S, PCS>, TranscriptGadget<S>), Error> {
         let cs = &assigned_vk.cs;
 
         // Check that instances matches the expected number of instance columns
@@ -338,7 +340,7 @@ impl<S: SelfEmulation> VerifierGadget<S> {
 
         assigned_committed_instances
             .iter()
-            .try_for_each(|com| transcript.common_commitment(layouter, com))?;
+            .try_for_each(|com| PCS::common_commitment(&mut transcript, layouter, com))?;
 
         for instance in assigned_instances {
             let n = self.scalar_chip.assign_fixed(layouter, (instance.len() as u64).into())?;
@@ -350,8 +352,7 @@ impl<S: SelfEmulation> VerifierGadget<S> {
         // challenges
         let advice_commitments = (0..cs.num_advice_columns())
             .map(|i| {
-                transcript
-                    .read_commitment(layouter)
+                PCS::read_commitment(&mut transcript, layouter)
                     .map(|c| c.label(PolynomialLabel::Advice(i)))
             })
             .collect::<Result<Vec<_>, Error>>()?;
@@ -431,16 +432,16 @@ impl<S: SelfEmulation> VerifierGadget<S> {
     /// polynomial is expected to open to `expected_eval` at `x`.
     #[allow(clippy::too_many_arguments)]
     #[allow(clippy::type_complexity)]
-    fn compute_linearization_commitment<'com>(
+    fn compute_linearization_commitment<'com, PCS: InCircuitPCS<S>>(
         layouter: &mut impl Layouter<S::F>,
         scalar_chip: &S::ScalarChip,
         expressions: Vec<(Option<usize>, AssignedNative<S::F>)>,
-        vk: &'com AssignedVk<S>,
+        vk: &'com AssignedVk<S, PCS>,
         y: AssignedNative<S::F>,
         xn: AssignedNative<S::F>,
         splitting_factor: AssignedNative<S::F>,
-        quotient_limb_commitments: &'com [AssignedKZGCommitment<S>],
-    ) -> Result<(AssignedKZGCommitment<S>, AssignedNative<S::F>), Error> {
+        quotient_limb_commitments: &'com [PCS::AssignedCommitment],
+    ) -> Result<(PCS::AssignedCommitment, AssignedNative<S::F>), Error> {
         let zero: AssignedNative<S::F> = scalar_chip.assign_fixed(layouter, S::F::ZERO)?;
         let one: AssignedNative<S::F> = scalar_chip.assign_fixed(layouter, S::F::ONE)?;
 
@@ -506,12 +507,12 @@ impl<S: SelfEmulation> VerifierGadget<S> {
     /// The proof is considered to be valid if the resulting accumulator
     /// satisfies the [invariant](crate::verifier::Accumulator::check)
     /// with respect to the relevant `tau_in_g2`.
-    pub fn verify_algebraic_constraints(
+    pub fn verify_algebraic_constraints<PCS: InCircuitPCS<S>>(
         &self,
         layouter: &mut impl Layouter<S::F>,
-        assigned_vk: &AssignedVk<S>,
-        trace: VerifierTrace<S>,
-        assigned_committed_instances: &[AssignedKZGCommitment<S>],
+        assigned_vk: &AssignedVk<S, PCS>,
+        trace: VerifierTrace<S, PCS>,
+        assigned_committed_instances: &[PCS::AssignedCommitment],
         assigned_instances: &[&[AssignedNative<S::F>]],
         mut transcript: TranscriptGadget<S>,
     ) -> Result<AssignedAccumulator<S>, Error> {
@@ -541,7 +542,7 @@ impl<S: SelfEmulation> VerifierGadget<S> {
         let nb_quotient_coms = 1;
         let limb_commitments = {
             let raw = (0..nb_quotient_coms)
-                .map(|_| transcript.read_commitment(layouter))
+                .map(|_| PCS::read_commitment(&mut transcript, layouter))
                 .collect::<Result<Vec<_>, Error>>()?;
             #[cfg(not(feature = "single-h-commitment"))]
             let labeled = raw
@@ -784,7 +785,7 @@ impl<S: SelfEmulation> VerifierGadget<S> {
         let queries = iter::empty()
             .chain(
                 cs.advice_queries().iter().enumerate().map(|(query_index, &(column, rot))| {
-                    VerifierQuery::<S>::new(
+                    VerifierQuery::<S, PCS>::new(
                         get_point(&rot),
                         &advice_commitments[column.index()],
                         &advice_evals[query_index],
@@ -794,7 +795,7 @@ impl<S: SelfEmulation> VerifierGadget<S> {
             .chain(cs.instance_queries().iter().enumerate().filter_map(
                 |(query_index, &(column, rot))| {
                     if column.index() < nb_committed_instances {
-                        Some(VerifierQuery::<S>::new(
+                        Some(VerifierQuery::<S, PCS>::new(
                             get_point(&rot),
                             &assigned_committed_instances[column.index()],
                             &instance_evals[query_index],
@@ -835,9 +836,8 @@ impl<S: SelfEmulation> VerifierGadget<S> {
         // We are now convinced the circuit is satisfied so long as the
         // polynomial commitments open to the correct values, which is true as long
         // as the following accumulator passes the invariant.
-        kzg::multi_prepare::<S>(
+        PCS::multi_prepare(
             layouter,
-            #[cfg(feature = "truncated-challenges")]
             &self.curve_chip,
             &self.scalar_chip,
             &mut transcript,
@@ -853,11 +853,11 @@ impl<S: SelfEmulation> VerifierGadget<S> {
     /// The proof is considered to be valid if the resulting accumulator
     /// satisfies the [invariant](crate::verifier::Accumulator::check)
     /// with respect to the relevant `tau_in_g2`.
-    pub fn prepare(
+    pub fn prepare<PCS: InCircuitPCS<S>>(
         &self,
         layouter: &mut impl Layouter<S::F>,
-        assigned_vk: &AssignedVk<S>,
-        assigned_committed_instances: &[AssignedKZGCommitment<S>],
+        assigned_vk: &AssignedVk<S, PCS>,
+        assigned_committed_instances: &[PCS::AssignedCommitment],
         assigned_instances: &[&[AssignedNative<S::F>]],
         proof: Value<Vec<u8>>,
     ) -> Result<AssignedAccumulator<S>, Error> {
@@ -924,7 +924,9 @@ pub(crate) mod tests {
         },
         testing_utils::FromScratch,
         types::{ComposableChip, Instantiable},
-        verifier::{accumulator::Accumulator, BlstrsEmulation},
+        verifier::{
+            accumulator::Accumulator, AssignedKZGCommitment, BlstrsEmulation, InCircuitKZG,
+        },
     };
 
     type S = BlstrsEmulation;
@@ -1090,12 +1092,13 @@ pub(crate) mod tests {
             let verifier_chip =
                 VerifierGadget::<S>::new(&curve_chip, &native_gadget, &poseidon_chip);
 
-            let assigned_inner_vk: AssignedVk<S> = verifier_chip.assign_vk_as_public_input(
-                &mut layouter,
-                &self.inner_vk.0,
-                &self.inner_vk.1,
-                self.inner_vk.2,
-            )?;
+            let assigned_inner_vk: AssignedVk<S, InCircuitKZG<S>> = verifier_chip
+                .assign_vk_as_public_input(
+                    &mut layouter,
+                    &self.inner_vk.0,
+                    &self.inner_vk.1,
+                    self.inner_vk.2,
+                )?;
 
             let assigned_committed_instance = AssignedKZGCommitment::assign(
                 &mut layouter,
@@ -1195,7 +1198,7 @@ pub(crate) mod tests {
         // The inner proof is ready.
         // Now, let us make a proof that we know an inner proof.
 
-        let mut public_inputs = AssignedVk::<S>::as_public_input(&inner_vk);
+        let mut public_inputs = AssignedVk::<S, InCircuitKZG<S>>::as_public_input(&inner_vk);
         public_inputs.extend(AssignedAccumulator::as_public_input(&inner_acc));
 
         let circuit = TestCircuit {


### PR DESCRIPTION
Add an in-circuit Polynomial Commitment Scheme abstraction mirroring `midnight_proofs::poly::commitment` for the in-circuit verifier:

  - `InCircuitHomomorphicCommitment<S>`: in-circuit `mul`/`add` on an additively homomorphic commitment.
  - `InCircuitPCS<S>`: the scheme itself (associated commitment type, `fixed_commitment`, `assign_commitment`, `read_commitment`, `common_commitment`).