### PR TITLE
ci: add drop-untriaged-on-assign dispatcher

### DIFF
--- a/.github/workflows/drop-untriaged-on-assign.yml
+++ b/.github/workflows/drop-untriaged-on-assign.yml
@@ -1,0 +1,17 @@
+name: Drop status:untriaged once an issue is assigned
+
+on:
+  issues:
+    types: [assigned, labeled]
+
+permissions:
+  issues: write
+
+concurrency:
+  group: drop-untriaged-${{ github.event.issue.number }}
+  cancel-in-progress: true
+
+jobs:
+  drop-untriaged:
+    name: Remove status:untriaged from assigned issues
+    uses: midnightntwrk/.github/.github/workflows/drop-untriaged-on-assign.yml@2703a25b1b9d634fffa23f4f7dbc9da73cd5f7fb


### PR DESCRIPTION
## Summary

Opts midnight-zk into the `drop-untriaged-on-assign` reusable in `midnightntwrk/.github` (#4) via a SHA-pinned dispatcher. Removes `status:untriaged` from an issue once it has an assignee — an assigned issue has been picked up, so the marker is stale.

Mirror of the shieldedtech rollout (shieldedtech/.github#12, shielded-iac#1698).

## Testing
- `actionlint -shellcheck=""` → PASS

_AI-assisted (disclosure)._
