### PR TITLE
Return a valid Scalar even if it overflows

### DIFF
--- a/circuits/CHANGELOG.md
+++ b/circuits/CHANGELOG.md
@@ -13,6 +13,10 @@ We use [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Removed
 
+## [7.2.2]
+### Fixed
+* Fix `InnerValue` for `AssignedScalarOfNativeCurve` [#451](https://github.com/midnightntwrk/midnight-zk/pull/451)
+
 ## [7.2.1]
 ### Fixed
 * Bug fix in midnight-curves [#434](https://github.com/midnightntwrk/midnight-zk/pull/434)

--- a/circuits/Cargo.toml
+++ b/circuits/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "midnight-circuits"
-version = "7.2.1"
+version = "7.2.2"
 edition = "2021"
 license-file.workspace = true
 description = "Circuit and gadget implementations for Midnight zero-knowledge proofs"

--- a/circuits/src/ecc/native/edwards_chip.rs
+++ b/circuits/src/ecc/native/edwards_chip.rs
@@ -23,7 +23,7 @@ use midnight_proofs::{
     plonk::{Advice, Column, ConstraintSystem, Constraints, Error, Expression, Selector},
     poly::Rotation,
 };
-use num_bigint::ToBigUint;
+use num_bigint::{BigUint, ToBigUint};
 #[cfg(any(test, feature = "testing"))]
 use {
     crate::field::decomposition::chip::P2RDecompositionConfig,
@@ -127,7 +127,15 @@ impl<C: CircuitCurve> InnerValue for AssignedScalarOfNativeCurve<C> {
     fn value(&self) -> Value<Self::Element> {
         let bools = self.bits.iter().map(|b| b.value());
         let value_bools: Value<Vec<bool>> = Value::from_iter(bools);
-        value_bools.map(|le_bits| C::ScalarField::from_bits_le(&le_bits))
+        value_bools.map(|le_bits| {
+            let bytes: Vec<u8> = le_bits
+                .chunks(8)
+                .map(|chunk| chunk.iter().rev().fold(0u8, |acc, &b| (acc << 1) | (b as u8)))
+                .collect();
+            let n = BigUint::from_bytes_le(&bytes);
+            let modulus = C::ScalarField::modulus();
+            C::ScalarField::from_biguint(&(n % modulus)).unwrap()
+        })
     }
 }
 

--- a/zk_stdlib/CHANGELOG.md
+++ b/zk_stdlib/CHANGELOG.md
@@ -13,7 +13,11 @@ We use [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Removed
 
-##[2.3.1]
+## [2.3.2]
+### Changed
+* Bump `midnight-circuits` to 7.2.2 [451](https://github.com/midnightntwrk/midnight-zk/pull/451)
+
+## [2.3.1]
 ### Fixed
 * Bug fix in midnight-curves [#434](https://github.com/midnightntwrk/midnight-zk/pull/434)
 

--- a/zk_stdlib/Cargo.toml
+++ b/zk_stdlib/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "midnight-zk-stdlib"
-version = "2.3.1"
+version = "2.3.2"
 edition = "2021"
 license-file.workspace = true
 description = "Standard library of circuits and utilities for Midnight zero-knowledge proofs"
@@ -11,7 +11,7 @@ description = "Standard library of circuits and utilities for Midnight zero-know
 group = { workspace = true }
 ff = { workspace = true }
 blake2b_simd = { workspace = true }
-midnight-circuits = { version = "7.2.1", features = ["testing"] }
+midnight-circuits = { version = "7.2.2", features = ["testing"] }
 midnight-curves = { version = "0.3.1" }
 midnight-proofs = { version = "0.8.1", default-features = false, features = [
     "circuit-params",


### PR DESCRIPTION
In circuit we allow for Scalar to be represented with more bits than its modulus size, but off-circuit we do not allow that. We need to reduce the bits modulo the scalar field prime order before converting it to `ScalarField`