### PR TITLE
Multi-Polynomial Commitment Schemes

### DIFF
--- a/aggregation/examples/single_circuit_aggregation.rs
+++ b/aggregation/examples/single_circuit_aggregation.rs
@@ -21,22 +21,21 @@ mod sha_preimage;
 use std::{collections::BTreeMap, time::Instant};
 
 use ff::Field;
-use group::Group;
 use midnight_aggregation::ivc::{self, IvcCircuit, IvcContext, IvcIO, IvcState, IvcTransition};
 use midnight_circuits::{
     hash::poseidon::{PoseidonChip, PoseidonState},
     instructions::{hash::HashCPU, *},
     types::{AssignedNative, Instantiable},
     verifier::{
-        self, Accumulator, AssignedAccumulator, AssignedKZGCommitment, AssignedVk, BlstrsEmulation,
-        InCircuitKZG, SelfEmulation,
+        self, Accumulator, AssignedAccumulator, AssignedKZGMultiCommitment, AssignedVk,
+        BlstrsEmulation, InCircuitKZG, SelfEmulation,
     },
 };
 use midnight_proofs::{
     circuit::{Layouter, Value},
     plonk::{self, ConstraintSystem, Error},
     poly::{
-        kzg::{commitment::KZGCommitment, params::ParamsVerifierKZG, KZGCommitmentScheme},
+        kzg::{commitment::KZGMultiCommitment, params::ParamsVerifierKZG, KZGCommitmentScheme},
         EvaluationDomain, PolynomialLabel,
     },
     transcript::{CircuitTranscript, Transcript},
@@ -240,8 +239,7 @@ impl IvcTransition for ProofAggregation {
             let dual_msm =
                 plonk::prepare::<F, KZGCommitmentScheme<E>, CircuitTranscript<PoseidonState<F>>>(
                     ctx.vk.vk(),
-                    &[KZGCommitment::Simple(
-                        C::identity(),
+                    &[KZGMultiCommitment::commitment_to_zero(
                         PolynomialLabel::Instance(0),
                     )],
                     &[&statement_pis],
@@ -305,10 +303,11 @@ impl IvcTransition for ProofAggregation {
         )?;
 
         // Verify the inner proof in-circuit.
-        let instance_com = AssignedKZGCommitment::<S>::simple(
-            self.std_lib.bls12_381().assign_fixed(layouter, C::identity())?,
+        let instance_com = AssignedKZGMultiCommitment::commitment_to_zero(
+            layouter,
+            self.std_lib.bls12_381(),
             PolynomialLabel::CommittedInstance(0),
-        );
+        )?;
 
         let inner_proof_acc = self.std_lib.verifier().prepare(
             layouter,

--- a/aggregation/examples/single_circuit_aggregation.rs
+++ b/aggregation/examples/single_circuit_aggregation.rs
@@ -240,7 +240,7 @@ impl IvcTransition for ProofAggregation {
                 plonk::prepare::<F, KZGCommitmentScheme<E>, CircuitTranscript<PoseidonState<F>>>(
                     ctx.vk.vk(),
                     &[KZGMultiCommitment::commitment_to_zero(
-                        PolynomialLabel::Instance(0),
+                        PolynomialLabel::CommittedInstance(0),
                     )],
                     &[&statement_pis],
                     &mut transcript,

--- a/aggregation/src/ivc/circuit.rs
+++ b/aggregation/src/ivc/circuit.rs
@@ -9,11 +9,12 @@
 //! there is no meaningful prior proof to verify, so the circuit substitutes a
 //! default accumulator that satisfies the verification invariant.
 
-use group::Group;
 use midnight_circuits::{
-    instructions::{AssignmentInstructions, BinaryInstructions, PublicInputInstructions},
+    instructions::{BinaryInstructions, PublicInputInstructions},
     types::Instantiable,
-    verifier::{Accumulator, AssignedAccumulator, AssignedKZGCommitment, AssignedVk, InCircuitKZG},
+    verifier::{
+        Accumulator, AssignedAccumulator, AssignedKZGMultiCommitment, AssignedVk, InCircuitKZG,
+    },
 };
 use midnight_proofs::{
     circuit::{Layouter, Value},
@@ -22,7 +23,7 @@ use midnight_proofs::{
 };
 use midnight_zk_stdlib::{Relation, ZkStdLib, ZkStdLibArch};
 
-use super::{Ivc, IvcError, C, F, S};
+use super::{Ivc, IvcError, F, S};
 
 /// The public instance (statement) of an IVC proof.
 ///
@@ -180,10 +181,11 @@ impl<T: Ivc> Relation for IvcCircuit<T> {
         ]
         .concat();
 
-        let instance_com = AssignedKZGCommitment::<S>::simple(
-            std_lib.bls12_381().assign_fixed(layouter, C::identity())?,
+        let instance_com = AssignedKZGMultiCommitment::commitment_to_zero(
+            layouter,
+            std_lib.bls12_381(),
             PolynomialLabel::CommittedInstance(0),
-        );
+        )?;
 
         // Verify a witnessed proof that ensures the validity of `prev_state`.
         // The proof is valid iff `prev_proof_acc` satisfies the invariant.

--- a/aggregation/src/ivc/prover.rs
+++ b/aggregation/src/ivc/prover.rs
@@ -7,7 +7,6 @@
 //! accumulates the result, produces a new proof for the updated state, and
 //! stores everything internally so the next step can build on it.
 
-use group::Group;
 use midnight_circuits::{
     hash::poseidon::PoseidonState,
     types::Instantiable,
@@ -16,7 +15,7 @@ use midnight_circuits::{
 use midnight_proofs::{
     plonk::{self},
     poly::{
-        kzg::{commitment::KZGCommitment, params::ParamsKZG, KZGCommitmentScheme},
+        kzg::{commitment::KZGMultiCommitment, params::ParamsKZG, KZGCommitmentScheme},
         PolynomialLabel,
     },
     transcript::{CircuitTranscript, Transcript},
@@ -24,7 +23,7 @@ use midnight_proofs::{
 use midnight_zk_stdlib::MidnightPK;
 use rand::rngs::OsRng;
 
-use super::{Ivc, IvcCircuit, IvcError, IvcInstance, IvcWitness, C, E, F, S};
+use super::{Ivc, IvcCircuit, IvcError, IvcInstance, IvcWitness, E, F, S};
 
 /// Stateful IVC prover holding:
 /// - the SRS (params),
@@ -100,8 +99,7 @@ impl<T: Ivc> IvcProver<T> {
             let dual_msm =
                 plonk::prepare::<F, KZGCommitmentScheme<E>, CircuitTranscript<PoseidonState<F>>>(
                     vk,
-                    &[KZGCommitment::Simple(
-                        C::identity(),
+                    &[KZGMultiCommitment::commitment_to_zero(
                         PolynomialLabel::Instance(0),
                     )],
                     &[&prev_pi],

--- a/aggregation/src/ivc/prover.rs
+++ b/aggregation/src/ivc/prover.rs
@@ -100,7 +100,7 @@ impl<T: Ivc> IvcProver<T> {
                 plonk::prepare::<F, KZGCommitmentScheme<E>, CircuitTranscript<PoseidonState<F>>>(
                     vk,
                     &[KZGMultiCommitment::commitment_to_zero(
-                        PolynomialLabel::Instance(0),
+                        PolynomialLabel::CommittedInstance(0),
                     )],
                     &[&prev_pi],
                     &mut transcript,

--- a/aggregation/src/ivc/verifier.rs
+++ b/aggregation/src/ivc/verifier.rs
@@ -5,19 +5,18 @@
 //! to the claimed state exists. Verification is constant-time regardless
 //! of how many steps the prover has performed.
 
-use group::Group;
 use midnight_circuits::{hash::poseidon::PoseidonState, verifier::Accumulator};
 use midnight_proofs::{
     plonk::{self},
     poly::{
-        kzg::{commitment::KZGCommitment, params::ParamsVerifierKZG, KZGCommitmentScheme},
+        kzg::{commitment::KZGMultiCommitment, params::ParamsVerifierKZG, KZGCommitmentScheme},
         PolynomialLabel,
     },
     transcript::{CircuitTranscript, Transcript},
 };
 use midnight_zk_stdlib::{MidnightVK, Relation};
 
-use super::{Ivc, IvcCircuit, IvcError, IvcInstance, C, E, F, S};
+use super::{Ivc, IvcCircuit, IvcError, IvcInstance, E, F, S};
 
 /// Lightweight IVC verifier carrying:
 /// - the application context (for the decider check),
@@ -66,8 +65,7 @@ impl<T: Ivc> IvcVerifier<T> {
         let dual_msm =
             plonk::prepare::<F, KZGCommitmentScheme<E>, CircuitTranscript<PoseidonState<F>>>(
                 self.vk.vk(),
-                &[KZGCommitment::Simple(
-                    C::identity(),
+                &[KZGMultiCommitment::commitment_to_zero(
                     PolynomialLabel::Instance(0),
                 )],
                 &[&pi],

--- a/aggregation/src/ivc/verifier.rs
+++ b/aggregation/src/ivc/verifier.rs
@@ -66,7 +66,7 @@ impl<T: Ivc> IvcVerifier<T> {
             plonk::prepare::<F, KZGCommitmentScheme<E>, CircuitTranscript<PoseidonState<F>>>(
                 self.vk.vk(),
                 &[KZGMultiCommitment::commitment_to_zero(
-                    PolynomialLabel::Instance(0),
+                    PolynomialLabel::CommittedInstance(0),
                 )],
                 &[&pi],
                 &mut transcript,

--- a/aggregation/src/multi_circuit_aggregator/circuit.rs
+++ b/aggregation/src/multi_circuit_aggregator/circuit.rs
@@ -16,18 +16,17 @@
 use std::collections::BTreeMap;
 
 use ff::Field;
-use group::Group;
 use midnight_circuits::{
     hash::poseidon::{PoseidonChip, PoseidonState},
     instructions::{hash::HashCPU, *},
     types::{AssignedNative, Instantiable},
-    verifier::{self, Accumulator, AssignedAccumulator, AssignedKZGCommitment},
+    verifier::{self, Accumulator, AssignedAccumulator, AssignedKZGMultiCommitment},
 };
 use midnight_proofs::{
     circuit::{Layouter, Value},
     plonk::{self, ConstraintSystem, Error},
     poly::{
-        kzg::{commitment::KZGCommitment, params::ParamsVerifierKZG, KZGCommitmentScheme},
+        kzg::{commitment::KZGMultiCommitment, params::ParamsVerifierKZG, KZGCommitmentScheme},
         EvaluationDomain, PolynomialLabel,
     },
     transcript::{CircuitTranscript, Transcript},
@@ -37,7 +36,7 @@ use midnight_zk_stdlib::{ZkStdLib, ZkStdLibArch};
 
 use super::aggregator::AggregationWitness;
 use crate::{
-    ivc::{IvcContext, IvcIO, IvcState, IvcTransition, C, E, F, S},
+    ivc::{IvcContext, IvcIO, IvcState, IvcTransition, E, F, S},
     multi_circuit_aggregator::{
         utils::{assign_as_public_inputs_and_hash_vk, compute_vk_hash},
         Claim,
@@ -262,8 +261,7 @@ impl IvcTransition for ProofAggregation {
             let dual_msm =
                 plonk::prepare::<F, KZGCommitmentScheme<E>, CircuitTranscript<PoseidonState<F>>>(
                     witness.claim.vk.vk(),
-                    &[KZGCommitment::Simple(
-                        C::identity(),
+                    &[KZGMultiCommitment::commitment_to_zero(
                         PolynomialLabel::Instance(0),
                     )],
                     &[&[statement]],
@@ -329,10 +327,11 @@ impl IvcTransition for ProofAggregation {
 
         // 3. Verify the inner proof in-circuit against the witnessed VK and statement.
         let inner_proof_acc = {
-            let instance_com = AssignedKZGCommitment::<S>::simple(
-                self.std_lib.bls12_381().assign_fixed(layouter, C::identity())?,
+            let instance_com = AssignedKZGMultiCommitment::commitment_to_zero(
+                layouter,
+                self.std_lib.bls12_381(),
                 PolynomialLabel::CommittedInstance(0),
-            );
+            )?;
             let mut acc = self.std_lib.verifier().prepare(
                 layouter,
                 &assigned_vk,

--- a/aggregation/src/multi_circuit_aggregator/circuit.rs
+++ b/aggregation/src/multi_circuit_aggregator/circuit.rs
@@ -262,7 +262,7 @@ impl IvcTransition for ProofAggregation {
                 plonk::prepare::<F, KZGCommitmentScheme<E>, CircuitTranscript<PoseidonState<F>>>(
                     witness.claim.vk.vk(),
                     &[KZGMultiCommitment::commitment_to_zero(
-                        PolynomialLabel::Instance(0),
+                        PolynomialLabel::CommittedInstance(0),
                     )],
                     &[&[statement]],
                     &mut transcript,

--- a/aggregation/src/multi_circuit_aggregator/utils.rs
+++ b/aggregation/src/multi_circuit_aggregator/utils.rs
@@ -71,13 +71,13 @@ pub fn assign_as_public_inputs_and_hash_vk(
     let nb_perm = cs.permutation().columns.len();
 
     // Witness the VK commitment points.
-    let base_values: Vec<Value<C>> = (0..nb_fixed)
-        .map(|i| vk.map(|vk| vk.vk().fixed_commitments()[i].clone().into_point()))
-        .chain(
-            (0..nb_perm)
-                .map(|i| vk.map(|vk| vk.vk().permutation().commitments()[i].clone().into_point())),
-        )
-        .collect();
+    let base_values: Vec<Value<C>> =
+        (0..nb_fixed)
+            .map(|i| vk.map(|vk| vk.vk().fixed_commitments()[i].0[0].clone().into_point()))
+            .chain((0..nb_perm).map(|i| {
+                vk.map(|vk| vk.vk().permutation().commitments()[i].0[0].clone().into_point())
+            }))
+            .collect();
 
     let assigned_bases = base_values
         .into_iter()

--- a/circuits/src/verifier/accumulator.rs
+++ b/circuits/src/verifier/accumulator.rs
@@ -113,10 +113,10 @@ impl<S: SelfEmulation> Accumulator<S> {
     /// Returns a trivial accumulator that satisfies the pairing invariant.
     ///
     /// Both sides evaluate to the identity point for any `fixed_bases` map:
-    /// * LHS: a single `Variable(identity)` with scalar `1`, label `Collapsed`.
+    /// * LHS: a single `Variable(identity)` with scalar `1`, label `NoLabel`.
     /// * RHS: one `Fixed` entry per label in `fixed_base_labels` with scalar
     ///   `0` (contributing nothing), plus one `Variable(identity)` with scalar
-    ///   `1` and label `Collapsed`.
+    ///   `1` and label `NoLabel`.
     pub fn trivial(fixed_base_labels: &[PolynomialLabel]) -> Self {
         let n = fixed_base_labels.len();
         let id = S::C::identity();
@@ -125,12 +125,12 @@ impl<S: SelfEmulation> Accumulator<S> {
             lhs: Msm::new(
                 &[Point::Variable(id)],
                 &[S::F::ONE],
-                &[PolynomialLabel::Collapsed],
+                &[PolynomialLabel::NoLabel],
             ),
             rhs: Msm::new(
                 &[vec![Point::Fixed; n], vec![Point::Variable(id)]].concat(),
                 &[vec![S::F::ZERO; n], vec![S::F::ONE]].concat(),
-                &[fixed_base_labels, &[PolynomialLabel::Collapsed]].concat(),
+                &[fixed_base_labels, &[PolynomialLabel::NoLabel]].concat(),
             ),
         }
     }
@@ -172,8 +172,8 @@ impl<S: SelfEmulation> Accumulator<S> {
     ///
     /// This function mutates self.
     pub fn collapse(&mut self) {
-        self.lhs.collapse();
-        self.rhs.collapse();
+        self.lhs.collapse(PolynomialLabel::NoLabel);
+        self.rhs.collapse(PolynomialLabel::NoLabel);
     }
 
     /// Accumulates several accumulators together. The resulting acc will
@@ -329,8 +329,8 @@ impl<S: SelfEmulation> AssignedAccumulator<S> {
         curve_chip: &S::CurveChip,
         scalar_chip: &S::ScalarChip,
     ) -> Result<(), Error> {
-        self.lhs.collapse(layouter, curve_chip, scalar_chip)?;
-        self.rhs.collapse(layouter, curve_chip, scalar_chip)
+        self.lhs.collapse(layouter, curve_chip, scalar_chip, PolynomialLabel::NoLabel)?;
+        self.rhs.collapse(layouter, curve_chip, scalar_chip, PolynomialLabel::NoLabel)
     }
 
     /// Resolves all `Fixed` bases in both internal MSMs by substituting their

--- a/circuits/src/verifier/kzg.rs
+++ b/circuits/src/verifier/kzg.rs
@@ -494,9 +494,9 @@ pub(crate) fn multi_prepare_kzg<S: SelfEmulation>(
         // powers are truncated. Exceptionally, the first one is not collapsed,
         // as the first x4 power is 1.
         #[cfg(feature = "truncated-challenges")]
-        coms.iter_mut()
-            .skip(1)
-            .try_for_each(|com| com.collapse(layouter, curve_chip, scalar_chip))?;
+        coms.iter_mut().skip(1).try_for_each(|com| {
+            com.collapse(layouter, curve_chip, scalar_chip, PolynomialLabel::NoLabel)
+        })?;
         coms.push(f_com.into_msm(layouter, scalar_chip)?);
 
         msm_inner_product(layouter, scalar_chip, &coms, &truncated_x4_powers)?

--- a/circuits/src/verifier/kzg.rs
+++ b/circuits/src/verifier/kzg.rs
@@ -503,7 +503,7 @@ pub(crate) fn multi_prepare_kzg<S: SelfEmulation>(
         for (idx, dummy_point) in dummy_openings {
             queries.push(VerifierQuery {
                 point: dummy_point,
-                commitment_ref: queries[idx].commitment_ref,
+                commitment: queries[idx].commitment,
                 label: queries[idx].label.clone(),
                 eval: transcript_gadget.read_scalar(layouter)?,
             });
@@ -522,7 +522,7 @@ pub(crate) fn multi_prepare_kzg<S: SelfEmulation>(
     let label_to_commitment: HashMap<PolynomialLabel, &AssignedKZGCommitment<S>> = queries
         .iter()
         .map(|q| {
-            let inners = &q.commitment_ref.0 .0;
+            let inners = &q.commitment.0;
             let inner = if inners.len() == 1 {
                 &inners[0]
             } else {

--- a/circuits/src/verifier/kzg.rs
+++ b/circuits/src/verifier/kzg.rs
@@ -27,6 +27,7 @@ use std::{
 };
 
 use ff::Field;
+use group::Group;
 use midnight_proofs::{
     circuit::{Layouter, Value},
     plonk::Error,
@@ -41,7 +42,7 @@ use crate::{
     types::InnerValue,
     verifier::{
         msm::{AssignedMsm, AssignedPoint},
-        pcs::{CommitmentReference, InCircuitHomomorphicCommitment, InCircuitPCS, VerifierQuery},
+        pcs::{InCircuitHomomorphicCommitment, InCircuitPCS, VerifierQuery},
         transcript_gadget::TranscriptGadget,
         utils::{
             evaluate_interpolated_polynomial, inner_product, mul_add, mul_bounded_scalars,
@@ -141,18 +142,159 @@ impl<S: SelfEmulation> AssignedKZGCommitment<S> {
     }
 }
 
-impl<S: SelfEmulation> Labelable for AssignedKZGCommitment<S> {
-    /// Adds a label to the assigned KZG commitment.
+impl<S: SelfEmulation> AssignedKZGCommitment<S> {
+    /// Attaches `label` to a freshly-read (`NoLabel`) commitment.
     ///
     /// # Panics
     ///
     /// If the commitment is not `Simple` or if it was already labeled.
-    fn label(self, label: PolynomialLabel) -> Self {
+    pub(crate) fn label(self, label: PolynomialLabel) -> Self {
         match self {
             Self::Simple(p, PolynomialLabel::NoLabel) => Self::Simple(p, label),
             Self::Simple(_, existing) => panic!("commitment is already labeled: {existing:?}"),
             Self::Linear(_, _, _) => panic!("KZGCommitment::Linear cannot be labeled"),
         }
+    }
+
+    /// Scales this commitment by a scalar.
+    ///
+    /// `Simple(p, l)` becomes `Linear([p], [scalar], [l])`.
+    /// For `Linear`, all existing scalars are multiplied by `scalar`.
+    fn mul(
+        self,
+        layouter: &mut impl Layouter<S::F>,
+        scalar_chip: &S::ScalarChip,
+        scalar: &AssignedNative<S::F>,
+    ) -> Result<Self, Error> {
+        let scalar = AssignedBoundedScalar::new(scalar, None);
+        match self {
+            Self::Simple(p, label) => Ok(Self::Linear(vec![p], vec![scalar], vec![label])),
+            Self::Linear(points, scalars, labels) => Ok(Self::Linear(
+                points,
+                scalars
+                    .iter()
+                    .map(|s| mul_bounded_scalars(layouter, scalar_chip, s, &scalar))
+                    .collect::<Result<Vec<_>, _>>()?,
+                labels,
+            )),
+        }
+    }
+
+    /// Adds two commitments, merging them into a `Linear` combination.
+    fn add(
+        self,
+        layouter: &mut impl Layouter<S::F>,
+        scalar_chip: &S::ScalarChip,
+        other: Self,
+    ) -> Result<Self, Error> {
+        let one = AssignedBoundedScalar::one(layouter, scalar_chip)?;
+        let (mut points, mut scalars, mut labels) = match self {
+            Self::Simple(p, label) => (vec![p], vec![one.clone()], vec![label]),
+            Self::Linear(points, scalars, labels) => (points, scalars, labels),
+        };
+        let (other_points, other_scalars, other_labels) = match other {
+            Self::Simple(p, label) => (vec![p], vec![one.clone()], vec![label]),
+            Self::Linear(points, scalars, labels) => (points, scalars, labels),
+        };
+        points.extend(other_points);
+        scalars.extend(other_scalars);
+        labels.extend(other_labels);
+        Ok(Self::Linear(points, scalars, labels))
+    }
+}
+
+/// In-circuit analog of
+/// [`KZGMultiCommitment`](midnight_proofs::poly::kzg::commitment::KZGMultiCommitment):
+/// a commitment to one or more polynomials.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct AssignedKZGMultiCommitment<S: SelfEmulation>(pub Vec<AssignedKZGCommitment<S>>);
+
+impl<S: SelfEmulation> AssignedKZGMultiCommitment<S> {
+    fn assert_single(&self) {
+        assert_eq!(
+            self.0.len(),
+            1,
+            "operation on AssignedKZGMultiCommitment requires exactly one polynomial"
+        );
+    }
+
+    /// Returns the single inner [`AssignedKZGCommitment`], panicking if this
+    /// commitment does not hold exactly one polynomial.
+    pub(crate) fn into_single(self) -> AssignedKZGCommitment<S> {
+        self.assert_single();
+        self.0.into_iter().next().unwrap()
+    }
+
+    /// In-circuit commitment to the zero polynomial (the identity point),
+    /// tagged with `label`. Used e.g. for empty committed-instance columns.
+    pub fn commitment_to_zero(
+        layouter: &mut impl Layouter<S::F>,
+        curve_chip: &S::CurveChip,
+        label: PolynomialLabel,
+    ) -> Result<Self, Error>
+    where
+        S::CurveChip: AssignmentInstructions<S::F, S::AssignedPoint>,
+    {
+        let point = curve_chip.assign_fixed(layouter, S::C::identity())?;
+        Ok(Self(vec![AssignedKZGCommitment::simple(point, label)]))
+    }
+}
+
+impl<S: SelfEmulation> InnerValue for AssignedKZGMultiCommitment<S> {
+    type Element = midnight_proofs::poly::kzg::commitment::KZGMultiCommitment<S::Engine>;
+
+    fn value(&self) -> Value<Self::Element> {
+        Value::from_iter(self.0.iter().map(|c| c.value()))
+            .map(midnight_proofs::poly::kzg::commitment::KZGMultiCommitment)
+    }
+}
+
+impl<S: SelfEmulation> Labelable for AssignedKZGMultiCommitment<S> {
+    /// Attaches one label per inner polynomial.
+    ///
+    /// # Panics
+    ///
+    /// If `labels.len() != self.length()`.
+    fn label(self, labels: &[PolynomialLabel]) -> Self {
+        assert_eq!(
+            labels.len(),
+            self.0.len(),
+            "label count must match polynomial count"
+        );
+        Self(self.0.into_iter().zip(labels).map(|(c, l)| c.label(l.clone())).collect())
+    }
+
+    fn length(&self) -> usize {
+        self.0.len()
+    }
+}
+
+impl<S: SelfEmulation> InCircuitHomomorphicCommitment<S> for AssignedKZGMultiCommitment<S> {
+    fn mul(
+        self,
+        layouter: &mut impl Layouter<S::F>,
+        scalar_chip: &S::ScalarChip,
+        scalar: &AssignedNative<S::F>,
+    ) -> Result<Self, Error> {
+        self.assert_single();
+        let inner = self.0.into_iter().next().unwrap().mul(layouter, scalar_chip, scalar)?;
+        Ok(Self(vec![inner]))
+    }
+
+    fn add(
+        self,
+        layouter: &mut impl Layouter<S::F>,
+        scalar_chip: &S::ScalarChip,
+        other: Self,
+    ) -> Result<Self, Error> {
+        self.assert_single();
+        other.assert_single();
+        let inner = self.0.into_iter().next().unwrap().add(
+            layouter,
+            scalar_chip,
+            other.0.into_iter().next().unwrap(),
+        )?;
+        Ok(Self(vec![inner]))
     }
 }
 
@@ -161,17 +303,17 @@ impl<S: SelfEmulation> Labelable for AssignedKZGCommitment<S> {
 // --------------------------------
 
 #[derive(Clone, Debug)]
-pub(crate) struct CommitmentData<S: SelfEmulation, T: PartialEq> {
-    commitment_ref: T,
+pub(crate) struct CommitmentData<S: SelfEmulation> {
+    label: PolynomialLabel,
     set_index: usize,
     point_indices: Vec<usize>,
     evals: Vec<AssignedNative<S::F>>,
 }
 
-impl<S: SelfEmulation, T: PartialEq> CommitmentData<S, T> {
-    fn new(commitment_ref: T) -> Self {
+impl<S: SelfEmulation> CommitmentData<S> {
+    fn new(label: PolynomialLabel) -> Self {
         CommitmentData {
-            commitment_ref,
+            label,
             set_index: 0,
             point_indices: vec![],
             evals: vec![],
@@ -179,19 +321,19 @@ impl<S: SelfEmulation, T: PartialEq> CommitmentData<S, T> {
     }
 }
 
-type IntermediateSets<S, T> = (
-    Vec<CommitmentData<S, T>>,
+type IntermediateSets<S> = (
+    Vec<CommitmentData<S>>,
     Vec<Vec<AssignedNative<<S as SelfEmulation>::F>>>,
 );
 
 #[allow(clippy::type_complexity)]
-fn construct_intermediate_sets<S: SelfEmulation, T: PartialEq + Copy>(
-    queries: &[(T, AssignedNative<S::F>, AssignedNative<S::F>)],
+fn construct_intermediate_sets<S: SelfEmulation>(
+    queries: &[(PolynomialLabel, AssignedNative<S::F>, AssignedNative<S::F>)],
     default_eval: AssignedNative<S::F>,
-) -> Result<IntermediateSets<S, T>, Error> {
+) -> Result<IntermediateSets<S>, Error> {
     // Construct sets of unique commitments and corresponding information about
     // their queries.
-    let mut commitment_map: Vec<CommitmentData<S, T>> = vec![];
+    let mut commitment_map: Vec<CommitmentData<S>> = vec![];
 
     // Also construct mapping from a unique point to a point_index. This defines
     // an ordering on the points.
@@ -203,19 +345,17 @@ fn construct_intermediate_sets<S: SelfEmulation, T: PartialEq + Copy>(
 
     // Iterate over all of the queries, computing the ordering of the points
     // while also creating new commitment data.
-    for (query_com_ref, query_point, _query_eval) in queries.iter() {
+    for (query_label, query_point, _query_eval) in queries.iter() {
         let num_points = point_index_map.len();
         let point_idx = point_index_map.entry(query_point).or_insert(num_points);
 
-        if let Some(pos) =
-            commitment_map.iter().position(|comm| &comm.commitment_ref == query_com_ref)
-        {
+        if let Some(pos) = commitment_map.iter().position(|comm| &comm.label == query_label) {
             if commitment_map[pos].point_indices.contains(point_idx) {
                 return Err(Error::Synthesis("repeated query".into()));
             }
             commitment_map[pos].point_indices.push(*point_idx);
         } else {
-            let mut tmp = CommitmentData::new(*query_com_ref);
+            let mut tmp = CommitmentData::new(query_label.clone());
             tmp.point_indices.push(*point_idx);
             commitment_map.push(tmp);
         }
@@ -240,7 +380,7 @@ fn construct_intermediate_sets<S: SelfEmulation, T: PartialEq + Copy>(
         }
 
         // Push point_index_set to CommitmentData for the relevant commitment
-        commitment_set_map.push((commitment_data.commitment_ref, point_index_set.clone()));
+        commitment_set_map.push((commitment_data.label.clone(), point_index_set.clone()));
 
         let num_sets = point_idx_sets.len();
         point_idx_sets.entry(point_index_set).or_insert(num_sets);
@@ -253,14 +393,14 @@ fn construct_intermediate_sets<S: SelfEmulation, T: PartialEq + Copy>(
     }
 
     // Populate set_index, evals and points for each commitment using point_idx_sets
-    for (query_com_ref, query_point, query_eval) in queries.iter() {
+    for (query_label, query_point, query_eval) in queries.iter() {
         // The index of the point at which the commitment is queried
         let point_index = point_index_map.get(&query_point).unwrap();
 
         // The point_index_set at which the commitment was queried
         let mut point_index_set = BTreeSet::new();
-        for (c, point_idx_set) in commitment_set_map.iter() {
-            if c == query_com_ref {
+        for (l, point_idx_set) in commitment_set_map.iter() {
+            if l == query_label {
                 point_index_set.clone_from(point_idx_set);
             }
         }
@@ -269,7 +409,7 @@ fn construct_intermediate_sets<S: SelfEmulation, T: PartialEq + Copy>(
         // The set_index of the point_index_set
         let set_index = point_idx_sets.get(&point_index_set).unwrap();
         for commitment_data in commitment_map.iter_mut() {
-            if query_com_ref == &commitment_data.commitment_ref {
+            if query_label == &commitment_data.label {
                 commitment_data.set_index = *set_index;
             }
         }
@@ -279,7 +419,7 @@ fn construct_intermediate_sets<S: SelfEmulation, T: PartialEq + Copy>(
         let point_index_in_set = point_index_set.iter().position(|i| i == point_index).unwrap();
 
         for commitment_data in commitment_map.iter_mut() {
-            if *query_com_ref == commitment_data.commitment_ref {
+            if *query_label == commitment_data.label {
                 // Insert the eval using the ordering of the point_index_set
                 commitment_data.evals[point_index_in_set] = query_eval.clone();
             }
@@ -357,13 +497,14 @@ pub(crate) fn multi_prepare_kzg<S: SelfEmulation>(
     // Add dummy queries to reduce the number of distinct multi-open point sets.
     #[cfg(feature = "fewer-point-sets")]
     let queries = &{
-        let pairs: Vec<_> = queries.iter().map(|q| (q.commitment_ref, q.point.clone())).collect();
+        let pairs: Vec<_> = queries.iter().map(|q| (q.label.clone(), q.point.clone())).collect();
         let dummy_openings = midnight_proofs::poly::kzg::compute_dummy_queries(&pairs);
         let mut queries = queries.to_vec();
         for (idx, dummy_point) in dummy_openings {
             queries.push(VerifierQuery {
                 point: dummy_point,
                 commitment_ref: queries[idx].commitment_ref,
+                label: queries[idx].label.clone(),
                 eval: transcript_gadget.read_scalar(layouter)?,
             });
         }
@@ -373,28 +514,41 @@ pub(crate) fn multi_prepare_kzg<S: SelfEmulation>(
     let x1 = transcript_gadget.squeeze_challenge(layouter)?;
     let x2 = transcript_gadget.squeeze_challenge(layouter)?;
 
+    // Peel each query's multi-commitment down to the single inner commitment it
+    // targets, keyed by the query label. A length-1 commitment (the common case,
+    // including the `Linear` linearization commitment) peels to its sole inner;
+    // a batched commitment holds several `Simple`s, so we pick the one whose own
+    // label matches the query.
+    let label_to_commitment: HashMap<PolynomialLabel, &AssignedKZGCommitment<S>> = queries
+        .iter()
+        .map(|q| {
+            let inners = &q.commitment_ref.0 .0;
+            let inner = if inners.len() == 1 {
+                &inners[0]
+            } else {
+                inners
+                    .iter()
+                    .find(|c| matches!(c, AssignedKZGCommitment::Simple(_, label) if *label == q.label))
+                    .expect("batched commitment has no polynomial matching the query label")
+            };
+            (q.label.clone(), inner)
+        })
+        .collect();
+
     let default_eval = scalar_chip.assign_fixed(layouter, S::F::default())?;
     let kzg_queries = queries
         .iter()
-        .map(|query| {
-            (
-                query.commitment_ref,
-                query.point.clone(),
-                query.eval.clone(),
-            )
-        })
+        .map(|query| (query.label.clone(), query.point.clone(), query.eval.clone()))
         .collect::<Vec<_>>();
-    let (commitment_map, point_sets) = construct_intermediate_sets::<
-        S,
-        CommitmentReference<AssignedKZGCommitment<S>>,
-    >(&kzg_queries, default_eval)?;
+    let (commitment_map, point_sets) =
+        construct_intermediate_sets::<S>(&kzg_queries, default_eval)?;
 
     let mut q_coms: Vec<_> = vec![vec![]; point_sets.len()];
     let mut q_eval_sets = vec![vec![]; point_sets.len()];
 
     for com_data in commitment_map.into_iter() {
         let mut msm = AssignedMsm::empty();
-        match com_data.commitment_ref.0 {
+        match label_to_commitment[&com_data.label] {
             AssignedKZGCommitment::Simple(p, label) => msm.add_term(&one, p, label),
             AssignedKZGCommitment::Linear(points, scalars, labels) => {
                 msm.add_msm(&AssignedMsm::new(scalars, points, labels))?;
@@ -437,8 +591,10 @@ pub(crate) fn multi_prepare_kzg<S: SelfEmulation>(
         (q_coms, q_eval_sets, point_sets)
     };
 
-    let f_com = transcript_gadget.read_commitment(layouter)?;
-    let f_com = f_com.label(PolynomialLabel::Custom("kzg_batch".into()));
+    let f_com = transcript_gadget
+        .read_commitment(layouter, 1)?
+        .label(&[PolynomialLabel::Custom("kzg_batch".into())])
+        .into_single();
 
     let x3 = transcript_gadget.squeeze_challenge(layouter)?;
     #[cfg(feature = "truncated-challenges")]
@@ -516,8 +672,9 @@ pub(crate) fn multi_prepare_kzg<S: SelfEmulation>(
     };
 
     let pi = transcript_gadget
-        .read_commitment(layouter)
-        .map(|c| c.label(PolynomialLabel::Custom("π".into())))?;
+        .read_commitment(layouter, 1)
+        .map(|c| c.label(&[PolynomialLabel::Custom("π".into())]))?
+        .into_single();
     let pi_msm = pi.into_msm(layouter, scalar_chip)?;
 
     // Scale zπ
@@ -538,74 +695,23 @@ pub(crate) fn multi_prepare_kzg<S: SelfEmulation>(
     Ok(AssignedAccumulator::new(left, right))
 }
 
-// -----------------------------------------------------------------------
-// InCircuitHomomorphicCommitment impl  (trait defined in pcs.rs)
-// -----------------------------------------------------------------------
-
-impl<S: SelfEmulation> InCircuitHomomorphicCommitment<S> for AssignedKZGCommitment<S> {
-    /// Scales this commitment by a scalar.
-    ///
-    /// `Simple(p, l)` becomes `Linear([p], [scalar], [l])`.
-    /// For `Linear`, all existing scalars are multiplied by `scalar`.
-    fn mul(
-        self,
-        layouter: &mut impl Layouter<S::F>,
-        scalar_chip: &S::ScalarChip,
-        scalar: &AssignedNative<S::F>,
-    ) -> Result<Self, Error> {
-        let scalar = AssignedBoundedScalar::new(scalar, None);
-        match self {
-            Self::Simple(p, label) => Ok(Self::Linear(vec![p], vec![scalar], vec![label])),
-            Self::Linear(points, scalars, labels) => Ok(Self::Linear(
-                points,
-                scalars
-                    .iter()
-                    .map(|s| mul_bounded_scalars(layouter, scalar_chip, s, &scalar))
-                    .collect::<Result<Vec<_>, _>>()?,
-                labels,
-            )),
-        }
-    }
-
-    /// Adds two commitments, merging them into a `Linear` combination.
-    fn add(
-        self,
-        layouter: &mut impl Layouter<S::F>,
-        scalar_chip: &S::ScalarChip,
-        other: Self,
-    ) -> Result<Self, Error> {
-        let one = AssignedBoundedScalar::one(layouter, scalar_chip)?;
-        let (mut points, mut scalars, mut labels) = match self {
-            Self::Simple(p, label) => (vec![p], vec![one.clone()], vec![label]),
-            Self::Linear(points, scalars, labels) => (points, scalars, labels),
-        };
-        let (other_points, other_scalars, other_labels) = match other {
-            Self::Simple(p, label) => (vec![p], vec![one.clone()], vec![label]),
-            Self::Linear(points, scalars, labels) => (points, scalars, labels),
-        };
-        points.extend(other_points);
-        scalars.extend(other_scalars);
-        labels.extend(other_labels);
-        Ok(Self::Linear(points, scalars, labels))
-    }
-}
-
 /// KZG instantiation of [`InCircuitPCS`].
 #[derive(Clone, Copy, Debug)]
 pub struct InCircuitKZG<S: SelfEmulation>(PhantomData<S>);
 
 impl<S: SelfEmulation> InCircuitPCS<S> for InCircuitKZG<S> {
-    type AssignedCommitment = AssignedKZGCommitment<S>;
+    type AssignedCommitment = AssignedKZGMultiCommitment<S>;
 
     fn fixed_commitment(label: PolynomialLabel) -> Self::AssignedCommitment {
-        AssignedKZGCommitment::fixed(label)
+        AssignedKZGMultiCommitment(vec![AssignedKZGCommitment::fixed(label)])
     }
 
     fn read_commitment(
         transcript: &mut TranscriptGadget<S>,
         layouter: &mut impl Layouter<S::F>,
+        length: usize,
     ) -> Result<Self::AssignedCommitment, Error> {
-        transcript.read_commitment(layouter)
+        transcript.read_commitment(layouter, length)
     }
 
     fn assign_commitment(
@@ -614,13 +720,15 @@ impl<S: SelfEmulation> InCircuitPCS<S> for InCircuitKZG<S> {
         value: Value<S::C>,
         label: PolynomialLabel,
     ) -> Result<Self::AssignedCommitment, Error> {
-        AssignedKZGCommitment::assign(layouter, curve_chip, value, label)
+        Ok(AssignedKZGMultiCommitment(vec![
+            AssignedKZGCommitment::assign(layouter, curve_chip, value, label)?,
+        ]))
     }
 
     fn common_commitment(
         transcript: &mut TranscriptGadget<S>,
         layouter: &mut impl Layouter<S::F>,
-        commitment: &AssignedKZGCommitment<S>,
+        commitment: &AssignedKZGMultiCommitment<S>,
     ) -> Result<(), Error> {
         transcript.common_commitment(layouter, commitment)
     }

--- a/circuits/src/verifier/lookup.rs
+++ b/circuits/src/verifier/lookup.rs
@@ -62,19 +62,19 @@ pub(crate) struct Evaluated<S: SelfEmulation, PCS: InCircuitPCS<S>> {
 
 /// Reads the prover's multiplicities commitment from the transcript.
 pub(crate) fn read_multiplicities<S: SelfEmulation, PCS: InCircuitPCS<S>>(
-    name: &str,
+    argument_index: usize,
     layouter: &mut impl Layouter<S::F>,
     transcript_gadget: &mut TranscriptGadget<S>,
 ) -> Result<CommittedMultiplicities<S, PCS>, Error> {
     let multiplicities = PCS::read_commitment(transcript_gadget, layouter)
-        .map(|c| c.label(PolynomialLabel::LogupMultiplicities(name.to_owned())))?;
+        .map(|c| c.label(PolynomialLabel::LogupMultiplicities(argument_index)))?;
     Ok(CommittedMultiplicities { multiplicities })
 }
 
 impl<S: SelfEmulation, PCS: InCircuitPCS<S>> CommittedMultiplicities<S, PCS> {
     pub(crate) fn read_commitment(
         self,
-        name: &str,
+        argument_index: usize,
         nb_flattened: usize,
         layouter: &mut impl Layouter<S::F>,
         transcript_gadget: &mut TranscriptGadget<S>,
@@ -82,11 +82,11 @@ impl<S: SelfEmulation, PCS: InCircuitPCS<S>> CommittedMultiplicities<S, PCS> {
         let helper_polys = (0..nb_flattened)
             .map(|_| {
                 PCS::read_commitment(transcript_gadget, layouter)
-                    .map(|c| c.label(PolynomialLabel::LogupHelper(name.to_owned())))
+                    .map(|c| c.label(PolynomialLabel::LogupHelper(argument_index)))
             })
             .collect::<Result<Vec<_>, Error>>()?;
         let accumulator = PCS::read_commitment(transcript_gadget, layouter)
-            .map(|c| c.label(PolynomialLabel::LogupAggregator(name.to_owned())))?;
+            .map(|c| c.label(PolynomialLabel::LogupAggregator(argument_index)))?;
 
         Ok(Committed {
             multiplicities: self.multiplicities,

--- a/circuits/src/verifier/lookup.rs
+++ b/circuits/src/verifier/lookup.rs
@@ -48,6 +48,7 @@ pub(crate) struct LookupEvaluated<S: SelfEmulation> {
 /// Commitments to the LogUp polynomials, read from the transcript.
 #[derive(Clone, Debug)]
 pub(crate) struct Committed<S: SelfEmulation, PCS: InCircuitPCS<S>> {
+    argument_index: usize,
     multiplicities: PCS::AssignedCommitment,
     helper_polys: Vec<PCS::AssignedCommitment>,
     accumulator: PCS::AssignedCommitment,
@@ -66,8 +67,8 @@ pub(crate) fn read_multiplicities<S: SelfEmulation, PCS: InCircuitPCS<S>>(
     layouter: &mut impl Layouter<S::F>,
     transcript_gadget: &mut TranscriptGadget<S>,
 ) -> Result<CommittedMultiplicities<S, PCS>, Error> {
-    let multiplicities = PCS::read_commitment(transcript_gadget, layouter)
-        .map(|c| c.label(PolynomialLabel::LogupMultiplicities(argument_index)))?;
+    let multiplicities = PCS::read_commitment(transcript_gadget, layouter, 1)
+        .map(|c| c.label(&[PolynomialLabel::LogupMultiplicities(argument_index)]))?;
     Ok(CommittedMultiplicities { multiplicities })
 }
 
@@ -81,14 +82,15 @@ impl<S: SelfEmulation, PCS: InCircuitPCS<S>> CommittedMultiplicities<S, PCS> {
     ) -> Result<Committed<S, PCS>, Error> {
         let helper_polys = (0..nb_flattened)
             .map(|j| {
-                PCS::read_commitment(transcript_gadget, layouter)
-                    .map(|c| c.label(PolynomialLabel::LogupHelper(argument_index, j)))
+                PCS::read_commitment(transcript_gadget, layouter, 1)
+                    .map(|c| c.label(&[PolynomialLabel::LogupHelper(argument_index, j)]))
             })
             .collect::<Result<Vec<_>, Error>>()?;
-        let accumulator = PCS::read_commitment(transcript_gadget, layouter)
-            .map(|c| c.label(PolynomialLabel::LogupAggregator(argument_index)))?;
+        let accumulator = PCS::read_commitment(transcript_gadget, layouter, 1)
+            .map(|c| c.label(&[PolynomialLabel::LogupAggregator(argument_index)]))?;
 
         Ok(Committed {
+            argument_index,
             multiplicities: self.multiplicities,
             helper_polys,
             accumulator,
@@ -130,30 +132,43 @@ impl<'a, S: SelfEmulation, PCS: InCircuitPCS<S>> Evaluated<S, PCS> {
         x: &AssignedNative<S::F>,      // evaluation point x
         x_next: &AssignedNative<S::F>, // ωx
     ) -> Vec<VerifierQuery<'a, S, PCS>> {
+        let arg = self.committed.argument_index;
         let mut queries = vec![
             // Open lookup product commitment at x
             VerifierQuery::new(
                 x,
                 &self.committed.multiplicities,
+                PolynomialLabel::LogupMultiplicities(arg),
                 &self.evaluated.multiplicities_eval,
             ),
         ];
         // Open lookup input commitments at x
-        for (h_commit, h_eval) in
-            self.committed.helper_polys.iter().zip(self.evaluated.helper_evals.iter())
+        for (j, (h_commit, h_eval)) in self
+            .committed
+            .helper_polys
+            .iter()
+            .zip(self.evaluated.helper_evals.iter())
+            .enumerate()
         {
-            queries.push(VerifierQuery::new(x, h_commit, h_eval));
+            queries.push(VerifierQuery::new(
+                x,
+                h_commit,
+                PolynomialLabel::LogupHelper(arg, j),
+                h_eval,
+            ));
         }
         // Open lookup table commitments at x
         queries.push(VerifierQuery::new(
             x,
             &self.committed.accumulator,
+            PolynomialLabel::LogupAggregator(arg),
             &self.evaluated.accumulator_eval,
         ));
         // Open lookup product commitment at \omega x
         queries.push(VerifierQuery::new(
             x_next,
             &self.committed.accumulator,
+            PolynomialLabel::LogupAggregator(arg),
             &self.evaluated.accumulator_next_eval,
         ));
         queries

--- a/circuits/src/verifier/lookup.rs
+++ b/circuits/src/verifier/lookup.rs
@@ -80,9 +80,9 @@ impl<S: SelfEmulation, PCS: InCircuitPCS<S>> CommittedMultiplicities<S, PCS> {
         transcript_gadget: &mut TranscriptGadget<S>,
     ) -> Result<Committed<S, PCS>, Error> {
         let helper_polys = (0..nb_flattened)
-            .map(|_| {
+            .map(|j| {
                 PCS::read_commitment(transcript_gadget, layouter)
-                    .map(|c| c.label(PolynomialLabel::LogupHelper(argument_index)))
+                    .map(|c| c.label(PolynomialLabel::LogupHelper(argument_index, j)))
             })
             .collect::<Result<Vec<_>, Error>>()?;
         let accumulator = PCS::read_commitment(transcript_gadget, layouter)

--- a/circuits/src/verifier/mod.rs
+++ b/circuits/src/verifier/mod.rs
@@ -43,7 +43,7 @@ mod utils;
 mod verifier_gadget;
 
 pub use accumulator::{Accumulator, AssignedAccumulator};
-pub use kzg::{AssignedKZGCommitment, InCircuitKZG};
+pub use kzg::{AssignedKZGCommitment, AssignedKZGMultiCommitment, InCircuitKZG};
 pub use msm::{AssignedMsm, AssignedPoint, Msm, Point};
 pub use pcs::{InCircuitHomomorphicCommitment, InCircuitPCS};
 #[cfg(feature = "dev-curves")]
@@ -120,11 +120,11 @@ pub fn fixed_bases<S: SelfEmulation>(vk: &VerifyingKey<S>) -> BTreeMap<Polynomia
     let perm_commitments = vk.permutation().commitments();
 
     for (i, com) in fixed_commitments.iter().enumerate() {
-        fixed_bases.insert(PolynomialLabel::Fixed(i), *com.as_point());
+        fixed_bases.insert(PolynomialLabel::Fixed(i), *com.0[0].as_point());
     }
 
     for (i, com) in perm_commitments.iter().enumerate() {
-        fixed_bases.insert(PolynomialLabel::PermutationFixed(i), *com.as_point());
+        fixed_bases.insert(PolynomialLabel::PermutationFixed(i), *com.0[0].as_point());
     }
 
     fixed_bases.insert(PolynomialLabel::Custom("-G".into()), -S::C::generator());

--- a/circuits/src/verifier/msm.rs
+++ b/circuits/src/verifier/msm.rs
@@ -224,16 +224,16 @@ impl<S: SelfEmulation> Msm<S> {
     }
 
     /// Collapses the variable-base part into a single `(collapsed-point, 1)`
-    /// term.
+    /// term, labeling the result with `label`.
     ///
     /// All `Variable` entries are accumulated into one curve point via MSM and
-    /// stored with scalar `1` and label `PolynomialLabel::Collapsed`.
+    /// stored with scalar `1` and the given `label`.
     /// `Fixed` entries are preserved: terms sharing the same label have their
     /// scalars summed. After the call the MSM has exactly one `Variable` entry
     /// (the collapsed result) plus one `Fixed` entry per distinct fixed label.
     ///
     /// This function mutates `self`.
-    pub fn collapse(&mut self) {
+    pub fn collapse(&mut self, label: PolynomialLabel) {
         // We allocate max capacity but we may not fill it.
         let n = self.bases.len();
         let mut variable_bases = Vec::<S::G1Affine>::with_capacity(n);
@@ -263,7 +263,7 @@ impl<S: SelfEmulation> Msm<S> {
         let collapsed_base = msm_best(&variable_scalars, &variable_bases);
         bases.push(Point::Variable(collapsed_base));
         scalars.push(S::F::ONE);
-        labels.push(PolynomialLabel::Collapsed);
+        labels.push(label);
 
         self.bases = bases;
         self.scalars = scalars;
@@ -303,10 +303,10 @@ impl<S: SelfEmulation> Msm<S> {
     pub fn eval(&self, fixed_bases: &BTreeMap<PolynomialLabel, S::C>) -> S::C {
         let mut msm = self.clone();
         msm.resolve_fixed_bases(fixed_bases);
-        msm.collapse();
+        msm.collapse(PolynomialLabel::NoLabel);
 
         debug_assert_eq!(msm.scalars, vec![S::F::ONE]);
-        debug_assert_eq!(msm.labels, vec![PolynomialLabel::Collapsed]);
+        debug_assert_eq!(msm.labels, vec![PolynomialLabel::NoLabel]);
 
         match msm.bases.as_slice() {
             [Point::Variable(p)] => *p,
@@ -573,9 +573,10 @@ impl<S: SelfEmulation> AssignedMsm<S> {
     /// In-circuit analog of [`Msm::collapse`].
     ///
     /// Reduces the variable-base part to a single MSM point via the circuit's
-    /// MSM chip. Fixed-base terms sharing the same label have their scalars
-    /// added in-circuit. After the call, the MSM has one `Variable` entry
-    /// (label `Collapsed`) and one `Fixed` entry per distinct fixed label.
+    /// MSM chip, labeling the result with `label`. Fixed-base terms sharing the
+    /// same label have their scalars added in-circuit. After the call, the MSM
+    /// has one `Variable` entry (the collapsed result) and one `Fixed` entry
+    /// per distinct fixed label.
     ///
     /// This function mutates `self`.
     pub fn collapse(
@@ -583,6 +584,7 @@ impl<S: SelfEmulation> AssignedMsm<S> {
         layouter: &mut impl Layouter<S::F>,
         curve_chip: &S::CurveChip,
         scalar_chip: &S::ScalarChip,
+        label: PolynomialLabel,
     ) -> Result<(), Error> {
         // We allocate max capacity but we may not fill it.
         let n = self.bases.len();
@@ -623,7 +625,7 @@ impl<S: SelfEmulation> AssignedMsm<S> {
         let collapsed_base = S::msm(layouter, curve_chip, &variable_scalars, &variable_bases)?;
         bases.push(AssignedPoint::Variable(collapsed_base));
         scalars.push(AssignedBoundedScalar::one(layouter, scalar_chip)?);
-        labels.push(PolynomialLabel::Collapsed);
+        labels.push(label);
 
         self.bases = bases;
         self.scalars = scalars;

--- a/circuits/src/verifier/pcs.rs
+++ b/circuits/src/verifier/pcs.rs
@@ -29,33 +29,6 @@ use crate::{
 };
 
 // ---------------------------------------------------------------------------
-// CommitmentReference  (mirrors proofs/src/poly/query.rs)
-// ---------------------------------------------------------------------------
-
-/// A pointer to an in-circuit commitment, with pointer-based equality.
-///
-/// Two references are equal iff they point to the same allocation, so
-/// commitments are grouped by identity rather than by value.
-pub(crate) struct CommitmentReference<'a, C>(pub(crate) &'a C);
-
-impl<C> Clone for CommitmentReference<'_, C> {
-    fn clone(&self) -> Self {
-        *self
-    }
-}
-impl<C> Copy for CommitmentReference<'_, C> {}
-impl<C: Debug> Debug for CommitmentReference<'_, C> {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        self.0.fmt(f)
-    }
-}
-impl<C> PartialEq for CommitmentReference<'_, C> {
-    fn eq(&self, other: &Self) -> bool {
-        std::ptr::eq(self.0, other.0)
-    }
-}
-
-// ---------------------------------------------------------------------------
 // VerifierQuery  (mirrors proofs/src/poly/query.rs)
 // ---------------------------------------------------------------------------
 
@@ -63,7 +36,7 @@ impl<C> PartialEq for CommitmentReference<'_, C> {
 #[derive(Clone, Debug)]
 pub struct VerifierQuery<'a, S: SelfEmulation, PCS: InCircuitPCS<S>> {
     pub(crate) point: AssignedNative<S::F>,
-    pub(crate) commitment_ref: CommitmentReference<'a, PCS::AssignedCommitment>,
+    pub(crate) commitment: &'a PCS::AssignedCommitment,
     pub(crate) label: PolynomialLabel,
     pub(crate) eval: AssignedNative<S::F>,
 }
@@ -77,7 +50,7 @@ impl<'a, S: SelfEmulation, PCS: InCircuitPCS<S>> VerifierQuery<'a, S, PCS> {
     ) -> Self {
         Self {
             point: point.clone(),
-            commitment_ref: CommitmentReference(commitment),
+            commitment,
             label,
             eval: eval.clone(),
         }

--- a/circuits/src/verifier/pcs.rs
+++ b/circuits/src/verifier/pcs.rs
@@ -64,6 +64,7 @@ impl<C> PartialEq for CommitmentReference<'_, C> {
 pub struct VerifierQuery<'a, S: SelfEmulation, PCS: InCircuitPCS<S>> {
     pub(crate) point: AssignedNative<S::F>,
     pub(crate) commitment_ref: CommitmentReference<'a, PCS::AssignedCommitment>,
+    pub(crate) label: PolynomialLabel,
     pub(crate) eval: AssignedNative<S::F>,
 }
 
@@ -71,11 +72,13 @@ impl<'a, S: SelfEmulation, PCS: InCircuitPCS<S>> VerifierQuery<'a, S, PCS> {
     pub fn new(
         point: &AssignedNative<S::F>,
         commitment: &'a PCS::AssignedCommitment,
+        label: PolynomialLabel,
         eval: &AssignedNative<S::F>,
     ) -> Self {
         Self {
             point: point.clone(),
             commitment_ref: CommitmentReference(commitment),
+            label,
             eval: eval.clone(),
         }
     }
@@ -125,10 +128,13 @@ pub trait InCircuitPCS<S: SelfEmulation>: Sized + Clone + Debug {
         label: PolynomialLabel,
     ) -> Result<Self::AssignedCommitment, Error>;
 
-    /// Reads one commitment from the proof transcript.
+    /// Reads one commitment (to `length` polynomials) from the proof
+    /// transcript. Commitments are not length-prefixed on the wire, so the
+    /// caller supplies the polynomial count (`1` unless batched).
     fn read_commitment(
         transcript: &mut TranscriptGadget<S>,
         layouter: &mut impl Layouter<S::F>,
+        length: usize,
     ) -> Result<Self::AssignedCommitment, Error>;
 
     /// Absorbs a commitment into the proof transcript.

--- a/circuits/src/verifier/permutation.rs
+++ b/circuits/src/verifier/permutation.rs
@@ -65,11 +65,11 @@ pub(crate) fn read_product_commitments<S: SelfEmulation, PCS: InCircuitPCS<S>>(
         .permutation()
         .get_columns()
         .chunks(chunk_len)
-        .map(|_| PCS::read_commitment(transcript_gadget, layouter))
+        .map(|_| PCS::read_commitment(transcript_gadget, layouter, 1))
         .collect::<Result<Vec<_>, _>>()?
         .into_iter()
         .enumerate()
-        .map(|(i, c)| c.label(PolynomialLabel::PermutationAccumulator(i)))
+        .map(|(i, c)| c.label(&[PolynomialLabel::PermutationAccumulator(i)]))
         .collect();
 
     Ok(Committed {
@@ -139,11 +139,13 @@ impl<'a, S: SelfEmulation, PCS: InCircuitPCS<S>> Evaluated<S, PCS> {
             queries.push(VerifierQuery::new(
                 x,
                 &self.coms.permutation_product_commitments[i],
+                PolynomialLabel::PermutationAccumulator(i),
                 &set.permutation_product_eval,
             ));
             queries.push(VerifierQuery::new(
                 x_next,
                 &self.coms.permutation_product_commitments[i],
+                PolynomialLabel::PermutationAccumulator(i),
                 &set.permutation_product_next_eval,
             ));
         }
@@ -153,6 +155,7 @@ impl<'a, S: SelfEmulation, PCS: InCircuitPCS<S>> Evaluated<S, PCS> {
             queries.push(VerifierQuery::new(
                 x_last,
                 &self.coms.permutation_product_commitments[i],
+                PolynomialLabel::PermutationAccumulator(i),
                 set.permutation_product_last_eval.as_ref().unwrap(),
             ));
         }
@@ -172,7 +175,10 @@ impl<S: SelfEmulation> CommonEvaluated<S> {
         vkey_commitments
             .iter()
             .zip(self.permutation_evals.iter())
-            .map(|(commitment, eval)| VerifierQuery::new(x, *commitment, eval))
+            .enumerate()
+            .map(|(i, (commitment, eval))| {
+                VerifierQuery::new(x, *commitment, PolynomialLabel::PermutationFixed(i), eval)
+            })
             .collect()
     }
 }

--- a/circuits/src/verifier/transcript_gadget.rs
+++ b/circuits/src/verifier/transcript_gadget.rs
@@ -25,7 +25,11 @@ use midnight_proofs::{
 use crate::{
     instructions::{AssignmentInstructions, PublicInputInstructions, SpongeInstructions},
     types::AssignedNative,
-    verifier::{kzg::AssignedKZGCommitment, msm::AssignedPoint, SelfEmulation},
+    verifier::{
+        kzg::{AssignedKZGCommitment, AssignedKZGMultiCommitment},
+        msm::AssignedPoint,
+        SelfEmulation,
+    },
 };
 
 type SpongeState<S> = <<S as SelfEmulation>::SpongeChip as SpongeInstructions<
@@ -98,28 +102,33 @@ impl<S: SelfEmulation> TranscriptGadget<S> {
         self.sponge_chip.absorb(layouter, state, std::slice::from_ref(scalar))
     }
 
-    /// Absorbs a commitment into the transcript.
+    /// Absorbs a commitment into the transcript, one inner polynomial point at
+    /// a time (the absorbed input never includes the multi-commitment's
+    /// length prefix, matching the off-circuit `Hashable::to_input`).
     pub fn common_commitment(
         &mut self,
         layouter: &mut impl Layouter<S::F>,
-        point: &AssignedKZGCommitment<S>,
+        commitment: &AssignedKZGMultiCommitment<S>,
     ) -> Result<(), Error> {
-        let pis = match point {
-            AssignedKZGCommitment::Simple(AssignedPoint::Variable(p), _label) => {
-                self.curve_chip.as_public_input(layouter, p)
-            }
-            AssignedKZGCommitment::Simple(AssignedPoint::Fixed, label) => Err(Synthesis(format!(
-                "Fixed commitments cannot be added to the transcript: {label}"
-            ))),
-            AssignedKZGCommitment::Linear(_, _, labels) => Err(Synthesis(format!(
-                "Linear commitments cannot be added to the transcript: {labels:?}"
-            ))),
-        }?;
+        for inner in commitment.0.iter() {
+            let pis = match inner {
+                AssignedKZGCommitment::Simple(AssignedPoint::Variable(p), _label) => {
+                    self.curve_chip.as_public_input(layouter, p)
+                }
+                AssignedKZGCommitment::Simple(AssignedPoint::Fixed, label) => Err(Synthesis(
+                    format!("Fixed commitments cannot be added to the transcript: {label}"),
+                )),
+                AssignedKZGCommitment::Linear(_, _, labels) => Err(Synthesis(format!(
+                    "Linear commitments cannot be added to the transcript: {labels:?}"
+                ))),
+            }?;
 
-        self.input_len += pis.len();
+            self.input_len += pis.len();
 
-        let state = self.sponge_state.as_mut().expect("You must init the transcript gadget");
-        self.sponge_chip.absorb(layouter, state, &pis)
+            let state = self.sponge_state.as_mut().expect("You must init the transcript gadget");
+            self.sponge_chip.absorb(layouter, state, &pis)?;
+        }
+        Ok(())
     }
 
     /// Derives a scalar challenge from the current transcript.
@@ -131,30 +140,44 @@ impl<S: SelfEmulation> TranscriptGadget<S> {
         self.sponge_chip.squeeze(layouter, state)
     }
 
-    /// Reads the next curve point from the prover transcript and absorbs it
-    /// into the running hash state.
+    /// Reads `length` curve points from the prover transcript (one per
+    /// polynomial held by the commitment) and absorbs them into the running
+    /// hash state.
     ///
-    /// Returns an [`AssignedKZGCommitment::Simple`] with label
-    /// [`PolynomialLabel::NoLabel`]; callers must attach a label with
-    /// `.label(...)` before using the commitment in verifier queries.
+    /// Commitments are not length-prefixed on the wire, so the caller supplies
+    /// the number of polynomials (`1` unless the commitment is batched).
+    ///
+    /// Returns an [`AssignedKZGMultiCommitment`] whose inner commitments are
+    /// labeled [`PolynomialLabel::NoLabel`]; callers must attach labels with
+    /// `.label(...)` before using it in verifier queries.
     ///
     /// # Warning
     ///
-    /// The received point is not enforced to be in the prime-order subgroup.
+    /// The received points are not enforced to be in the prime-order subgroup.
     pub fn read_commitment(
         &mut self,
         layouter: &mut impl Layouter<S::F>,
-    ) -> Result<AssignedKZGCommitment<S>, Error> {
-        let reader = self.transcript_reader.as_mut().expect("You must init the transcript gadget");
-        // If an error, do not fail, assign a default commitment instead.
-        // (This allows us to parse dummy proofs.)
-        let point: Value<S::C> = match reader.read::<S::C>() {
-            Ok(point) => Value::known(point),
-            Err(_) => Value::known(S::C::default()),
-        };
+        length: usize,
+    ) -> Result<AssignedKZGMultiCommitment<S>, Error> {
+        let mut inners = Vec::with_capacity(length);
+        for _ in 0..length {
+            let reader =
+                self.transcript_reader.as_mut().expect("You must init the transcript gadget");
+            // If an error, do not fail, assign a default commitment instead.
+            // (This allows us to parse dummy proofs.)
+            let point: Value<S::C> = match reader.read::<S::C>() {
+                Ok(point) => Value::known(point),
+                Err(_) => Value::known(S::C::default()),
+            };
+            let assigned_point =
+                S::assign_without_subgroup_check(layouter, &self.curve_chip, point)?;
+            inners.push(AssignedKZGCommitment::simple(
+                assigned_point,
+                PolynomialLabel::NoLabel,
+            ));
+        }
 
-        let assigned_point = S::assign_without_subgroup_check(layouter, &self.curve_chip, point)?;
-        let assigned_com = AssignedKZGCommitment::simple(assigned_point, PolynomialLabel::NoLabel);
+        let assigned_com = AssignedKZGMultiCommitment(inners);
         self.common_commitment(layouter, &assigned_com)?;
 
         Ok(assigned_com)
@@ -318,10 +341,9 @@ mod tests {
                         &transcript_gadget.curve_chip,
                         *p,
                     )?;
-                    Ok(AssignedKZGCommitment::simple(
-                        assigned_p,
-                        PolynomialLabel::NoLabel,
-                    ))
+                    Ok(AssignedKZGMultiCommitment(vec![
+                        AssignedKZGCommitment::simple(assigned_p, PolynomialLabel::NoLabel),
+                    ]))
                 })
                 .collect::<Result<Vec<_>, Error>>()?;
 

--- a/circuits/src/verifier/trash.rs
+++ b/circuits/src/verifier/trash.rs
@@ -38,6 +38,7 @@ pub(crate) struct TrashEvaluated<S: SelfEmulation> {
 
 #[derive(Clone, Debug)]
 pub(crate) struct Committed<S: SelfEmulation, PCS: InCircuitPCS<S>> {
+    argument_index: usize,
     trash_commitment: PCS::AssignedCommitment,
 }
 
@@ -52,10 +53,13 @@ pub(crate) fn read_committed<S: SelfEmulation, PCS: InCircuitPCS<S>>(
     layouter: &mut impl Layouter<S::F>,
     transcript_gadget: &mut TranscriptGadget<S>,
 ) -> Result<Committed<S, PCS>, Error> {
-    let trash_commitment = PCS::read_commitment(transcript_gadget, layouter)
-        .map(|c| c.label(PolynomialLabel::Trash(argument_index)))?;
+    let trash_commitment = PCS::read_commitment(transcript_gadget, layouter, 1)
+        .map(|c| c.label(&[PolynomialLabel::Trash(argument_index)]))?;
 
-    Ok(Committed { trash_commitment })
+    Ok(Committed {
+        argument_index,
+        trash_commitment,
+    })
 }
 
 impl<S: SelfEmulation, PCS: InCircuitPCS<S>> Committed<S, PCS> {
@@ -83,6 +87,7 @@ impl<'a, S: SelfEmulation, PCS: InCircuitPCS<S>> Evaluated<S, PCS> {
         vec![VerifierQuery::new(
             x,
             &self.committed.trash_commitment,
+            PolynomialLabel::Trash(self.committed.argument_index),
             &self.evaluated.trash_eval,
         )]
     }

--- a/circuits/src/verifier/trash.rs
+++ b/circuits/src/verifier/trash.rs
@@ -48,12 +48,12 @@ pub(crate) struct Evaluated<S: SelfEmulation, PCS: InCircuitPCS<S>> {
 }
 
 pub(crate) fn read_committed<S: SelfEmulation, PCS: InCircuitPCS<S>>(
-    argument_name: &str,
+    argument_index: usize,
     layouter: &mut impl Layouter<S::F>,
     transcript_gadget: &mut TranscriptGadget<S>,
 ) -> Result<Committed<S, PCS>, Error> {
     let trash_commitment = PCS::read_commitment(transcript_gadget, layouter)
-        .map(|c| c.label(PolynomialLabel::Trash(argument_name.to_owned())))?;
+        .map(|c| c.label(PolynomialLabel::Trash(argument_index)))?;
 
     Ok(Committed { trash_commitment })
 }

--- a/circuits/src/verifier/verifier_gadget.rs
+++ b/circuits/src/verifier/verifier_gadget.rs
@@ -363,7 +363,8 @@ impl<S: SelfEmulation> VerifierGadget<S> {
         let multiplicities_committed = cs
             .lookups()
             .iter()
-            .map(|l| lookup::read_multiplicities(l.name(), layouter, &mut transcript))
+            .enumerate()
+            .map(|(i, _l)| lookup::read_multiplicities(i, layouter, &mut transcript))
             .collect::<Result<Vec<_>, Error>>()?;
 
         let beta = transcript.squeeze_challenge(layouter)?;
@@ -376,10 +377,11 @@ impl<S: SelfEmulation> VerifierGadget<S> {
         let lookups_committed = multiplicities_committed
             .into_iter()
             .zip(cs.lookups().iter())
-            .map(|(m, batch)| {
+            .enumerate()
+            .map(|(i, (m, batch))| {
                 let nb_flat = batch.num_chunks(assigned_vk.cs_degree);
                 // Hash each lookup product commitment
-                m.read_commitment(batch.name(), nb_flat, layouter, &mut transcript)
+                m.read_commitment(i, nb_flat, layouter, &mut transcript)
             })
             .collect::<Result<Vec<_>, _>>()?;
 
@@ -388,7 +390,8 @@ impl<S: SelfEmulation> VerifierGadget<S> {
         let trashcans_committed = cs
             .trashcans()
             .iter()
-            .map(|argument| trash::read_committed(argument.name(), layouter, &mut transcript))
+            .enumerate()
+            .map(|(i, _argument)| trash::read_committed(i, layouter, &mut transcript))
             .collect::<Result<Vec<_>, _>>()?;
 
         // Sample y challenge, which keeps the gates linearly independent

--- a/circuits/src/verifier/verifier_gadget.rs
+++ b/circuits/src/verifier/verifier_gadget.rs
@@ -178,9 +178,9 @@ impl<S: SelfEmulation> VerifierGadget<S> {
     /// Witnesses the "collapsed" form of a KZG accumulator.
     ///
     /// The expected shape is:
-    /// * LHS: exactly one `Variable` entry labeled `Collapsed` with scalar `1`.
+    /// * LHS: exactly one `Variable` entry labeled `NoLabel` with scalar `1`.
     /// * RHS: one `Fixed` entry per label in `fixed_base_labels` plus one
-    ///   `Variable` entry labeled `Collapsed` with scalar `1`.
+    ///   `Variable` entry labeled `NoLabel` with scalar `1`.
     ///
     /// This shape matches the invariant maintained by the KZG multiopen
     /// accumulation after `collapse()` has been called off-circuit.
@@ -198,8 +198,8 @@ impl<S: SelfEmulation> VerifierGadget<S> {
             layouter,
             &self.curve_chip,
             &self.scalar_chip,
-            &[PolynomialLabel::Collapsed],
-            &[fixed_base_labels, &[PolynomialLabel::Collapsed]].concat(),
+            &[PolynomialLabel::NoLabel],
+            &[fixed_base_labels, &[PolynomialLabel::NoLabel]].concat(),
             &HashSet::new(),
             &fixed_base_labels.iter().cloned().collect(),
             value,

--- a/circuits/src/verifier/verifier_gadget.rs
+++ b/circuits/src/verifier/verifier_gadget.rs
@@ -1187,7 +1187,7 @@ pub(crate) mod tests {
             prepare::<F, KZGCommitmentScheme<E>, CircuitTranscript<PoseidonState<F>>>(
                 &inner_vk,
                 &[KZGMultiCommitment::commitment_to_zero(
-                    PolynomialLabel::Instance(0),
+                    PolynomialLabel::CommittedInstance(0),
                 )],
                 &[&inner_public_inputs],
                 &mut transcript,

--- a/circuits/src/verifier/verifier_gadget.rs
+++ b/circuits/src/verifier/verifier_gadget.rs
@@ -352,8 +352,8 @@ impl<S: SelfEmulation> VerifierGadget<S> {
         // challenges
         let advice_commitments = (0..cs.num_advice_columns())
             .map(|i| {
-                PCS::read_commitment(&mut transcript, layouter)
-                    .map(|c| c.label(PolynomialLabel::Advice(i)))
+                PCS::read_commitment(&mut transcript, layouter, 1)
+                    .map(|c| c.label(&[PolynomialLabel::Advice(i)]))
             })
             .collect::<Result<Vec<_>, Error>>()?;
 
@@ -545,17 +545,19 @@ impl<S: SelfEmulation> VerifierGadget<S> {
         let nb_quotient_coms = 1;
         let limb_commitments = {
             let raw = (0..nb_quotient_coms)
-                .map(|_| PCS::read_commitment(&mut transcript, layouter))
+                .map(|_| PCS::read_commitment(&mut transcript, layouter, 1))
                 .collect::<Result<Vec<_>, Error>>()?;
             #[cfg(not(feature = "single-h-commitment"))]
             let labeled = raw
                 .into_iter()
                 .enumerate()
-                .map(|(i, c)| c.label(PolynomialLabel::QuotientPiece(i)))
+                .map(|(i, c)| c.label(&[PolynomialLabel::QuotientPiece(i)]))
                 .collect::<Vec<_>>();
             #[cfg(feature = "single-h-commitment")]
-            let labeled =
-                raw.into_iter().map(|c| c.label(PolynomialLabel::Quotient)).collect::<Vec<_>>();
+            let labeled = raw
+                .into_iter()
+                .map(|c| c.label(&[PolynomialLabel::Quotient]))
+                .collect::<Vec<_>>();
             labeled
         };
 
@@ -791,6 +793,7 @@ impl<S: SelfEmulation> VerifierGadget<S> {
                     VerifierQuery::<S, PCS>::new(
                         get_point(&rot),
                         &advice_commitments[column.index()],
+                        PolynomialLabel::Advice(column.index()),
                         &advice_evals[query_index],
                     )
                 }),
@@ -801,6 +804,7 @@ impl<S: SelfEmulation> VerifierGadget<S> {
                         Some(VerifierQuery::<S, PCS>::new(
                             get_point(&rot),
                             &assigned_committed_instances[column.index()],
+                            PolynomialLabel::CommittedInstance(column.index()),
                             &instance_evals[query_index],
                         ))
                     } else {
@@ -821,6 +825,7 @@ impl<S: SelfEmulation> VerifierGadget<S> {
                         VerifierQuery::new(
                             get_point(&rot),
                             &assigned_vk.fixed_commitments[column.index()],
+                            PolynomialLabel::Fixed(column.index()),
                             &fixed_evals[query_index],
                         )
                     }),
@@ -832,6 +837,7 @@ impl<S: SelfEmulation> VerifierGadget<S> {
             .chain(iter::once(VerifierQuery::new(
                 &x,
                 &lin_commitment,
+                PolynomialLabel::Linearization,
                 &lin_eval,
             )))
             .collect::<Vec<_>>();
@@ -892,7 +898,7 @@ pub(crate) mod tests {
         dev::MockProver,
         plonk::{create_proof, keygen_pk, keygen_vk_with_k, prepare, Circuit, Error},
         poly::{
-            kzg::{commitment::KZGCommitment, params::ParamsKZG, KZGCommitmentScheme},
+            kzg::{commitment::KZGMultiCommitment, params::ParamsKZG, KZGCommitmentScheme},
             PolynomialLabel,
         },
         transcript::{CircuitTranscript, Transcript},
@@ -928,7 +934,8 @@ pub(crate) mod tests {
         testing_utils::FromScratch,
         types::{ComposableChip, Instantiable},
         verifier::{
-            accumulator::Accumulator, AssignedKZGCommitment, BlstrsEmulation, InCircuitKZG,
+            accumulator::Accumulator, kzg::AssignedKZGMultiCommitment, AssignedKZGCommitment,
+            BlstrsEmulation, InCircuitKZG,
         },
     };
 
@@ -1103,12 +1110,13 @@ pub(crate) mod tests {
                     self.inner_vk.2,
                 )?;
 
-            let assigned_committed_instance = AssignedKZGCommitment::assign(
-                &mut layouter,
-                &curve_chip,
-                self.inner_committed_instance,
-                PolynomialLabel::CommittedInstance(0),
-            )?;
+            let assigned_committed_instance =
+                AssignedKZGMultiCommitment(vec![AssignedKZGCommitment::assign(
+                    &mut layouter,
+                    &curve_chip,
+                    self.inner_committed_instance,
+                    PolynomialLabel::CommittedInstance(0),
+                )?]);
 
             let assigned_inner_pi = native_gadget
                 .assign_many(&mut layouter, &self.inner_instances.transpose_array())?;
@@ -1178,8 +1186,7 @@ pub(crate) mod tests {
                 CircuitTranscript::<PoseidonState<F>>::init_from_bytes(&inner_proof);
             prepare::<F, KZGCommitmentScheme<E>, CircuitTranscript<PoseidonState<F>>>(
                 &inner_vk,
-                &[KZGCommitment::Simple(
-                    C::identity(),
+                &[KZGMultiCommitment::commitment_to_zero(
                     PolynomialLabel::Instance(0),
                 )],
                 &[&inner_public_inputs],

--- a/circuits/src/verifier/verifier_gadget.rs
+++ b/circuits/src/verifier/verifier_gadget.rs
@@ -178,9 +178,9 @@ impl<S: SelfEmulation> VerifierGadget<S> {
     /// Witnesses the "collapsed" form of a KZG accumulator.
     ///
     /// The expected shape is:
-    /// * LHS: exactly one `Variable` entry labeled `NoLabel` with scalar `1`.
+    /// * LHS: exactly one `Variable` entry labeled `NoLabel`.
     /// * RHS: one `Fixed` entry per label in `fixed_base_labels` plus one
-    ///   `Variable` entry labeled `NoLabel` with scalar `1`.
+    ///   `Variable` entry labeled `NoLabel`.
     ///
     /// This shape matches the invariant maintained by the KZG multiopen
     /// accumulation after `collapse()` has been called off-circuit.

--- a/proofs/CHANGELOG.md
+++ b/proofs/CHANGELOG.md
@@ -55,6 +55,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * Remove multi-phase PLONK support: `Phase`, `Challenge`, `FirstPhase`, and `Layouter::get_challenge()` are removed; `Any::Advice` is no longer phase-parameterized; the prover and dev tools synthesize in a single pass [#376](https://github.com/midnightntwrk/midnight-zk/pull/376)
 * Remove multi-proof support; `create_proof` and `prepare` now operate on a single circuit and take `instances: &[&[F]]` instead of `&[&[&[F]]]` [#375](https://github.com/midnightntwrk/midnight-zk/pull/375)
 * Remove `msm_inner_product` from `utils::arithmetic`; superseded by the generic `inner_product` [#430](https://github.com/midnightntwrk/midnight-zk/pull/430)
+* Remove redundant `PolynomialLabel::Instance` variant; use `CommittedInstance` [#450](https://github.com/midnightntwrk/midnight-zk/pull/450)
 
 ## [0.8.0]
 ### Added

--- a/proofs/benches/zswap_output.rs
+++ b/proofs/benches/zswap_output.rs
@@ -24,7 +24,7 @@ use midnight_proofs::{
     },
     poly::{
         commitment::Guard,
-        kzg::{commitment::KZGCommitment, params::ParamsKZG, KZGCommitmentScheme},
+        kzg::{commitment::KZGMultiCommitment, params::ParamsKZG, KZGCommitmentScheme},
         PolynomialLabel,
     },
     transcript::{CircuitTranscript, Transcript},
@@ -35,7 +35,6 @@ use rand_chacha::ChaCha8Rng;
 use sha2::Digest;
 
 type F = midnight_curves::Fq;
-type C = midnight_curves::G1Projective;
 
 type CoinCom = [u8; 32];
 type ValueCom = JubjubSubgroup;
@@ -286,9 +285,8 @@ fn bench_zswap_output(c: &mut Criterion) {
             |mut t| {
                 parse_trace(
                     pk.get_vk(),
-                    &[KZGCommitment::Simple(
-                        C::identity(),
-                        PolynomialLabel::Instance(0),
+                    &[KZGMultiCommitment::commitment_to_zero(
+                        PolynomialLabel::CommittedInstance(0),
                     )],
                     &[&instance],
                     &mut t,
@@ -306,9 +304,8 @@ fn bench_zswap_output(c: &mut Criterion) {
                 (
                     parse_trace(
                         pk.get_vk(),
-                        &[KZGCommitment::Simple(
-                            C::identity(),
-                            PolynomialLabel::Instance(0),
+                        &[KZGMultiCommitment::commitment_to_zero(
+                            PolynomialLabel::CommittedInstance(0),
                         )],
                         &[&instance],
                         &mut t,
@@ -321,9 +318,8 @@ fn bench_zswap_output(c: &mut Criterion) {
                 verify_algebraic_constraints(
                     pk.get_vk(),
                     trace,
-                    &[KZGCommitment::Simple(
-                        C::identity(),
-                        PolynomialLabel::Instance(0),
+                    &[KZGMultiCommitment::commitment_to_zero(
+                        PolynomialLabel::CommittedInstance(0),
                     )],
                     &[&instance],
                     &mut t,
@@ -339,9 +335,8 @@ fn bench_zswap_output(c: &mut Criterion) {
                 let mut t = transcript.clone();
                 let trace = parse_trace(
                     pk.get_vk(),
-                    &[KZGCommitment::Simple(
-                        C::identity(),
-                        PolynomialLabel::Instance(0),
+                    &[KZGMultiCommitment::commitment_to_zero(
+                        PolynomialLabel::CommittedInstance(0),
                     )],
                     &[&instance],
                     &mut t,
@@ -350,9 +345,8 @@ fn bench_zswap_output(c: &mut Criterion) {
                 let guard = verify_algebraic_constraints(
                     pk.get_vk(),
                     trace,
-                    &[KZGCommitment::Simple(
-                        C::identity(),
-                        PolynomialLabel::Instance(0),
+                    &[KZGMultiCommitment::commitment_to_zero(
+                        PolynomialLabel::CommittedInstance(0),
                     )],
                     &[&instance],
                     &mut t,

--- a/proofs/src/plonk/bench/prover.rs
+++ b/proofs/src/plonk/bench/prover.rs
@@ -148,9 +148,11 @@ where
                         .collect();
                     let results: Vec<_> = logup_args
                         .par_iter()
+                        .enumerate()
                         .zip(mult_blinds.par_iter())
-                        .map(|(logup, blinds)| {
+                        .map(|((argument_index, logup), blinds)| {
                             logup.compute_multiplicities_parallel(
+                                argument_index,
                                 pk,
                                 params,
                                 theta,
@@ -173,9 +175,11 @@ where
             pk.vk.cs.lookups.iter().map(|l| l.chunk_by_degree(pk.vk.cs.degree())).collect();
         let results: Vec<_> = logup_args
             .par_iter()
+            .enumerate()
             .zip(mult_blindings.par_iter())
-            .map(|(logup, blinds)| {
+            .map(|((argument_index, logup), blinds)| {
                 logup.compute_multiplicities_parallel(
+                    argument_index,
                     pk,
                     params,
                     theta,
@@ -285,7 +289,7 @@ where
                                     CS::commit(
                                         params,
                                         &h_poly,
-                                        PolynomialLabel::LogupHelper(c.name.clone()),
+                                        PolynomialLabel::LogupHelper(c.argument_index),
                                     )
                                 })
                                 .collect()
@@ -319,7 +323,7 @@ where
                         CS::commit(
                             params,
                             &h_poly,
-                            PolynomialLabel::LogupHelper(c.name.clone()),
+                            PolynomialLabel::LogupHelper(c.argument_index),
                         )
                     })
                     .collect()
@@ -361,8 +365,10 @@ where
                         .cs
                         .trashcans
                         .iter()
-                        .map(|trash| {
+                        .enumerate()
+                        .map(|(i, trash)| {
                             trash.commit::<CS, _>(
+                                i,
                                 params,
                                 domain,
                                 trash_challenge,
@@ -381,8 +387,10 @@ where
             .cs
             .trashcans
             .iter()
-            .map(|trash| {
+            .enumerate()
+            .map(|(i, trash)| {
                 trash.commit::<CS, _>(
+                    i,
                     params,
                     domain,
                     trash_challenge,

--- a/proofs/src/plonk/bench/prover.rs
+++ b/proofs/src/plonk/bench/prover.rs
@@ -284,12 +284,13 @@ where
                         .map(|c| {
                             c.helper_polys_lagrange
                                 .par_iter()
-                                .map(|h| {
+                                .enumerate()
+                                .map(|(j, h)| {
                                     let h_poly = domain.lagrange_from_vec(h.clone());
                                     CS::commit(
                                         params,
                                         &h_poly,
-                                        PolynomialLabel::LogupHelper(c.argument_index),
+                                        PolynomialLabel::LogupHelper(c.argument_index, j),
                                     )
                                 })
                                 .collect()
@@ -318,12 +319,13 @@ where
             .map(|c| {
                 c.helper_polys_lagrange
                     .par_iter()
-                    .map(|h| {
+                    .enumerate()
+                    .map(|(j, h)| {
                         let h_poly = domain.lagrange_from_vec(h.clone());
                         CS::commit(
                             params,
                             &h_poly,
-                            PolynomialLabel::LogupHelper(c.argument_index),
+                            PolynomialLabel::LogupHelper(c.argument_index, j),
                         )
                     })
                     .collect()
@@ -344,6 +346,7 @@ where
                     .map(|h| domain.lagrange_to_coeff(domain.lagrange_from_vec(h)))
                     .collect();
                 logup::prover::Committed {
+                    argument_index: c.argument_index,
                     multiplicities: domain.lagrange_to_coeff(c.multiplicities),
                     helper_polys,
                     aggregator_poly: domain.lagrange_to_coeff(c.aggregator_poly),

--- a/proofs/src/plonk/logup/prover.rs
+++ b/proofs/src/plonk/logup/prover.rs
@@ -43,6 +43,7 @@ use crate::{
 #[cfg_attr(feature = "bench-internal", derive(Clone))]
 #[derive(Debug)]
 pub(crate) struct Committed<F: PrimeField> {
+    pub(crate) argument_index: usize,
     pub(crate) multiplicities: Polynomial<F, Coeff>,
     pub(crate) helper_polys: Vec<Polynomial<F, Coeff>>,
     pub(crate) aggregator_poly: Polynomial<F, Coeff>,
@@ -359,15 +360,32 @@ impl<F: WithSmallOrderMulGroup<3>> Evaluated<F> {
         x: F,
     ) -> impl Iterator<Item = ProverQuery<'a, F>> + Clone {
         let x_next = pk.vk.domain.rotate_omega(x, Rotation::next());
+        let arg = self.constructed.argument_index;
 
-        let m_query = iter::once(ProverQuery::new(x, &self.constructed.multiplicities));
+        let m_query = iter::once(ProverQuery::new(
+            x,
+            &self.constructed.multiplicities,
+            PolynomialLabel::LogupMultiplicities(arg),
+        ));
 
-        let helper_queries =
-            self.constructed.helper_polys.iter().map(move |h| ProverQuery::new(x, h));
+        let helper_queries = self
+            .constructed
+            .helper_polys
+            .iter()
+            .enumerate()
+            .map(move |(j, h)| ProverQuery::new(x, h, PolynomialLabel::LogupHelper(arg, j)));
 
         let z_queries = [
-            ProverQuery::new(x, &self.constructed.aggregator_poly),
-            ProverQuery::new(x_next, &self.constructed.aggregator_poly),
+            ProverQuery::new(
+                x,
+                &self.constructed.aggregator_poly,
+                PolynomialLabel::LogupAggregator(arg),
+            ),
+            ProverQuery::new(
+                x_next,
+                &self.constructed.aggregator_poly,
+                PolynomialLabel::LogupAggregator(arg),
+            ),
         ];
 
         m_query.chain(helper_queries).chain(z_queries)

--- a/proofs/src/plonk/logup/prover.rs
+++ b/proofs/src/plonk/logup/prover.rs
@@ -55,7 +55,7 @@ pub(crate) struct Committed<F: PrimeField> {
 #[cfg_attr(feature = "bench-internal", derive(Clone))]
 #[derive(Debug)]
 pub(crate) struct ComputedMultiplicities<F: PrimeField> {
-    pub(crate) name: String,
+    pub(crate) argument_index: usize,
     pub(crate) selector: Polynomial<F, LagrangeCoeff>,
     pub(crate) multiplicities: Polynomial<F, LagrangeCoeff>,
     pub(crate) chunked_compressed_inputs: Vec<Vec<Polynomial<F, LagrangeCoeff>>>,
@@ -65,7 +65,7 @@ pub(crate) struct ComputedMultiplicities<F: PrimeField> {
 /// Intermediate result from logderivative computation, before transcript
 /// write and FFT conversion to coefficient form.
 pub(crate) struct ComputedLogderivative<F: PrimeField, C> {
-    pub(crate) name: String,
+    pub(crate) argument_index: usize,
     pub(crate) multiplicities: Polynomial<F, LagrangeCoeff>,
     pub(crate) helper_polys_lagrange: Vec<Vec<F>>,
     pub(crate) aggregator_poly: Polynomial<F, LagrangeCoeff>,
@@ -93,6 +93,7 @@ impl<F: WithSmallOrderMulGroup<3> + Hash> ChunkedArgument<F> {
     #[allow(clippy::too_many_arguments)]
     pub(crate) fn compute_multiplicities_parallel<'a, CS: PolynomialCommitmentScheme<F>>(
         &self,
+        argument_index: usize,
         pk: &ProvingKey<F, CS>,
         params: &CS::Parameters,
         theta: F,
@@ -166,12 +167,12 @@ impl<F: WithSmallOrderMulGroup<3> + Hash> ChunkedArgument<F> {
         let commitment = CS::commit(
             params,
             &multiplicities.to_delta(),
-            PolynomialLabel::LogupMultiplicities(self.name.clone()),
+            PolynomialLabel::LogupMultiplicities(argument_index),
         );
 
         Ok((
             ComputedMultiplicities {
-                name: self.name.clone(),
+                argument_index,
                 selector,
                 multiplicities,
                 chunked_compressed_inputs,
@@ -297,11 +298,11 @@ impl<F: WithSmallOrderMulGroup<3> + Hash> ComputedMultiplicities<F> {
         let aggregator_commitment = CS::commit(
             params,
             &aggregator_poly.to_double_delta(),
-            PolynomialLabel::LogupAggregator(self.name.clone()),
+            PolynomialLabel::LogupAggregator(self.argument_index),
         );
 
         Ok(ComputedLogderivative {
-            name: self.name,
+            argument_index: self.argument_index,
             multiplicities: self.multiplicities,
             helper_polys_lagrange,
             aggregator_poly,

--- a/proofs/src/plonk/logup/verifier.rs
+++ b/proofs/src/plonk/logup/verifier.rs
@@ -63,7 +63,7 @@ impl<F: WithSmallOrderMulGroup<3>> ChunkedArgument<F> {
         CS::Commitment: Hashable<T::Hash>,
     {
         let multiplicities = transcript.read().map(|c: CS::Commitment| {
-            c.label(PolynomialLabel::LogupMultiplicities(argument_index))
+            c.label(&[PolynomialLabel::LogupMultiplicities(argument_index)])
         })?;
         Ok(CommittedMultiplicities { multiplicities })
     }
@@ -86,13 +86,13 @@ impl<F: WithSmallOrderMulGroup<3>, CS: PolynomialCommitmentScheme<F>>
         let helper_polys = (0..nb_chunks)
             .map(|j| {
                 transcript.read().map(|c: CS::Commitment| {
-                    c.label(PolynomialLabel::LogupHelper(argument_index, j))
+                    c.label(&[PolynomialLabel::LogupHelper(argument_index, j)])
                 })
             })
             .collect::<Result<Vec<_>, _>>()?;
-        let accumulator = transcript
-            .read()
-            .map(|c: CS::Commitment| c.label(PolynomialLabel::LogupAggregator(argument_index)))?;
+        let accumulator = transcript.read().map(|c: CS::Commitment| {
+            c.label(&[PolynomialLabel::LogupAggregator(argument_index)])
+        })?;
 
         Ok(Committed {
             argument_index,

--- a/proofs/src/plonk/logup/verifier.rs
+++ b/proofs/src/plonk/logup/verifier.rs
@@ -39,6 +39,7 @@ pub struct CommittedMultiplicities<F: PrimeField, CS: PolynomialCommitmentScheme
 /// One shared `m` and `Z`, plus one `hᵢ` per chunk.
 #[derive(Debug)]
 pub struct Committed<F: PrimeField, CS: PolynomialCommitmentScheme<F>> {
+    argument_index: usize,
     multiplicities: CS::Commitment,
     /// One commitment per chunk of the batched argument.
     helper_polys: Vec<CS::Commitment>,
@@ -83,10 +84,10 @@ impl<F: WithSmallOrderMulGroup<3>, CS: PolynomialCommitmentScheme<F>>
         CS::Commitment: Hashable<T::Hash>,
     {
         let helper_polys = (0..nb_chunks)
-            .map(|_| {
-                transcript
-                    .read()
-                    .map(|c: CS::Commitment| c.label(PolynomialLabel::LogupHelper(argument_index)))
+            .map(|j| {
+                transcript.read().map(|c: CS::Commitment| {
+                    c.label(PolynomialLabel::LogupHelper(argument_index, j))
+                })
             })
             .collect::<Result<Vec<_>, _>>()?;
         let accumulator = transcript
@@ -94,6 +95,7 @@ impl<F: WithSmallOrderMulGroup<3>, CS: PolynomialCommitmentScheme<F>>
             .map(|c: CS::Commitment| c.label(PolynomialLabel::LogupAggregator(argument_index)))?;
 
         Ok(Committed {
+            argument_index,
             multiplicities: self.multiplicities,
             helper_polys,
             accumulator,
@@ -141,10 +143,12 @@ impl<F: WithSmallOrderMulGroup<3>, CS: PolynomialCommitmentScheme<F>> Evaluated<
         x: F,
     ) -> impl Iterator<Item = VerifierQuery<'_, F, CS>> + Clone {
         let x_next = vk.domain.rotate_omega(x, Rotation::next());
+        let arg = self.committed.argument_index;
 
         let m_query = iter::once(VerifierQuery::new(
             x,
             &self.committed.multiplicities,
+            PolynomialLabel::LogupMultiplicities(arg),
             self.evaluated.multiplicities_eval,
         ));
 
@@ -153,18 +157,23 @@ impl<F: WithSmallOrderMulGroup<3>, CS: PolynomialCommitmentScheme<F>> Evaluated<
             .helper_polys
             .iter()
             .zip(self.evaluated.helper_evals.iter())
-            .map(move |(com, &eval)| VerifierQuery::new(x, com, eval))
+            .enumerate()
+            .map(move |(j, (com, &eval))| {
+                VerifierQuery::new(x, com, PolynomialLabel::LogupHelper(arg, j), eval)
+            })
             .collect::<Vec<_>>();
 
         let z_queries = [
             VerifierQuery::new(
                 x,
                 &self.committed.accumulator,
+                PolynomialLabel::LogupAggregator(arg),
                 self.evaluated.accumulator_eval,
             ),
             VerifierQuery::new(
                 x_next,
                 &self.committed.accumulator,
+                PolynomialLabel::LogupAggregator(arg),
                 self.evaluated.accumulator_next_eval,
             ),
         ];

--- a/proofs/src/plonk/logup/verifier.rs
+++ b/proofs/src/plonk/logup/verifier.rs
@@ -55,13 +55,14 @@ impl<F: WithSmallOrderMulGroup<3>> ChunkedArgument<F> {
     /// Reads the multiplicities commitment from the transcript.
     pub(in crate::plonk) fn read_multiplicities<T: Transcript, CS: PolynomialCommitmentScheme<F>>(
         &self,
+        argument_index: usize,
         transcript: &mut T,
     ) -> Result<CommittedMultiplicities<F, CS>, Error>
     where
         CS::Commitment: Hashable<T::Hash>,
     {
         let multiplicities = transcript.read().map(|c: CS::Commitment| {
-            c.label(PolynomialLabel::LogupMultiplicities(self.name.clone()))
+            c.label(PolynomialLabel::LogupMultiplicities(argument_index))
         })?;
         Ok(CommittedMultiplicities { multiplicities })
     }
@@ -74,7 +75,7 @@ impl<F: WithSmallOrderMulGroup<3>, CS: PolynomialCommitmentScheme<F>>
     /// from the transcript.
     pub(in crate::plonk) fn read_commitment<T: Transcript>(
         self,
-        name: &str,
+        argument_index: usize,
         nb_chunks: usize,
         transcript: &mut T,
     ) -> Result<Committed<F, CS>, Error>
@@ -85,12 +86,12 @@ impl<F: WithSmallOrderMulGroup<3>, CS: PolynomialCommitmentScheme<F>>
             .map(|_| {
                 transcript
                     .read()
-                    .map(|c: CS::Commitment| c.label(PolynomialLabel::LogupHelper(name.to_owned())))
+                    .map(|c: CS::Commitment| c.label(PolynomialLabel::LogupHelper(argument_index)))
             })
             .collect::<Result<Vec<_>, _>>()?;
         let accumulator = transcript
             .read()
-            .map(|c: CS::Commitment| c.label(PolynomialLabel::LogupAggregator(name.to_owned())))?;
+            .map(|c: CS::Commitment| c.label(PolynomialLabel::LogupAggregator(argument_index)))?;
 
         Ok(Committed {
             multiplicities: self.multiplicities,

--- a/proofs/src/plonk/mod.rs
+++ b/proofs/src/plonk/mod.rs
@@ -182,7 +182,7 @@ where
         let fixed_commitments: Vec<_> = (0..num_fixed_columns)
             .map(|i| {
                 CS::Commitment::read(reader, format)
-                    .map(|c| c.label(PolynomialLabel::Fixed(i as usize)))
+                    .map(|c| c.label(&[PolynomialLabel::Fixed(i as usize)]))
             })
             .collect::<Result<_, _>>()?;
 

--- a/proofs/src/plonk/permutation.rs
+++ b/proofs/src/plonk/permutation.rs
@@ -126,7 +126,7 @@ impl<F: PrimeField, CS: PolynomialCommitmentScheme<F>> VerifyingKey<F, CS> {
         let commitments = (0..argument.columns.len())
             .map(|i| {
                 CS::Commitment::read(reader, format)
-                    .map(|c| c.label(PolynomialLabel::PermutationFixed(i)))
+                    .map(|c| c.label(&[PolynomialLabel::PermutationFixed(i)]))
             })
             .collect::<Result<Vec<_>, _>>()?;
         Ok(VerifyingKey { commitments })

--- a/proofs/src/plonk/permutation/prover.rs
+++ b/proofs/src/plonk/permutation/prover.rs
@@ -257,7 +257,10 @@ impl Argument {
 
 impl<F: PrimeField> super::ProvingKey<F> {
     pub(crate) fn open(&self, x: F) -> impl Iterator<Item = ProverQuery<'_, F>> + Clone {
-        self.polys.iter().map(move |poly| ProverQuery::new(x, poly))
+        self.polys
+            .iter()
+            .enumerate()
+            .map(move |(i, poly)| ProverQuery::new(x, poly, PolynomialLabel::PermutationFixed(i)))
     }
 
     pub(crate) fn evaluate<T: Transcript>(
@@ -345,22 +348,39 @@ impl<F: WithSmallOrderMulGroup<3>> Evaluated<F> {
         let x_last = pk.vk.domain.rotate_omega(x, Rotation(-((blinding_factors + 1) as i32)));
 
         iter::empty()
-            .chain(self.constructed.sets.iter().flat_map(move |set| {
-                iter::empty()
-                    // Open permutation product commitments at x and \omega x
-                    .chain(Some(ProverQuery::new(x, &set.permutation_product_poly)))
-                    .chain(Some(ProverQuery::new(
-                        x_next,
-                        &set.permutation_product_poly,
-                    )))
-            }))
+            .chain(
+                self.constructed.sets.iter().enumerate().flat_map(move |(i, set)| {
+                    iter::empty()
+                        // Open permutation product commitments at x and \omega x
+                        .chain(Some(ProverQuery::new(
+                            x,
+                            &set.permutation_product_poly,
+                            PolynomialLabel::PermutationAccumulator(i),
+                        )))
+                        .chain(Some(ProverQuery::new(
+                            x_next,
+                            &set.permutation_product_poly,
+                            PolynomialLabel::PermutationAccumulator(i),
+                        )))
+                }),
+            )
             // Open it at \omega^{last} x for all but the last set. This rotation is only
             // sensical for the first row, but we only use this rotation in a constraint
             // that is gated on l_0.
             .chain(
-                self.constructed.sets.iter().rev().skip(1).flat_map(move |set| {
-                    Some(ProverQuery::new(x_last, &set.permutation_product_poly))
-                }),
+                self.constructed
+                    .sets
+                    .iter()
+                    .enumerate()
+                    .rev()
+                    .skip(1)
+                    .flat_map(move |(i, set)| {
+                        Some(ProverQuery::new(
+                            x_last,
+                            &set.permutation_product_poly,
+                            PolynomialLabel::PermutationAccumulator(i),
+                        ))
+                    }),
             )
     }
 }

--- a/proofs/src/plonk/permutation/verifier.rs
+++ b/proofs/src/plonk/permutation/verifier.rs
@@ -122,11 +122,13 @@ impl<F: WithSmallOrderMulGroup<3>, CS: PolynomialCommitmentScheme<F>> Evaluated<
             queries.push(VerifierQuery::new(
                 x,
                 &product_coms[i],
+                PolynomialLabel::PermutationAccumulator(i),
                 set.permutation_product_eval,
             ));
             queries.push(VerifierQuery::new(
                 x_next,
                 &product_coms[i],
+                PolynomialLabel::PermutationAccumulator(i),
                 set.permutation_product_next_eval,
             ));
         }
@@ -135,6 +137,7 @@ impl<F: WithSmallOrderMulGroup<3>, CS: PolynomialCommitmentScheme<F>> Evaluated<
             queries.push(VerifierQuery::new(
                 x_last,
                 &product_coms[i],
+                PolynomialLabel::PermutationAccumulator(i),
                 set.permutation_product_last_eval.unwrap(),
             ));
         }
@@ -152,6 +155,9 @@ impl<F: PrimeField> CommonEvaluated<F> {
         vkey.commitments
             .iter()
             .zip(evals)
-            .map(move |(commitment, eval)| VerifierQuery::new(x, commitment, eval))
+            .enumerate()
+            .map(move |(i, (commitment, eval))| {
+                VerifierQuery::new(x, commitment, PolynomialLabel::PermutationFixed(i), eval)
+            })
     }
 }

--- a/proofs/src/plonk/permutation/verifier.rs
+++ b/proofs/src/plonk/permutation/verifier.rs
@@ -46,7 +46,7 @@ impl Argument {
             .collect::<Result<Vec<_>, _>>()?
             .into_iter()
             .enumerate()
-            .map(|(i, c)| c.label(PolynomialLabel::PermutationAccumulator(i)))
+            .map(|(i, c)| c.label(&[PolynomialLabel::PermutationAccumulator(i)]))
             .collect();
 
         Ok(Committed {

--- a/proofs/src/plonk/prover.rs
+++ b/proofs/src/plonk/prover.rs
@@ -198,12 +198,13 @@ where
                 .map(|c| {
                     c.helper_polys_lagrange
                         .par_iter()
-                        .map(|h| {
+                        .enumerate()
+                        .map(|(j, h)| {
                             let h_poly = domain.lagrange_from_vec(h.clone());
                             CS::commit(
                                 params,
                                 &h_poly,
-                                PolynomialLabel::LogupHelper(c.argument_index),
+                                PolynomialLabel::LogupHelper(c.argument_index, j),
                             )
                         })
                         .collect()
@@ -233,6 +234,7 @@ where
                 .map(|h| domain.lagrange_to_coeff(domain.lagrange_from_vec(h)))
                 .collect();
             logup::prover::Committed {
+                argument_index: c.argument_index,
                 multiplicities: domain.lagrange_to_coeff(c.multiplicities),
                 helper_polys,
                 aggregator_poly: domain.lagrange_to_coeff(c.aggregator_poly),
@@ -884,7 +886,11 @@ pub(super) fn compute_queries<
     let domain = pk.vk.get_domain();
     iter::empty()
         .chain(pk.vk.cs.advice_queries.iter().map(move |&(column, at)| {
-            ProverQuery::new(domain.rotate_omega(x, at), &advice_polys[column.index()])
+            ProverQuery::new(
+                domain.rotate_omega(x, at),
+                &advice_polys[column.index()],
+                PolynomialLabel::Advice(column.index()),
+            )
         }))
         .chain(
             pk.vk.cs.instance_queries.iter().filter_map(move |&(column, at)| {
@@ -892,6 +898,7 @@ pub(super) fn compute_queries<
                     Some(ProverQuery::new(
                         domain.rotate_omega(x, at),
                         &instance_polys[column.index()],
+                        PolynomialLabel::CommittedInstance(column.index()),
                     ))
                 } else {
                     None
@@ -909,13 +916,18 @@ pub(super) fn compute_queries<
                 // Filter out queries for simple, multiplicative selectors
                 .filter(|(col, _)| !pk.vk.cs.has_simple_selector_col(col.index()))
                 .map(|&(column, at)| {
-                    ProverQuery::new(domain.rotate_omega(x, at), &pk.fixed_polys[column.index()])
+                    ProverQuery::new(
+                        domain.rotate_omega(x, at),
+                        &pk.fixed_polys[column.index()],
+                        PolynomialLabel::Fixed(column.index()),
+                    )
                 }),
         )
         .chain(pk.permutation.open(x))
         .chain(iter::once(ProverQuery::new(
             domain.rotate_omega(x, Rotation::cur()),
             lin_poly_non_constant_part,
+            PolynomialLabel::Linearization,
         )))
         .collect()
 }

--- a/proofs/src/plonk/prover.rs
+++ b/proofs/src/plonk/prover.rs
@@ -54,7 +54,7 @@ where
     for (poly_eval, value) in poly.iter_mut().zip(instances.iter()) {
         *poly_eval = *value;
     }
-    CS::commit(params, &poly, PolynomialLabel::Instance(0))
+    CS::commit(params, &poly, PolynomialLabel::CommittedInstance(0))
 }
 
 /// This computes a proof trace for the provided `circuit` when given the

--- a/proofs/src/plonk/prover.rs
+++ b/proofs/src/plonk/prover.rs
@@ -130,9 +130,11 @@ where
         // Compute all lookups in parallel (no transcript access, no rng).
         let results: Vec<_> = logup_args
             .par_iter()
+            .enumerate()
             .zip(mult_blindings.par_iter())
-            .map(|(logup, blinds)| {
+            .map(|((argument_index, logup), blinds)| {
                 logup.compute_multiplicities_parallel(
+                    argument_index,
                     pk,
                     params,
                     theta,
@@ -201,7 +203,7 @@ where
                             CS::commit(
                                 params,
                                 &h_poly,
-                                PolynomialLabel::LogupHelper(c.name.clone()),
+                                PolynomialLabel::LogupHelper(c.argument_index),
                             )
                         })
                         .collect()
@@ -246,8 +248,10 @@ where
         .cs
         .trashcans
         .iter()
-        .map(|trash| {
+        .enumerate()
+        .map(|(i, trash)| {
             trash.commit::<CS, _>(
+                i,
                 params,
                 domain,
                 trash_challenge,

--- a/proofs/src/plonk/trash/prover.rs
+++ b/proofs/src/plonk/trash/prover.rs
@@ -26,6 +26,7 @@ impl<F: WithSmallOrderMulGroup<3> + Ord> Argument<F> {
     #[allow(clippy::too_many_arguments)]
     pub(crate) fn commit<'a, 'params: 'a, CS, T>(
         &self,
+        argument_index: usize,
         params: &'params CS::Parameters,
         domain: &EvaluationDomain<F>,
         trash_challenge: F,
@@ -60,7 +61,7 @@ impl<F: WithSmallOrderMulGroup<3> + Ord> Argument<F> {
         let trash_commitment = CS::commit(
             params,
             &compressed_expression,
-            PolynomialLabel::Trash(self.name.clone()),
+            PolynomialLabel::Trash(argument_index),
         );
         let trash_poly = domain.lagrange_to_coeff(compressed_expression);
 

--- a/proofs/src/plonk/trash/prover.rs
+++ b/proofs/src/plonk/trash/prover.rs
@@ -14,6 +14,7 @@ use crate::{
 #[cfg_attr(feature = "bench-internal", derive(Clone))]
 #[derive(Debug)]
 pub(crate) struct Committed<F: PrimeField> {
+    pub(crate) argument_index: usize,
     pub(crate) trash_poly: Polynomial<F, Coeff>,
 }
 
@@ -68,7 +69,10 @@ impl<F: WithSmallOrderMulGroup<3> + Ord> Argument<F> {
         // Hash permuted input commitment
         transcript.write(&trash_commitment)?;
 
-        Ok(Committed { trash_poly })
+        Ok(Committed {
+            argument_index,
+            trash_poly,
+        })
     }
 }
 
@@ -90,6 +94,11 @@ impl<F: WithSmallOrderMulGroup<3>> Committed<F> {
 
 impl<F: WithSmallOrderMulGroup<3>> Evaluated<F> {
     pub(crate) fn open(&self, x: F) -> impl Iterator<Item = ProverQuery<'_, F>> + Clone {
-        vec![ProverQuery::new(x, &self.committed.trash_poly)].into_iter()
+        vec![ProverQuery::new(
+            x,
+            &self.committed.trash_poly,
+            PolynomialLabel::Trash(self.committed.argument_index),
+        )]
+        .into_iter()
     }
 }

--- a/proofs/src/plonk/trash/verifier.rs
+++ b/proofs/src/plonk/trash/verifier.rs
@@ -33,7 +33,7 @@ impl<F: PrimeField> Argument<F> {
     {
         let trash_commitment = transcript
             .read()
-            .map(|c: CS::Commitment| c.label(PolynomialLabel::Trash(argument_index)))?;
+            .map(|c: CS::Commitment| c.label(&[PolynomialLabel::Trash(argument_index)]))?;
         Ok(Committed {
             argument_index,
             trash_commitment,

--- a/proofs/src/plonk/trash/verifier.rs
+++ b/proofs/src/plonk/trash/verifier.rs
@@ -12,6 +12,7 @@ use crate::{
 
 #[derive(Debug)]
 pub struct Committed<F: PrimeField, CS: PolynomialCommitmentScheme<F>> {
+    argument_index: usize,
     trash_commitment: CS::Commitment,
 }
 
@@ -33,7 +34,10 @@ impl<F: PrimeField> Argument<F> {
         let trash_commitment = transcript
             .read()
             .map(|c: CS::Commitment| c.label(PolynomialLabel::Trash(argument_index)))?;
-        Ok(Committed { trash_commitment })
+        Ok(Committed {
+            argument_index,
+            trash_commitment,
+        })
     }
 }
 
@@ -59,6 +63,7 @@ impl<F: WithSmallOrderMulGroup<3>, CS: PolynomialCommitmentScheme<F>> Evaluated<
         vec![VerifierQuery::new(
             x,
             &self.committed.trash_commitment,
+            PolynomialLabel::Trash(self.committed.argument_index),
             self.evaluated.trash_eval,
         )]
         .into_iter()

--- a/proofs/src/plonk/trash/verifier.rs
+++ b/proofs/src/plonk/trash/verifier.rs
@@ -24,6 +24,7 @@ pub struct Evaluated<F: PrimeField, CS: PolynomialCommitmentScheme<F>> {
 impl<F: PrimeField> Argument<F> {
     pub(crate) fn read_committed<CS: PolynomialCommitmentScheme<F>, T: Transcript>(
         &self,
+        argument_index: usize,
         transcript: &mut T,
     ) -> Result<Committed<F, CS>, Error>
     where
@@ -31,7 +32,7 @@ impl<F: PrimeField> Argument<F> {
     {
         let trash_commitment = transcript
             .read()
-            .map(|c: CS::Commitment| c.label(PolynomialLabel::Trash(self.name.clone())))?;
+            .map(|c: CS::Commitment| c.label(PolynomialLabel::Trash(argument_index)))?;
         Ok(Committed { trash_commitment })
     }
 }

--- a/proofs/src/plonk/verifier.rs
+++ b/proofs/src/plonk/verifier.rs
@@ -304,6 +304,7 @@ where
                 VerifierQuery::new(
                     vk.domain.rotate_omega(x, at),
                     &advice_commitments[column.index()],
+                    PolynomialLabel::Advice(column.index()),
                     advice_evals[query_index],
                 )
             }),
@@ -314,6 +315,7 @@ where
                     Some(VerifierQuery::new(
                         vk.domain.rotate_omega(x, at),
                         &committed_instances[column.index()],
+                        PolynomialLabel::CommittedInstance(column.index()),
                         instance_evals[query_index],
                     ))
                 } else {
@@ -335,12 +337,18 @@ where
                     VerifierQuery::new(
                         vk.domain.rotate_omega(x, at),
                         &vk.fixed_commitments[column.index()],
+                        PolynomialLabel::Fixed(column.index()),
                         fixed_evals[query_index],
                     )
                 }),
         )
         .chain(permutations_common.queries(&vk.permutation, x))
-        .chain(iter::once(VerifierQuery::new(x, &lin_commitment, lin_eval)))
+        .chain(iter::once(VerifierQuery::new(
+            x,
+            &lin_commitment,
+            PolynomialLabel::Linearization,
+            lin_eval,
+        )))
         .collect::<Vec<_>>();
 
     // We are now convinced the circuit is satisfied so long as the

--- a/proofs/src/plonk/verifier.rs
+++ b/proofs/src/plonk/verifier.rs
@@ -68,7 +68,11 @@ where
     // Hash the prover's advice commitments into the transcript and squeeze
     // challenges
     let advice_commitments: Vec<_> = (0..vk.cs.num_advice_columns)
-        .map(|i| transcript.read().map(|c: CS::Commitment| c.label(PolynomialLabel::Advice(i))))
+        .map(|i| {
+            transcript
+                .read()
+                .map(|c: CS::Commitment| c.label(&[PolynomialLabel::Advice(i)]))
+        })
         .collect::<Result<_, _>>()?;
 
     // Sample theta challenge for keeping lookup columns linearly independent
@@ -181,11 +185,13 @@ where
         let labeled = raw
             .into_iter()
             .enumerate()
-            .map(|(i, c)| c.label(PolynomialLabel::QuotientPiece(i)))
+            .map(|(i, c)| c.label(&[PolynomialLabel::QuotientPiece(i)]))
             .collect::<Vec<_>>();
         #[cfg(feature = "single-h-commitment")]
-        let labeled =
-            raw.into_iter().map(|c| c.label(PolynomialLabel::Quotient)).collect::<Vec<_>>();
+        let labeled = raw
+            .into_iter()
+            .map(|c| c.label(&[PolynomialLabel::Quotient]))
+            .collect::<Vec<_>>();
         labeled
     };
 

--- a/proofs/src/plonk/verifier.rs
+++ b/proofs/src/plonk/verifier.rs
@@ -79,7 +79,8 @@ where
         .cs
         .lookups
         .iter()
-        .map(|l| l.chunk_by_degree(vk.cs_degree).read_multiplicities::<_, CS>(transcript))
+        .enumerate()
+        .map(|(i, l)| l.chunk_by_degree(vk.cs_degree).read_multiplicities::<_, CS>(i, transcript))
         .collect::<Result<Vec<_>, _>>()?;
 
     // Sample beta challenge
@@ -93,7 +94,8 @@ where
     let lookups_committed: Vec<_> = lookup_multiplicities
         .into_iter()
         .zip(vk.cs.lookups.iter().map(|l| l.chunk_by_degree(vk.cs_degree)))
-        .map(|(m, batch)| m.read_commitment(&batch.name, batch.num_chunks(), transcript))
+        .enumerate()
+        .map(|(i, (m, batch))| m.read_commitment(i, batch.num_chunks(), transcript))
         .collect::<Result<Vec<_>, _>>()?;
 
     let trash_challenge: F = transcript.squeeze_challenge();
@@ -102,7 +104,8 @@ where
         .cs
         .trashcans
         .iter()
-        .map(|argument| argument.read_committed::<CS, _>(transcript))
+        .enumerate()
+        .map(|(i, argument)| argument.read_committed::<CS, _>(i, transcript))
         .collect::<Result<Vec<_>, _>>()?;
 
     // Sample y challenge, which keeps the gates linearly independent.

--- a/proofs/src/poly/commitment.rs
+++ b/proofs/src/poly/commitment.rs
@@ -44,13 +44,29 @@ pub trait PolynomialCommitmentScheme<F: PrimeField>: Clone + Debug {
     /// Extract the `VerifierParameters` from `Parameters`
     fn get_verifier_params(params: &Self::Parameters) -> Self::VerifierParameters;
 
-    /// Commit to a polynomial in coefficient form, tagging the result with
-    /// `label` for identification during multi-open accumulation.
+    /// Commit to one or more polynomials, tagging the result with the
+    /// corresponding labels for identification during multi-open accumulation.
+    ///
+    /// # Panics
+    ///
+    /// Panics if `polynomials` and `labels` have different lengths, or if
+    /// either slice is empty.
+    fn commit_many<B: PolynomialRepresentation>(
+        params: &Self::Parameters,
+        polynomials: &[&Polynomial<F, B>],
+        labels: &[PolynomialLabel],
+    ) -> Self::Commitment;
+
+    /// Commit to a single polynomial in coefficient form, tagging the result
+    /// with `label`. Convenience wrapper around
+    /// [`commit_many`](Self::commit_many).
     fn commit<B: PolynomialRepresentation>(
         params: &Self::Parameters,
         polynomial: &Polynomial<F, B>,
         label: PolynomialLabel,
-    ) -> Self::Commitment;
+    ) -> Self::Commitment {
+        Self::commit_many(params, &[polynomial], &[label])
+    }
 
     /// Create a multi-opening proof at a set of [ProverQuery]'s.
     fn multi_open<T: Transcript>(
@@ -82,14 +98,22 @@ pub trait PolynomialCommitmentScheme<F: PrimeField>: Clone + Debug {
         Self::Commitment: Hashable<T::Hash> + 'com;
 }
 
-/// A commitment that can be assigned a [`PolynomialLabel`].
+/// A commitment that can be assigned [`PolynomialLabel`]s.
 ///
-/// Deserialized commitments start with [`PolynomialLabel::NoLabel`]; call sites
-/// must attach the correct label before the commitment reaches the MSM layer.
-pub trait Labelable {
-    /// Attaches the given [`PolynomialLabel`] to this commitment, replacing any
-    /// existing label (including [`PolynomialLabel::NoLabel`]).
-    fn label(self, label: PolynomialLabel) -> Self;
+/// Deserialized commitments start with [`PolynomialLabel::NoLabel`] for each
+/// polynomial they hold; call sites must attach the correct labels before the
+/// commitment reaches the MSM layer.
+pub trait Labelable: Sized {
+    /// Attaches the given labels to this commitment, one per polynomial,
+    /// replacing any existing labels (including [`PolynomialLabel::NoLabel`]).
+    ///
+    /// # Panics
+    ///
+    /// Panics if `labels.len() != self.length()`.
+    fn label(self, labels: &[PolynomialLabel]) -> Self;
+
+    /// Returns the number of polynomials held by this commitment.
+    fn length(&self) -> usize;
 }
 
 /// Interface for verifier finalizer

--- a/proofs/src/poly/kzg/commitment.rs
+++ b/proofs/src/poly/kzg/commitment.rs
@@ -83,16 +83,15 @@ where
     E::G1Affine: CurveAffine<ScalarExt = E::Fr, CurveExt = E::G1>,
 {
     /// Collapses a `Linear` combination into a `Simple` commitment by computing
-    /// the MSM `∑ scalars[i] * points[i]`.
+    /// the MSM `∑ scalars[i] * points[i]`, labeling the result with `label`.
     ///
-    /// A `Simple` commitment is left unchanged.
-    /// After the call, the result always has scalar `1` and label `Collapsed`.
-    pub fn collapse(&mut self) {
+    /// A `Simple` commitment is left unchanged (its existing label is kept).
+    pub fn collapse(&mut self, label: PolynomialLabel) {
         match self {
             Self::Simple(_, _) => (),
             Self::Linear(points, scalars, labels) => {
                 let mut msm = MSMKZG::<E>::new(scalars, points, labels);
-                msm.collapse();
+                msm.collapse(label);
                 debug_assert_eq!(msm.bases.len(), 1);
                 debug_assert_eq!(msm.scalars, vec![E::Fr::ONE]);
                 *self = Self::Simple(msm.bases[0], msm.labels[0].clone());
@@ -117,7 +116,7 @@ where
     E::G1: Default,
 {
     fn default() -> Self {
-        Self::Simple(E::G1::default(), PolynomialLabel::Collapsed)
+        Self::Simple(E::G1::default(), PolynomialLabel::NoLabel)
     }
 }
 

--- a/proofs/src/poly/kzg/commitment.rs
+++ b/proofs/src/poly/kzg/commitment.rs
@@ -4,6 +4,7 @@ use std::{
 };
 
 use ff::Field;
+use group::Group;
 use midnight_curves::{pairing::MultiMillerLoop, CurveAffine};
 
 use crate::{
@@ -120,13 +121,13 @@ where
     }
 }
 
-impl<E: MultiMillerLoop> Labelable for KZGCommitment<E> {
-    /// Adds a label to the KZG commitment.
+impl<E: MultiMillerLoop> KZGCommitment<E> {
+    /// Attaches `label` to a freshly-deserialized (`NoLabel`) commitment.
     ///
     /// # Panics
     ///
     /// If the commitment is not `Simple` or if it was already labeled.
-    fn label(self, label: PolynomialLabel) -> Self {
+    pub(super) fn label(self, label: PolynomialLabel) -> Self {
         match self {
             Self::Simple(p, PolynomialLabel::NoLabel) => Self::Simple(p, label),
             Self::Simple(_, existing) => panic!("commitment is already labeled: {existing:?}"),
@@ -223,5 +224,154 @@ impl<E: MultiMillerLoop> Add for KZGCommitment<E> {
         scalars.extend(other_scalars);
         labels.extend(other_labels);
         Self::Linear(points, scalars, labels)
+    }
+}
+
+/// A KZG commitment to one or more polynomials.
+///
+/// Each inner [`KZGCommitment`] corresponds to one polynomial. Committing to
+/// multiple polynomials is handled sequentially with no sublinear optimization;
+/// commitments are independent curve points, one per polynomial.
+#[derive(Clone, Debug)]
+pub struct KZGMultiCommitment<E: MultiMillerLoop>(pub Vec<KZGCommitment<E>>);
+
+impl<E: MultiMillerLoop> KZGMultiCommitment<E> {
+    fn assert_single(&self) {
+        assert_eq!(
+            self.0.len(),
+            1,
+            "operation on KZGMultiCommitment requires exactly one polynomial"
+        );
+    }
+
+    /// Consumes the commitment, returning its single inner [`KZGCommitment`].
+    ///
+    /// # Panics
+    ///
+    /// If this commitment does not hold exactly one polynomial.
+    pub fn into_single(self) -> KZGCommitment<E> {
+        self.assert_single();
+        self.0.into_iter().next().unwrap()
+    }
+
+    /// A commitment to the zero polynomial (the identity point), tagged with
+    /// `label`. Used e.g. for empty committed-instance columns.
+    pub fn commitment_to_zero(label: PolynomialLabel) -> Self {
+        Self(vec![KZGCommitment::Simple(E::G1::identity(), label)])
+    }
+}
+
+impl<E: MultiMillerLoop> PartialEq for KZGMultiCommitment<E>
+where
+    E::G1: PartialEq,
+    E::Fr: PartialEq,
+{
+    fn eq(&self, other: &Self) -> bool {
+        self.0 == other.0
+    }
+}
+
+impl<E: MultiMillerLoop> Default for KZGMultiCommitment<E>
+where
+    E::G1: Default,
+{
+    fn default() -> Self {
+        Self(vec![KZGCommitment::default()])
+    }
+}
+
+impl<E: MultiMillerLoop> Labelable for KZGMultiCommitment<E> {
+    fn label(self, labels: &[PolynomialLabel]) -> Self {
+        assert_eq!(
+            labels.len(),
+            self.0.len(),
+            "label count must match polynomial count"
+        );
+        Self(self.0.into_iter().zip(labels).map(|(c, l)| c.label(l.clone())).collect())
+    }
+
+    fn length(&self) -> usize {
+        self.0.len()
+    }
+}
+
+/// The inner per-polynomial `KZGCommitment`s, concatenated with no length
+/// prefix: a single-polynomial commitment serializes exactly like its inner
+/// commitment. The number of polynomials is therefore not recoverable from the
+/// bytes alone; `read` deserializes a single polynomial (the common case), and
+/// batched commitments are read with an explicit length elsewhere.
+///
+/// Labels are not part of the serialized form; deserialized commitments receive
+/// [`PolynomialLabel::NoLabel`] and must be labeled at the call site.
+impl<E: MultiMillerLoop> ProcessedSerdeObject for KZGMultiCommitment<E>
+where
+    E::G1: Default + ProcessedSerdeObject,
+{
+    fn read<R: io::Read>(reader: &mut R, format: SerdeFormat) -> io::Result<Self> {
+        Ok(Self(vec![
+            <KZGCommitment<E> as ProcessedSerdeObject>::read(reader, format)?,
+        ]))
+    }
+
+    fn write<W: io::Write>(&self, writer: &mut W, format: SerdeFormat) -> io::Result<()> {
+        for c in &self.0 {
+            c.write(writer, format)?;
+        }
+        Ok(())
+    }
+
+    fn byte_length(&self, format: SerdeFormat) -> usize {
+        self.0.iter().map(|c| c.byte_length(format)).sum()
+    }
+}
+
+impl<H: TranscriptHash, E: MultiMillerLoop> Hashable<H> for KZGMultiCommitment<E>
+where
+    E::G1: Hashable<H>,
+{
+    fn to_input(&self) -> H::Input {
+        // Without batching every commitment holds a single polynomial, so we
+        // hash its sole inner commitment. Hashing a batched commitment (which
+        // would require concatenating per-polynomial inputs) is left for when
+        // batching is introduced.
+        assert_eq!(
+            self.0.len(),
+            1,
+            "hashing a KZGMultiCommitment with more than one polynomial is not yet supported"
+        );
+        self.0[0].to_input()
+    }
+
+    fn to_bytes(&self) -> Vec<u8> {
+        let mut bytes = Vec::new();
+        for c in &self.0 {
+            bytes.extend_from_slice(&c.to_bytes());
+        }
+        bytes
+    }
+
+    fn read(buffer: &mut impl Read) -> io::Result<Self> {
+        Ok(Self(vec![<KZGCommitment<E> as Hashable<H>>::read(buffer)?]))
+    }
+}
+
+impl<E: MultiMillerLoop> Mul<E::Fr> for KZGMultiCommitment<E> {
+    type Output = Self;
+
+    fn mul(self, scalar: E::Fr) -> Self {
+        self.assert_single();
+        Self(vec![self.0.into_iter().next().unwrap() * scalar])
+    }
+}
+
+impl<E: MultiMillerLoop> Add for KZGMultiCommitment<E> {
+    type Output = Self;
+
+    fn add(self, other: Self) -> Self {
+        self.assert_single();
+        other.assert_single();
+        Self(vec![
+            self.0.into_iter().next().unwrap() + other.0.into_iter().next().unwrap(),
+        ])
     }
 }

--- a/proofs/src/poly/kzg/commitment.rs
+++ b/proofs/src/poly/kzg/commitment.rs
@@ -43,6 +43,9 @@ pub enum KZGCommitment<E: MultiMillerLoop> {
 // We implement `PartialEq` manually because its derivation would require
 // `E: PartialEq`. In practice, only `E::G1` and `E::Fr` need it;
 // `E` itself never appears directly in a comparison.
+//
+// This comparison is literal. Two equivalent commitments are considered
+// different if their representation is different.
 impl<E: MultiMillerLoop> PartialEq for KZGCommitment<E>
 where
     E::G1: PartialEq,

--- a/proofs/src/poly/kzg/mod.rs
+++ b/proofs/src/poly/kzg/mod.rs
@@ -386,7 +386,7 @@ where
             // Collapse all MSMs before combining with x4 powers, to match the
             // in-circuit verifier. Skip the first one since its x4 power is 1.
             #[cfg(feature = "truncated-challenges")]
-            coms.iter_mut().skip(1).for_each(|c| c.collapse());
+            coms.iter_mut().skip(1).for_each(|c| c.collapse(PolynomialLabel::NoLabel));
             coms.push(f_com);
 
             #[cfg(feature = "truncated-challenges")]

--- a/proofs/src/poly/kzg/mod.rs
+++ b/proofs/src/poly/kzg/mod.rs
@@ -24,7 +24,7 @@ mod utils;
 
 use std::{fmt::Debug, hash::Hash};
 
-use commitment::KZGCommitment;
+use commitment::{KZGCommitment, KZGMultiCommitment};
 use ff::Field;
 use group::Group;
 use midnight_curves::pairing::MultiMillerLoop;
@@ -68,7 +68,7 @@ where
 {
     type Parameters = ParamsKZG<E>;
     type VerifierParameters = ParamsVerifierKZG<E>;
-    type Commitment = KZGCommitment<E>;
+    type Commitment = KZGMultiCommitment<E>;
     type VerificationGuard = DualMSM<E>;
 
     fn gen_params(k: u32) -> Self::Parameters {
@@ -79,17 +79,31 @@ where
         params.verifier_params()
     }
 
-    fn commit<B: PolynomialRepresentation>(
+    fn commit_many<B: PolynomialRepresentation>(
         params: &Self::Parameters,
-        polynomial: &Polynomial<E::Fr, B>,
-        label: PolynomialLabel,
+        polynomials: &[&Polynomial<E::Fr, B>],
+        labels: &[PolynomialLabel],
     ) -> Self::Commitment {
+        assert_eq!(
+            polynomials.len(),
+            labels.len(),
+            "polynomials and labels must have the same length"
+        );
+        assert!(!polynomials.is_empty(), "cannot commit to zero polynomials");
         let bases = params.bases::<B>();
-        let size = polynomial.values.len();
-        assert!(bases.len() >= size);
-        KZGCommitment::Simple(
-            msm_specific::<E::G1Affine>(&polynomial.values, &bases[..size]),
-            label,
+        KZGMultiCommitment(
+            polynomials
+                .iter()
+                .zip(labels)
+                .map(|(polynomial, label)| {
+                    let size = polynomial.values.len();
+                    assert!(bases.len() >= size);
+                    KZGCommitment::Simple(
+                        msm_specific::<E::G1Affine>(&polynomial.values, &bases[..size]),
+                        label.clone(),
+                    )
+                })
+                .collect(),
         )
     }
 
@@ -100,7 +114,7 @@ where
     ) -> Result<(), Error>
     where
         E::Fr: Sampleable<T::Hash> + Hash + Ord + Hashable<T::Hash>,
-        KZGCommitment<E>: Hashable<T::Hash>,
+        KZGMultiCommitment<E>: Hashable<T::Hash>,
     {
         /// Like [`inner_product`] but for coefficient-form polynomials that may
         /// have different lengths (zero-extending the shorter operands).
@@ -281,7 +295,7 @@ where
     where
         E::Fr: Sampleable<T::Hash> + Ord + Hash + Hashable<T::Hash>,
         E::G1: CurveExt<ScalarExt = E::Fr>,
-        KZGCommitment<E>: Hashable<T::Hash> + 'com,
+        KZGMultiCommitment<E>: Hashable<T::Hash> + 'com,
     {
         // Add dummy queries to reduce the number of distinct multi-open point sets.
         #[cfg(feature = "fewer-point-sets")]
@@ -307,10 +321,29 @@ where
         let x1: E::Fr = transcript.squeeze_challenge();
         let x2: E::Fr = transcript.squeeze_challenge();
 
-        // Map each label to the commitment it identifies, so the per-set
-        // grouping (keyed by label) can recover the actual commitments.
-        let label_to_commitment: HashMap<PolynomialLabel, &KZGCommitment<E>> =
-            queries.iter().map(|q| (q.label.clone(), q.commitment_ref.0)).collect();
+        // Peel each query's multi-commitment down to the single inner
+        // `KZGCommitment` it targets, keyed by the query label. The rest of the
+        // routine then operates on individual `KZGCommitment`s as before.
+        //
+        // A length-1 commitment (the common case, including the `Linear`
+        // linearization commitment) peels to its sole inner. A batched
+        // commitment holds several `Simple`s, so we pick the one whose own label
+        // matches the query.
+        let label_to_commitment: HashMap<PolynomialLabel, &KZGCommitment<E>> = queries
+            .iter()
+            .map(|q| {
+                let inners = &q.commitment_ref.0 .0;
+                let inner = if inners.len() == 1 {
+                    &inners[0]
+                } else {
+                    inners
+                        .iter()
+                        .find(|c| matches!(c, KZGCommitment::Simple(_, label) if *label == q.label))
+                        .expect("batched commitment has no polynomial matching the query label")
+                };
+                (q.label.clone(), inner)
+            })
+            .collect();
 
         let kzg_queries = queries
             .iter()
@@ -362,8 +395,11 @@ where
             (q_coms, q_eval_sets, point_sets)
         };
 
-        let f_com = transcript.read::<KZGCommitment<E>>().map_err(|_| Error::SamplingError)?;
-        let f_com = f_com.label(PolynomialLabel::Custom("kzg_batch".into()));
+        let f_com = transcript
+            .read::<KZGMultiCommitment<E>>()
+            .map_err(|_| Error::SamplingError)?
+            .label(&[PolynomialLabel::Custom("kzg_batch".into())])
+            .into_single();
 
         // Sample a challenge x_3 for checking that f(X) was committed to
         // correctly.
@@ -426,8 +462,9 @@ where
         };
 
         let pi: E::G1 = transcript
-            .read::<KZGCommitment<E>>()
+            .read::<KZGMultiCommitment<E>>()
             .map_err(|_| Error::SamplingError)?
+            .into_single()
             .into_point();
 
         let mut pi_msm = MSMKZG::<E>::init();
@@ -467,7 +504,7 @@ mod tests {
         poly::{
             commitment::{Guard, Labelable, PolynomialCommitmentScheme},
             kzg::{
-                commitment::KZGCommitment,
+                commitment::KZGMultiCommitment,
                 params::{ParamsKZG, ParamsVerifierKZG},
                 KZGCommitmentScheme,
             },
@@ -501,22 +538,22 @@ mod tests {
         E::Fr: Hashable<T::Hash> + Sampleable<T::Hash> + Ord + Hash,
         E::G1: Hashable<T::Hash> + CurveExt<ScalarExt = E::Fr, AffineExt = E::G1Affine>,
         E::G1Affine: CurveAffine<ScalarExt = E::Fr, CurveExt = E::G1> + SerdeObject,
-        KZGCommitment<E>: Hashable<T::Hash>,
+        KZGMultiCommitment<E>: Hashable<T::Hash>,
     {
         let mut transcript = T::init_from_bytes(proof);
 
         let a = transcript
-            .read::<KZGCommitment<E>>()
+            .read::<KZGMultiCommitment<E>>()
             .unwrap()
-            .label(PolynomialLabel::Custom("a".into()));
+            .label(&[PolynomialLabel::Custom("a".into())]);
         let b = transcript
-            .read::<KZGCommitment<E>>()
+            .read::<KZGMultiCommitment<E>>()
             .unwrap()
-            .label(PolynomialLabel::Custom("b".into()));
+            .label(&[PolynomialLabel::Custom("b".into())]);
         let c = transcript
-            .read::<KZGCommitment<E>>()
+            .read::<KZGMultiCommitment<E>>()
             .unwrap()
-            .label(PolynomialLabel::Custom("c".into()));
+            .label(&[PolynomialLabel::Custom("c".into())]);
 
         let x: E::Fr = transcript.squeeze_challenge();
         let y: E::Fr = transcript.squeeze_challenge();

--- a/proofs/src/poly/kzg/mod.rs
+++ b/proofs/src/poly/kzg/mod.rs
@@ -152,14 +152,14 @@ where
             let mut queries = queries.to_vec();
             let pairs: Vec<_> = queries.iter().map(|q| (q.label.clone(), q.point)).collect();
             for (idx, dummy_point) in compute_dummy_queries(&pairs) {
-                let poly_ref = queries[idx].poly_ref;
+                let poly = queries[idx].poly;
                 let label = queries[idx].label.clone();
                 transcript
-                    .write(&eval_polynomial(&poly_ref.0[..], dummy_point))
+                    .write(&eval_polynomial(&poly[..], dummy_point))
                     .map_err(|_| Error::OpeningError)?;
                 queries.push(ProverQuery {
                     point: dummy_point,
-                    poly_ref,
+                    poly,
                     label,
                 });
             }
@@ -174,7 +174,7 @@ where
         // Map each label to the polynomial it identifies, so the per-set
         // grouping (keyed by label) can recover the actual polynomials.
         let label_to_poly: HashMap<PolynomialLabel, &Polynomial<E::Fr, Coeff>> =
-            queries.iter().map(|q| (q.label.clone(), q.poly_ref.0)).collect();
+            queries.iter().map(|q| (q.label.clone(), q.poly)).collect();
 
         let kzg_queries = queries
             .iter()
@@ -182,7 +182,7 @@ where
                 (
                     query.label.clone(),
                     query.point,
-                    eval_polynomial(&query.poly_ref.0[..], query.point),
+                    eval_polynomial(&query.poly[..], query.point),
                 )
             })
             .collect::<Vec<_>>();
@@ -303,12 +303,12 @@ where
             let mut queries = queries.to_vec();
             let pairs: Vec<_> = queries.iter().map(|q| (q.label.clone(), q.point)).collect();
             for (idx, dummy_point) in compute_dummy_queries(&pairs) {
-                let commitment_ref = queries[idx].commitment_ref;
+                let commitment = queries[idx].commitment;
                 let label = queries[idx].label.clone();
                 let eval = transcript.read().map_err(|_| Error::SamplingError)?;
                 queries.push(VerifierQuery {
                     point: dummy_point,
-                    commitment_ref,
+                    commitment,
                     label,
                     eval,
                 });
@@ -332,7 +332,7 @@ where
         let label_to_commitment: HashMap<PolynomialLabel, &KZGCommitment<E>> = queries
             .iter()
             .map(|q| {
-                let inners = &q.commitment_ref.0 .0;
+                let inners = &q.commitment.0;
                 let inner = if inners.len() == 1 {
                     &inners[0]
                 } else {
@@ -508,7 +508,7 @@ mod tests {
                 params::{ParamsKZG, ParamsVerifierKZG},
                 KZGCommitmentScheme,
             },
-            query::{PolynomialReference, ProverQuery, VerifierQuery},
+            query::{ProverQuery, VerifierQuery},
             EvaluationDomain, PolynomialLabel,
         },
         transcript::{CircuitTranscript, Hashable, Sampleable, Transcript},
@@ -669,17 +669,17 @@ mod tests {
         let queries = [
             ProverQuery {
                 point: x,
-                poly_ref: PolynomialReference(&ax),
+                poly: &ax,
                 label: PolynomialLabel::Custom("a".into()),
             },
             ProverQuery {
                 point: x,
-                poly_ref: PolynomialReference(&bx),
+                poly: &bx,
                 label: PolynomialLabel::Custom("b".into()),
             },
             ProverQuery {
                 point: y,
-                poly_ref: PolynomialReference(&cx),
+                poly: &cx,
                 label: PolynomialLabel::Custom("c".into()),
             },
         ]

--- a/proofs/src/poly/kzg/mod.rs
+++ b/proofs/src/poly/kzg/mod.rs
@@ -7,7 +7,7 @@
 //!
 //! For a more detailed explanation, see the [Halo 2 Book](https://zcash.github.io/halo2/design/proving-system/multipoint-opening.html) on Multipoint Openings.
 
-use std::marker::PhantomData;
+use std::{collections::HashMap, marker::PhantomData};
 
 use midnight_curves::pairing::Engine;
 use rayon::iter::{
@@ -136,15 +136,17 @@ where
         #[cfg(feature = "fewer-point-sets")]
         let queries = &{
             let mut queries = queries.to_vec();
-            let pairs: Vec<_> = queries.iter().map(|q| (q.poly_ref, q.point)).collect();
+            let pairs: Vec<_> = queries.iter().map(|q| (q.label.clone(), q.point)).collect();
             for (idx, dummy_point) in compute_dummy_queries(&pairs) {
                 let poly_ref = queries[idx].poly_ref;
+                let label = queries[idx].label.clone();
                 transcript
                     .write(&eval_polynomial(&poly_ref.0[..], dummy_point))
                     .map_err(|_| Error::OpeningError)?;
                 queries.push(ProverQuery {
                     point: dummy_point,
                     poly_ref,
+                    label,
                 });
             }
             queries
@@ -155,11 +157,16 @@ where
         let x1: E::Fr = transcript.squeeze_challenge();
         let x2: E::Fr = transcript.squeeze_challenge();
 
+        // Map each label to the polynomial it identifies, so the per-set
+        // grouping (keyed by label) can recover the actual polynomials.
+        let label_to_poly: HashMap<PolynomialLabel, &Polynomial<E::Fr, Coeff>> =
+            queries.iter().map(|q| (q.label.clone(), q.poly_ref.0)).collect();
+
         let kzg_queries = queries
             .iter()
             .map(|query| {
                 (
-                    query.poly_ref,
+                    query.label.clone(),
                     query.point,
                     eval_polynomial(&query.poly_ref.0[..], query.point),
                 )
@@ -170,7 +177,7 @@ where
         let mut q_polys = vec![vec![]; point_sets.len()];
 
         for com_data in poly_map.iter() {
-            q_polys[com_data.set_index].push(com_data.commitment_ref.0);
+            q_polys[com_data.set_index].push(label_to_poly[&com_data.label]);
         }
 
         let q_polys: Vec<_> = q_polys
@@ -280,13 +287,15 @@ where
         #[cfg(feature = "fewer-point-sets")]
         let queries = &{
             let mut queries = queries.to_vec();
-            let pairs: Vec<_> = queries.iter().map(|q| (q.commitment_ref, q.point)).collect();
+            let pairs: Vec<_> = queries.iter().map(|q| (q.label.clone(), q.point)).collect();
             for (idx, dummy_point) in compute_dummy_queries(&pairs) {
                 let commitment_ref = queries[idx].commitment_ref;
+                let label = queries[idx].label.clone();
                 let eval = transcript.read().map_err(|_| Error::SamplingError)?;
                 queries.push(VerifierQuery {
                     point: dummy_point,
                     commitment_ref,
+                    label,
                     eval,
                 });
             }
@@ -298,9 +307,14 @@ where
         let x1: E::Fr = transcript.squeeze_challenge();
         let x2: E::Fr = transcript.squeeze_challenge();
 
+        // Map each label to the commitment it identifies, so the per-set
+        // grouping (keyed by label) can recover the actual commitments.
+        let label_to_commitment: HashMap<PolynomialLabel, &KZGCommitment<E>> =
+            queries.iter().map(|q| (q.label.clone(), q.commitment_ref.0)).collect();
+
         let kzg_queries = queries
             .iter()
-            .map(|query| (query.commitment_ref, query.point, query.eval))
+            .map(|query| (query.label.clone(), query.point, query.eval))
             .collect::<Vec<_>>();
         let (commitment_map, point_sets) = construct_intermediate_sets(&kzg_queries)?;
 
@@ -308,7 +322,7 @@ where
         let mut q_eval_sets = vec![vec![]; point_sets.len()];
 
         for com_data in commitment_map.into_iter() {
-            q_coms[com_data.set_index].push(com_data.commitment_ref.0.clone());
+            q_coms[com_data.set_index].push(label_to_commitment[&com_data.label].clone());
             q_eval_sets[com_data.set_index].push(com_data.evals);
         }
 
@@ -451,7 +465,7 @@ mod tests {
 
     use crate::{
         poly::{
-            commitment::{Guard, PolynomialCommitmentScheme},
+            commitment::{Guard, Labelable, PolynomialCommitmentScheme},
             kzg::{
                 commitment::KZGCommitment,
                 params::{ParamsKZG, ParamsVerifierKZG},
@@ -491,9 +505,18 @@ mod tests {
     {
         let mut transcript = T::init_from_bytes(proof);
 
-        let a: KZGCommitment<E> = transcript.read().unwrap();
-        let b: KZGCommitment<E> = transcript.read().unwrap();
-        let c: KZGCommitment<E> = transcript.read().unwrap();
+        let a = transcript
+            .read::<KZGCommitment<E>>()
+            .unwrap()
+            .label(PolynomialLabel::Custom("a".into()));
+        let b = transcript
+            .read::<KZGCommitment<E>>()
+            .unwrap()
+            .label(PolynomialLabel::Custom("b".into()));
+        let c = transcript
+            .read::<KZGCommitment<E>>()
+            .unwrap()
+            .label(PolynomialLabel::Custom("c".into()));
 
         let x: E::Fr = transcript.squeeze_challenge();
         let y: E::Fr = transcript.squeeze_challenge();
@@ -503,14 +526,44 @@ mod tests {
         let cvy: E::Fr = transcript.read().unwrap();
 
         let valid_queries = std::iter::empty()
-            .chain(Some(VerifierQuery::new(x, &a, avx)))
-            .chain(Some(VerifierQuery::new(x, &b, bvx)))
-            .chain(Some(VerifierQuery::new(y, &c, cvy)));
+            .chain(Some(VerifierQuery::new(
+                x,
+                &a,
+                PolynomialLabel::Custom("a".into()),
+                avx,
+            )))
+            .chain(Some(VerifierQuery::new(
+                x,
+                &b,
+                PolynomialLabel::Custom("b".into()),
+                bvx,
+            )))
+            .chain(Some(VerifierQuery::new(
+                y,
+                &c,
+                PolynomialLabel::Custom("c".into()),
+                cvy,
+            )));
 
         let invalid_queries = std::iter::empty()
-            .chain(Some(VerifierQuery::new(x, &a, avx)))
-            .chain(Some(VerifierQuery::new(x, &b, avx)))
-            .chain(Some(VerifierQuery::new(y, &c, cvy)));
+            .chain(Some(VerifierQuery::new(
+                x,
+                &a,
+                PolynomialLabel::Custom("a".into()),
+                avx,
+            )))
+            .chain(Some(VerifierQuery::new(
+                x,
+                &b,
+                PolynomialLabel::Custom("b".into()),
+                avx,
+            )))
+            .chain(Some(VerifierQuery::new(
+                y,
+                &c,
+                PolynomialLabel::Custom("c".into()),
+                cvy,
+            )));
 
         let queries = if should_fail {
             invalid_queries
@@ -580,14 +633,17 @@ mod tests {
             ProverQuery {
                 point: x,
                 poly_ref: PolynomialReference(&ax),
+                label: PolynomialLabel::Custom("a".into()),
             },
             ProverQuery {
                 point: x,
                 poly_ref: PolynomialReference(&bx),
+                label: PolynomialLabel::Custom("b".into()),
             },
             ProverQuery {
                 point: y,
                 poly_ref: PolynomialReference(&cx),
+                label: PolynomialLabel::Custom("c".into()),
             },
         ]
         .into_iter();

--- a/proofs/src/poly/kzg/msm.rs
+++ b/proofs/src/poly/kzg/msm.rs
@@ -79,7 +79,7 @@ impl<E: Engine> MSMKZG<E> {
         MSMKZG {
             scalars: vec![E::Fr::ONE],
             bases: vec![*base],
-            labels: vec![PolynomialLabel::Collapsed],
+            labels: vec![PolynomialLabel::NoLabel],
         }
     }
 }
@@ -89,7 +89,7 @@ where
     E::G1Affine: CurveAffine<ScalarExt = E::Fr, CurveExt = E::G1>,
 {
     /// Evaluates the MSM to a single point and replaces all terms with that
-    /// single point (scalar = 1, label = `Collapsed`).
+    /// single point (scalar = 1), labeling the result with `label`.
     ///
     /// This mirrors `AssignedMsm::collapse` in the circuits crate.
     ///
@@ -98,19 +98,19 @@ where
     /// If a term carries a `Fixed` or `PermutationFixed` label.
     //  This is because these "fixed" labels carry information that we do not want
     //  to lose when collapsing, since it is relevant for the `verifier_gadget`.
-    pub fn collapse(&mut self) {
+    pub fn collapse(&mut self, label: PolynomialLabel) {
         debug_assert!(
             !self.labels.iter().any(|l| matches!(
                 l,
                 PolynomialLabel::Fixed(_) | PolynomialLabel::PermutationFixed(_)
             )),
-            "collapse: all labels must be Collapsed, Advice or Instance, found: {:?}",
+            "collapse: no label may be Fixed or PermutationFixed, found: {:?}",
             self.labels,
         );
         let point = self.eval();
         self.scalars = vec![E::Fr::ONE];
         self.bases = vec![point];
-        self.labels = vec![PolynomialLabel::Collapsed];
+        self.labels = vec![label];
     }
 }
 

--- a/proofs/src/poly/kzg/utils.rs
+++ b/proofs/src/poly/kzg/utils.rs
@@ -6,20 +6,20 @@ use std::{
 
 use ff::Field;
 
-use crate::poly::Error;
+use crate::poly::{query::PolynomialLabel, Error};
 
 #[derive(Clone, Debug)]
-pub(super) struct CommitmentData<F, T: PartialEq> {
-    pub(super) commitment_ref: T,
+pub(super) struct CommitmentData<F> {
+    pub(super) label: PolynomialLabel,
     pub(super) set_index: usize,
     pub(super) point_indices: Vec<usize>,
     pub(super) evals: Vec<F>,
 }
 
-impl<F, T: PartialEq> CommitmentData<F, T> {
-    fn new(commitment_ref: T) -> Self {
+impl<F> CommitmentData<F> {
+    fn new(label: PolynomialLabel) -> Self {
         CommitmentData {
-            commitment_ref,
+            label,
             set_index: 0,
             point_indices: vec![],
             evals: vec![],
@@ -27,24 +27,22 @@ impl<F, T: PartialEq> CommitmentData<F, T> {
     }
 }
 
-pub(super) type IntermediateSets<F, T> = (Vec<CommitmentData<F, T>>, Vec<Vec<F>>);
+pub(super) type IntermediateSets<F> = (Vec<CommitmentData<F>>, Vec<Vec<F>>);
 
-/// Groups a list of `(commitment_ref, point, eval)` queries into per-commitment
-/// data and point sets for multi-open batching.
+/// Groups a list of `(label, point, eval)` queries into per-polynomial data and
+/// point sets for multi-open batching.
 ///
-/// `T` is a commitment reference (a reference to a polynomial in the prover,
-/// a reference to a curve point in the verifier); its [`PartialEq`] must
-/// reflect equality between references.
-/// Queries are grouped by commitment reference and point set.
+/// Queries are grouped by their [`PolynomialLabel`] (each label identifies a
+/// unique polynomial) and by point set.
 ///
-/// Returns [`Error::DuplicatedQuery`] if the same `(commitment_ref, point)`
-/// pair appears more than once.
-pub fn construct_intermediate_sets<F: Field + Hash + Ord, T: PartialEq + Copy>(
-    queries: &[(T, F, F)],
-) -> Result<IntermediateSets<F, T>, Error> {
+/// Returns [`Error::DuplicatedQuery`] if the same `(label, point)` pair appears
+/// more than once.
+pub fn construct_intermediate_sets<F: Field + Hash + Ord>(
+    queries: &[(PolynomialLabel, F, F)],
+) -> Result<IntermediateSets<F>, Error> {
     // Construct sets of unique commitments and corresponding information about
     // their queries.
-    let mut commitment_map: Vec<CommitmentData<F, T>> = vec![];
+    let mut commitment_map: Vec<CommitmentData<F>> = vec![];
 
     // Also construct mapping from a unique point to a point_index. This defines
     // an ordering on the points.
@@ -52,19 +50,17 @@ pub fn construct_intermediate_sets<F: Field + Hash + Ord, T: PartialEq + Copy>(
 
     // Iterate over all of the queries, computing the ordering of the points
     // while also creating new commitment data.
-    for (query_com_ref, query_point, _query_eval) in queries {
+    for (query_label, query_point, _query_eval) in queries {
         let num_points = point_index_map.len();
         let point_idx = point_index_map.entry(*query_point).or_insert(num_points);
 
-        if let Some(pos) =
-            commitment_map.iter().position(|comm| &comm.commitment_ref == query_com_ref)
-        {
+        if let Some(pos) = commitment_map.iter().position(|comm| &comm.label == query_label) {
             if commitment_map[pos].point_indices.contains(point_idx) {
                 return Err(Error::DuplicatedQuery);
             }
             commitment_map[pos].point_indices.push(*point_idx);
         } else {
-            let mut tmp = CommitmentData::new(*query_com_ref);
+            let mut tmp = CommitmentData::new(query_label.clone());
             tmp.point_indices.push(*point_idx);
             commitment_map.push(tmp);
         }
@@ -83,7 +79,7 @@ pub fn construct_intermediate_sets<F: Field + Hash + Ord, T: PartialEq + Copy>(
         let point_index_set: BTreeSet<_> = commitment_data.point_indices.iter().cloned().collect();
 
         // Push point_index_set to CommitmentData for the relevant commitment
-        commitment_set_map.push((commitment_data.commitment_ref, point_index_set.clone()));
+        commitment_set_map.push((commitment_data.label.clone(), point_index_set.clone()));
 
         let num_sets = point_idx_sets.len();
         point_idx_sets.entry(point_index_set).or_insert(num_sets);
@@ -96,14 +92,14 @@ pub fn construct_intermediate_sets<F: Field + Hash + Ord, T: PartialEq + Copy>(
     }
 
     // Populate set_index, evals and points for each commitment using point_idx_sets
-    for (query_com_ref, query_point, query_eval) in queries {
+    for (query_label, query_point, query_eval) in queries {
         // The index of the point at which the commitment is queried
         let point_index = point_index_map.get(query_point).unwrap();
 
         // The point_index_set at which the commitment was queried
         let point_index_set = commitment_set_map
             .iter()
-            .find(|(c, _)| c == query_com_ref)
+            .find(|(l, _)| l == query_label)
             .map(|(_, s)| s)
             .unwrap();
         assert!(!point_index_set.is_empty());
@@ -117,7 +113,7 @@ pub fn construct_intermediate_sets<F: Field + Hash + Ord, T: PartialEq + Copy>(
         let point_index_in_set = point_index_set.iter().position(|i| i == point_index).unwrap();
 
         for commitment_data in commitment_map.iter_mut() {
-            if *query_com_ref == commitment_data.commitment_ref {
+            if *query_label == commitment_data.label {
                 commitment_data.set_index = *set_index;
                 // Insert the eval using the ordering of the point_index_set
                 commitment_data.evals[point_index_in_set] = *query_eval;

--- a/proofs/src/poly/query.rs
+++ b/proofs/src/poly/query.rs
@@ -19,18 +19,18 @@ pub enum PolynomialLabel {
     PermutationFixed(usize),
     /// Permutation accumulator polynomial z(X) (chain index).
     PermutationAccumulator(usize),
-    /// LogUp helper polynomial h_j(X) = 1/(f_j(X) + β), for a named argument.
-    LogupHelper(String),
-    /// LogUp multiplicities polynomial m(X), for a named argument.
-    LogupMultiplicities(String),
-    /// LogUp accumulator polynomial Z(X), for a named argument.
-    LogupAggregator(String),
+    /// LogUp helper polynomial h_j(X) = 1/(f_j(X) + β) (argument index).
+    LogupHelper(usize),
+    /// LogUp multiplicities polynomial m(X) (argument index).
+    LogupMultiplicities(usize),
+    /// LogUp accumulator polynomial Z(X) (argument index).
+    LogupAggregator(usize),
     /// PLONK quotient polynomial h(X), committed as a single piece.
     Quotient,
     /// PLONK quotient polynomial h(X), committed in pieces (piece index).
     QuotientPiece(usize),
-    /// Trash compressed polynomial, for a named argument.
-    Trash(String),
+    /// Trash compressed polynomial (argument index).
+    Trash(usize),
     /// A commitment obtained by collapsing an MSM.
     Collapsed,
     /// User-defined label.
@@ -49,10 +49,10 @@ impl fmt::Display for PolynomialLabel {
             Self::CommittedInstance(i) => write!(f, "committed_instance_{i}"),
             Self::PermutationFixed(i) => write!(f, "perm_fixed_{i}"),
             Self::PermutationAccumulator(i) => write!(f, "perm_acc_{i}"),
-            Self::LogupHelper(name) => write!(f, "logup_helper({name})"),
-            Self::LogupMultiplicities(name) => write!(f, "logup_multiplicities({name})"),
-            Self::LogupAggregator(name) => write!(f, "logup_aggregator({name})"),
-            Self::Trash(name) => write!(f, "trash({name})"),
+            Self::LogupHelper(i) => write!(f, "logup_helper({i})"),
+            Self::LogupMultiplicities(i) => write!(f, "logup_multiplicities({i})"),
+            Self::LogupAggregator(i) => write!(f, "logup_aggregator({i})"),
+            Self::Trash(i) => write!(f, "trash({i})"),
             Self::Quotient => f.write_str("quotient"),
             Self::QuotientPiece(i) => write!(f, "quotient_piece_{i}"),
             Self::Collapsed => f.write_str("collapsed"),

--- a/proofs/src/poly/query.rs
+++ b/proofs/src/poly/query.rs
@@ -69,8 +69,8 @@ impl fmt::Display for PolynomialLabel {
 pub struct ProverQuery<'com, F: PrimeField> {
     /// Point at which polynomial is queried
     pub(crate) point: F,
-    /// Reference to a polynomial
-    pub(crate) poly_ref: PolynomialReference<'com, F>,
+    /// Reference to the queried polynomial.
+    pub(crate) poly: &'com Polynomial<F, Coeff>,
     /// Label identifying the queried polynomial.
     pub(crate) label: PolynomialLabel,
 }
@@ -81,46 +81,7 @@ where
 {
     /// Create a new prover query based on a polynomial and its label.
     pub fn new(point: F, poly: &'com Polynomial<F, Coeff>, label: PolynomialLabel) -> Self {
-        ProverQuery {
-            point,
-            poly_ref: PolynomialReference(poly),
-            label,
-        }
-    }
-}
-
-#[doc(hidden)]
-#[derive(Copy, Clone, Debug)]
-pub struct PolynomialReference<'com, F: PrimeField>(pub(crate) &'com Polynomial<F, Coeff>);
-
-impl<F: PrimeField> PartialEq for PolynomialReference<'_, F> {
-    fn eq(&self, other: &Self) -> bool {
-        std::ptr::eq(self.0, other.0)
-    }
-}
-
-/// A pointer to a commitment, with pointer-based equality.
-///
-/// Two `CommitmentReference`s are equal iff they point to the same allocation,
-/// so that commitments are grouped by reference rather than by value.
-#[derive(Debug)]
-pub struct CommitmentReference<'com, F: PrimeField, CS: PolynomialCommitmentScheme<F>>(
-    pub(crate) &'com CS::Commitment,
-);
-
-impl<F: PrimeField, CS: PolynomialCommitmentScheme<F>> Copy for CommitmentReference<'_, F, CS> {}
-
-impl<F: PrimeField, CS: PolynomialCommitmentScheme<F>> Clone for CommitmentReference<'_, F, CS> {
-    fn clone(&self) -> Self {
-        *self
-    }
-}
-
-impl<F: PrimeField, CS: PolynomialCommitmentScheme<F>> PartialEq
-    for CommitmentReference<'_, F, CS>
-{
-    fn eq(&self, other: &Self) -> bool {
-        std::ptr::eq(self.0, other.0)
+        ProverQuery { point, poly, label }
     }
 }
 
@@ -130,7 +91,7 @@ pub struct VerifierQuery<'com, F: PrimeField, CS: PolynomialCommitmentScheme<F>>
     /// Point at which polynomial is queried.
     pub(crate) point: F,
     /// Commitment containing the queried polynomial.
-    pub(crate) commitment_ref: CommitmentReference<'com, F, CS>,
+    pub(crate) commitment: &'com CS::Commitment,
     /// Label identifying which polynomial within the commitment is queried.
     pub(crate) label: PolynomialLabel,
     /// Evaluation of polynomial at query point.
@@ -151,7 +112,7 @@ where
     ) -> Self {
         VerifierQuery {
             point,
-            commitment_ref: CommitmentReference(commitment),
+            commitment,
             label,
             eval,
         }

--- a/proofs/src/poly/query.rs
+++ b/proofs/src/poly/query.rs
@@ -19,8 +19,9 @@ pub enum PolynomialLabel {
     PermutationFixed(usize),
     /// Permutation accumulator polynomial z(X) (chain index).
     PermutationAccumulator(usize),
-    /// LogUp helper polynomial h_j(X) = 1/(f_j(X) + β) (argument index).
-    LogupHelper(usize),
+    /// LogUp helper polynomial h_j(X) = 1/(f_j(X) + β)
+    /// (argument index, chunk index `j`).
+    LogupHelper(usize, usize),
     /// LogUp multiplicities polynomial m(X) (argument index).
     LogupMultiplicities(usize),
     /// LogUp accumulator polynomial Z(X) (argument index).
@@ -50,7 +51,7 @@ impl fmt::Display for PolynomialLabel {
             Self::CommittedInstance(i) => write!(f, "committed_instance_{i}"),
             Self::PermutationFixed(i) => write!(f, "perm_fixed_{i}"),
             Self::PermutationAccumulator(i) => write!(f, "perm_acc_{i}"),
-            Self::LogupHelper(i) => write!(f, "logup_helper({i})"),
+            Self::LogupHelper(i, j) => write!(f, "logup_helper({i}, {j})"),
             Self::LogupMultiplicities(i) => write!(f, "logup_multiplicities({i})"),
             Self::LogupAggregator(i) => write!(f, "logup_aggregator({i})"),
             Self::Trash(i) => write!(f, "trash({i})"),
@@ -64,23 +65,26 @@ impl fmt::Display for PolynomialLabel {
 }
 
 /// A polynomial query at a point
-#[derive(Debug, Clone, Copy)]
+#[derive(Debug, Clone)]
 pub struct ProverQuery<'com, F: PrimeField> {
     /// Point at which polynomial is queried
     pub(crate) point: F,
     /// Reference to a polynomial
     pub(crate) poly_ref: PolynomialReference<'com, F>,
+    /// Label identifying the queried polynomial.
+    pub(crate) label: PolynomialLabel,
 }
 
 impl<'com, F> ProverQuery<'com, F>
 where
     F: PrimeField,
 {
-    /// Create a new prover query based on a polynomial
-    pub fn new(point: F, poly: &'com Polynomial<F, Coeff>) -> Self {
+    /// Create a new prover query based on a polynomial and its label.
+    pub fn new(point: F, poly: &'com Polynomial<F, Coeff>, label: PolynomialLabel) -> Self {
         ProverQuery {
             point,
             poly_ref: PolynomialReference(poly),
+            label,
         }
     }
 }
@@ -125,8 +129,10 @@ impl<F: PrimeField, CS: PolynomialCommitmentScheme<F>> PartialEq
 pub struct VerifierQuery<'com, F: PrimeField, CS: PolynomialCommitmentScheme<F>> {
     /// Point at which polynomial is queried.
     pub(crate) point: F,
-    /// Commitment to polynomial.
+    /// Commitment containing the queried polynomial.
     pub(crate) commitment_ref: CommitmentReference<'com, F, CS>,
+    /// Label identifying which polynomial within the commitment is queried.
+    pub(crate) label: PolynomialLabel,
     /// Evaluation of polynomial at query point.
     pub(crate) eval: F,
 }
@@ -137,10 +143,16 @@ where
     CS: PolynomialCommitmentScheme<F>,
 {
     /// Create a new verifier query.
-    pub fn new(point: F, commitment: &'com CS::Commitment, eval: F) -> Self {
+    pub fn new(
+        point: F,
+        commitment: &'com CS::Commitment,
+        label: PolynomialLabel,
+        eval: F,
+    ) -> Self {
         VerifierQuery {
             point,
             commitment_ref: CommitmentReference(commitment),
+            label,
             eval,
         }
     }

--- a/proofs/src/poly/query.rs
+++ b/proofs/src/poly/query.rs
@@ -11,8 +11,6 @@ pub enum PolynomialLabel {
     Fixed(usize),
     /// Advice column commitment (column index).
     Advice(usize),
-    /// Instance column commitment (column index).
-    Instance(usize),
     /// Committed instance column commitment (column index).
     CommittedInstance(usize),
     /// Permutation verifying-key commitment (index).
@@ -47,7 +45,6 @@ impl fmt::Display for PolynomialLabel {
         match self {
             Self::Fixed(i) => write!(f, "fixed_{i}"),
             Self::Advice(i) => write!(f, "advice_{i}"),
-            Self::Instance(i) => write!(f, "instance_{i}"),
             Self::CommittedInstance(i) => write!(f, "committed_instance_{i}"),
             Self::PermutationFixed(i) => write!(f, "perm_fixed_{i}"),
             Self::PermutationAccumulator(i) => write!(f, "perm_acc_{i}"),

--- a/proofs/src/poly/query.rs
+++ b/proofs/src/poly/query.rs
@@ -25,18 +25,19 @@ pub enum PolynomialLabel {
     LogupMultiplicities(usize),
     /// LogUp accumulator polynomial Z(X) (argument index).
     LogupAggregator(usize),
+    /// PLONK linearization polynomial.
+    Linearization,
     /// PLONK quotient polynomial h(X), committed as a single piece.
     Quotient,
     /// PLONK quotient polynomial h(X), committed in pieces (piece index).
     QuotientPiece(usize),
     /// Trash compressed polynomial (argument index).
     Trash(usize),
-    /// A commitment obtained by collapsing an MSM.
-    Collapsed,
     /// User-defined label.
     Custom(String),
-    /// A commitment freshly deserialized from bytes, not yet assigned a label.
-    /// Reaching the MSM/query layer with this label is a programming error.
+    /// Absence of a meaningful label. Used for freshly deserialized commitments
+    /// (before a label is attached) and for aggregate commitments produced by
+    /// collapsing an MSM, which do not correspond to a single polynomial.
     NoLabel,
 }
 
@@ -53,9 +54,9 @@ impl fmt::Display for PolynomialLabel {
             Self::LogupMultiplicities(i) => write!(f, "logup_multiplicities({i})"),
             Self::LogupAggregator(i) => write!(f, "logup_aggregator({i})"),
             Self::Trash(i) => write!(f, "trash({i})"),
+            Self::Linearization => f.write_str("linearization"),
             Self::Quotient => f.write_str("quotient"),
             Self::QuotientPiece(i) => write!(f, "quotient_piece_{i}"),
-            Self::Collapsed => f.write_str("collapsed"),
             Self::Custom(s) => write!(f, "custom({s})"),
             Self::NoLabel => f.write_str("no_label"),
         }

--- a/zk_stdlib/CHANGELOG.md
+++ b/zk_stdlib/CHANGELOG.md
@@ -20,7 +20,11 @@ We use [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 * Fix cost model proof size check to account for committed instance columns [#280](https://github.com/midnightntwrk/midnight-zk/pull/280)
 
 ### Changed
+<<<<<<< HEAD
 * `cost_model` passes `KZGCommitmentScheme<Bls12>` to `circuit_model`, removing the `COMMITMENT_BYTE_SIZE`/`SCALAR_BYTE_SIZE` constants [#440](https://github.com/midnightntwrk/midnight-zk/pull/440)
+=======
+* `verify` now takes `committed_instance: Option<KZGMultiCommitment<Bls12>>` instead of `Option<G1Affine>`, avoiding a commitment→point→commitment round-trip at call sites [#450](https://github.com/midnightntwrk/midnight-zk/pull/450)
+>>>>>>> fa84c669 (zk_stdlib: take committed instance as a commitment, not a curve point)
 * Adapt to new `KZGCommitment` API [#381](https://github.com/midnightntwrk/midnight-zk/pull/381)
 * Adapt to single-proof prover API [#375](https://github.com/midnightntwrk/midnight-zk/pull/375)
 * Add `nb_arith_cols` field to `ZkStdLibArch` for configurable arithmetic columns (requires `ZKSTD_VERSION` bump before release) [#287](https://github.com/midnightntwrk/midnight-zk/pull/287)

--- a/zk_stdlib/CHANGELOG.md
+++ b/zk_stdlib/CHANGELOG.md
@@ -20,11 +20,8 @@ We use [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 * Fix cost model proof size check to account for committed instance columns [#280](https://github.com/midnightntwrk/midnight-zk/pull/280)
 
 ### Changed
-<<<<<<< HEAD
 * `cost_model` passes `KZGCommitmentScheme<Bls12>` to `circuit_model`, removing the `COMMITMENT_BYTE_SIZE`/`SCALAR_BYTE_SIZE` constants [#440](https://github.com/midnightntwrk/midnight-zk/pull/440)
-=======
 * `verify` now takes `committed_instance: Option<KZGMultiCommitment<Bls12>>` instead of `Option<G1Affine>`, avoiding a commitment→point→commitment round-trip at call sites [#450](https://github.com/midnightntwrk/midnight-zk/pull/450)
->>>>>>> fa84c669 (zk_stdlib: take committed instance as a commitment, not a curve point)
 * Adapt to new `KZGCommitment` API [#381](https://github.com/midnightntwrk/midnight-zk/pull/381)
 * Adapt to single-proof prover API [#375](https://github.com/midnightntwrk/midnight-zk/pull/375)
 * Add `nb_arith_cols` field to `ZkStdLibArch` for configurable arithmetic columns (requires `ZKSTD_VERSION` bump before release) [#287](https://github.com/midnightntwrk/midnight-zk/pull/287)

--- a/zk_stdlib/examples/identity/jwt/enrollment.rs
+++ b/zk_stdlib/examples/identity/jwt/enrollment.rs
@@ -12,7 +12,7 @@ use midnight_circuits::{
     testing_utils::ecdsa::{ECDSASig, FromBase64, PublicKey},
     types::{AssignedByte, AssignedForeignPoint, Instantiable},
 };
-use midnight_curves::{k256::K256, G1Affine};
+use midnight_curves::k256::K256;
 use midnight_proofs::{
     circuit::{Layouter, Value},
     plonk::{commit_to_instances, Error},
@@ -198,12 +198,9 @@ fn main() {
         let w = CredentialEnrollment::witness_from_blob(credential_blob.as_slice());
         (w.0, w.1)
     };
-    let committed_credential: G1Affine = {
+    let committed_credential = {
         let instance = CredentialEnrollment::format_committed_instances(&witness);
         commit_to_instances::<_, KZGCommitmentScheme<_>>(&srs, vk.vk().get_domain(), &instance)
-            .into_single()
-            .into_point()
-            .into()
     };
     println!("... done\n{:?}", wit.elapsed());
 

--- a/zk_stdlib/examples/identity/jwt/enrollment.rs
+++ b/zk_stdlib/examples/identity/jwt/enrollment.rs
@@ -201,6 +201,7 @@ fn main() {
     let committed_credential: G1Affine = {
         let instance = CredentialEnrollment::format_committed_instances(&witness);
         commit_to_instances::<_, KZGCommitmentScheme<_>>(&srs, vk.vk().get_domain(), &instance)
+            .into_single()
             .into_point()
             .into()
     };

--- a/zk_stdlib/examples/identity/jwt/property_check.rs
+++ b/zk_stdlib/examples/identity/jwt/property_check.rs
@@ -25,10 +25,7 @@ use midnight_circuits::{
     types::{AssignedByte, AssignedForeignPoint, AssignedNative},
     CircuitField,
 };
-use midnight_curves::{
-    k256::{Fq as K256Scalar, K256},
-    G1Affine,
-};
+use midnight_curves::k256::{Fq as K256Scalar, K256};
 use midnight_proofs::{
     circuit::{Layouter, Value},
     plonk::{commit_to_instances, Error},
@@ -338,12 +335,9 @@ fn main() {
     let holder_sk = K256Scalar::from_bytes_be(&HOLDER_SK_BYTES).expect("Valid scalar");
     let witness = (witness.0, holder_sk);
 
-    let committed_credential: G1Affine = {
+    let committed_credential = {
         let instance = CredentialProperty::format_committed_instances(&witness);
         commit_to_instances::<_, KZGCommitmentScheme<_>>(&srs, vk.vk().get_domain(), &instance)
-            .into_single()
-            .into_point()
-            .into()
     };
     println!("... done ({:?})", wit.elapsed());
 

--- a/zk_stdlib/examples/identity/jwt/property_check.rs
+++ b/zk_stdlib/examples/identity/jwt/property_check.rs
@@ -341,6 +341,7 @@ fn main() {
     let committed_credential: G1Affine = {
         let instance = CredentialProperty::format_committed_instances(&witness);
         commit_to_instances::<_, KZGCommitmentScheme<_>>(&srs, vk.vk().get_domain(), &instance)
+            .into_single()
             .into_point()
             .into()
     };

--- a/zk_stdlib/src/interface.rs
+++ b/zk_stdlib/src/interface.rs
@@ -16,9 +16,8 @@
 use std::{cell::RefCell, io, rc::Rc};
 
 use ff::Field;
-use group::{prime::PrimeCurveAffine, Group};
 use midnight_circuits::types::ComposableChip;
-use midnight_curves::{G1Affine, G1Projective};
+use midnight_curves::G1Projective;
 use midnight_proofs::{
     circuit::{Layouter, SimpleFloorPlanner, Value},
     dev::cost_model::{circuit_model, CircuitModel},
@@ -28,9 +27,11 @@ use midnight_proofs::{
     poly::{
         commitment::{Guard, Params},
         kzg::{
+            commitment::KZGMultiCommitment,
             params::{ParamsKZG, ParamsVerifierKZG},
             KZGCommitmentScheme,
         },
+        PolynomialLabel,
     },
     transcript::{CircuitTranscript, Hashable, Sampleable, Transcript, TranscriptHash},
     utils::SerdeFormat,
@@ -565,7 +566,7 @@ pub fn verify<R: Relation, H: TranscriptHash>(
     params_verifier: &ParamsVerifierKZG<midnight_curves::Bls12>,
     vk: &MidnightVK,
     instance: &R::Instance,
-    committed_instance: Option<G1Affine>,
+    committed_instance: Option<KZGMultiCommitment<midnight_curves::Bls12>>,
     proof: &[u8],
 ) -> Result<(), R::Error>
 where
@@ -573,7 +574,9 @@ where
     F: Hashable<H> + Sampleable<H>,
 {
     let pi = R::format_instance(instance)?;
-    let committed_pi = committed_instance.unwrap_or(G1Affine::identity());
+    let committed_pi = committed_instance.unwrap_or(KZGMultiCommitment::commitment_to_zero(
+        PolynomialLabel::CommittedInstance(0),
+    ));
     if pi.len() != vk.nb_public_inputs {
         return Err(Error::InvalidInstances.into());
     }
@@ -628,12 +631,9 @@ where
                 CircuitTranscript<H>,
             >(
                 &vk.vk,
-                &[
-                    midnight_proofs::poly::kzg::commitment::KZGCommitment::Simple(
-                        midnight_curves::G1Projective::identity(),
-                        midnight_proofs::poly::PolynomialLabel::Instance(0),
-                    ),
-                ],
+                &[KZGMultiCommitment::commitment_to_zero(
+                    PolynomialLabel::CommittedInstance(0),
+                )],
                 &[pi],
                 &mut transcript,
             )?;

--- a/zk_stdlib/src/utils/plonk_api.rs
+++ b/zk_stdlib/src/utils/plonk_api.rs
@@ -31,7 +31,7 @@ use midnight_proofs::{
     poly::{
         commitment::Guard,
         kzg::{
-            commitment::KZGCommitment,
+            commitment::{KZGCommitment, KZGMultiCommitment},
             params::{ParamsKZG, ParamsVerifierKZG},
             KZGCommitmentScheme,
         },
@@ -153,7 +153,10 @@ macro_rules! plonk_api {
                         .iter()
                         .enumerate()
                         .map(|(i, c)| {
-                            KZGCommitment::Simple((*c).into(), PolynomialLabel::Instance(i))
+                            KZGMultiCommitment(vec![KZGCommitment::Simple(
+                                (*c).into(),
+                                PolynomialLabel::Instance(i),
+                            )])
                         })
                         .collect::<Vec<_>>(),
                     pi,

--- a/zk_stdlib/src/utils/plonk_api.rs
+++ b/zk_stdlib/src/utils/plonk_api.rs
@@ -155,7 +155,7 @@ macro_rules! plonk_api {
                         .map(|(i, c)| {
                             KZGMultiCommitment(vec![KZGCommitment::Simple(
                                 (*c).into(),
-                                PolynomialLabel::Instance(i),
+                                PolynomialLabel::CommittedInstance(i),
                             )])
                         })
                         .collect::<Vec<_>>(),

--- a/zk_stdlib/src/utils/plonk_api.rs
+++ b/zk_stdlib/src/utils/plonk_api.rs
@@ -31,11 +31,10 @@ use midnight_proofs::{
     poly::{
         commitment::Guard,
         kzg::{
-            commitment::{KZGCommitment, KZGMultiCommitment},
+            commitment::KZGMultiCommitment,
             params::{ParamsKZG, ParamsVerifierKZG},
             KZGCommitmentScheme,
         },
-        PolynomialLabel,
     },
     transcript::{CircuitTranscript, Hashable, Sampleable, Transcript, TranscriptHash},
     utils::SerdeFormat,
@@ -134,7 +133,7 @@ macro_rules! plonk_api {
             pub fn verify<H>(
                 params_verifier: &ParamsVerifierKZG<$engine>,
                 vk: &VerifyingKey<$native, KZGCommitmentScheme<$engine>>,
-                instance_commitments: &[$curve],
+                instance_commitments: &[KZGMultiCommitment<$engine>],
                 pi: &[&[$native]],
                 proof: &[u8],
             ) -> Result<(), Error>
@@ -149,16 +148,7 @@ macro_rules! plonk_api {
                 let start = Instant::now();
                 let res = prepare::<$native, KZGCommitmentScheme<$engine>, CircuitTranscript<H>>(
                     vk,
-                    &instance_commitments
-                        .iter()
-                        .enumerate()
-                        .map(|(i, c)| {
-                            KZGMultiCommitment(vec![KZGCommitment::Simple(
-                                (*c).into(),
-                                PolynomialLabel::CommittedInstance(i),
-                            )])
-                        })
-                        .collect::<Vec<_>>(),
+                    instance_commitments,
                     pi,
                     &mut transcript,
                 )?;


### PR DESCRIPTION
Adds multi-polynomial KZG commitments (`commit_many` / `KZGMultiCommitment`) and moves the prover/verifier to identifying and grouping commitment queries by `PolynomialLabel` rather than by ad-hoc references. Removes the wrapper types and redundant label variant that this makes unnecessary.

## Changes

 - **Multi-polynomial KZG commitments (`commit_many`).** A single commitment can now cover several polynomials, we use labels on the polynomials to be able to refer to them in the queries.

- **Identify multi-open queries by label, group by label.** Queries are keyed by `PolynomialLabel` and grouped by it in the multi-open path, replacing reference-based identification.

- **Drop `PolynomialReference` and `CommitmentReference` wrappers.** No longer needed once queries are label-identified.

- **Add a label parameter to `collapse`.** The collapse operation now carries an explicit `PolynomialLabel`, which will be the label of the collapsed commitment.

- **Make Trash and Logup labels positional.** These labels are now positional rather than named.

- **Drop the redundant `PolynomialLabel::Instance` variant**, using `CommittedInstance` everywhere.

- **`zk_stdlib::verify` takes the committed instance as a `KZGMultiCommitment`** instead of a `G1Affine`.

