### PR TITLE
Adapt the in-circuit verifier to have a public input dependent `k`

### DIFF
--- a/aggregation/examples/ivc.rs
+++ b/aggregation/examples/ivc.rs
@@ -169,7 +169,7 @@ fn main() {
     // smaller K might too. Binary-search to find it.
     const K: u32 = 17;
 
-    const N: usize = 1_000; // Number of Poseidon iteration per IVC step.
+    const N: usize = 500; // Number of Poseidon iteration per IVC step.
     const STEPS: usize = 3; // Number of IVC steps to run.
 
     let srs = load_srs(

--- a/aggregation/examples/multi_circuit_aggregation.rs
+++ b/aggregation/examples/multi_circuit_aggregation.rs
@@ -12,12 +12,15 @@
 //! The requirements for an inner circuit to be aggregatable are:
 //! - It must use the [`ZkStdLibArch`] chosen at IVC setup time.
 //! - It must encode its statement as a single formatted public input.
-//! - It must be padded to the common circuit size `K`.
+//!
+//! Inner circuits may have *different* sizes `K`: the verifier gadget
+//! witnesses each VK's evaluation domain (`k`, `omega`), so a single shared
+//! constraint system (whose shape is independent of `K`) suffices. This
+//! example aggregates a SHA-256 circuit and a Poseidon circuit of different
+//! sizes.
 //!
 //! The single-public-input restriction is not a real limitation: any circuit
-//! can hash its statement into a single field element. On the other hand, the
-//! shared-`K` constraint can be removed by extending the verifier gadget to
-//! accept dynamic domain parameters.
+//! can hash its statement into a single field element.
 //!
 //! DO NOT add this example to the CI as it is slow.
 
@@ -60,14 +63,19 @@ fn main() {
     // Circuit size parameters (log2 of rows).
     const IVC_K: u32 = 19;
 
-    // Shared K for all inner circuits (must accommodate the largest one).
-    const INNER_K: u32 = 13;
+    // Inner circuits may have different sizes.
+    const SHA_K: u32 = 13;
+    const POSEIDON_K: u32 = 14;
 
     // The IVC aggregator only requires a shared SRS and architecture. It does
     // not need to know which circuits will be aggregated. Inner circuits can be
     // introduced, proved and folded in on-the-fly, after IVC initialization.
-    let inner_srs = load_srs(SrsSource::Filecoin, INNER_K, cs_degree(inner_arch()));
-    let inner_ctx = InnerCircuitsContext::new(inner_arch(), INNER_K, inner_srs.verifier_params());
+    // Each circuit is proved against an SRS of its own size.
+    let sha_srs = load_srs(SrsSource::Filecoin, SHA_K, cs_degree(inner_arch()));
+    let poseidon_srs = load_srs(SrsSource::Filecoin, POSEIDON_K, cs_degree(inner_arch()));
+    // Note: verifier params from the SRS do not depend on `k`.
+    let inner_ctx =
+        InnerCircuitsContext::new(inner_arch(), POSEIDON_K, poseidon_srs.verifier_params());
 
     let aggregator_srs = load_srs(
         SrsSource::Midnight,
@@ -79,19 +87,13 @@ fn main() {
     println!("Aggregator setup completed in {:.2?}\n", start.elapsed());
 
     // --- Aggregate a SHA-256 preimage proof (circuit introduced just now) ---
-    let sha_vk = setup_vk(&inner_srs, &ShaCircuit);
+    let sha_vk = setup_vk(&sha_srs, &ShaCircuit);
     let sha_pk = setup_pk(&ShaCircuit, &sha_vk);
 
     let (sha_x, sha_w) = aggregatable_sha_preimage::random_instance();
-    let inner_proof = prove::<ShaCircuit, PoseidonState<F>>(
-        &inner_srs,
-        &sha_pk,
-        &ShaCircuit,
-        &sha_x,
-        sha_w,
-        OsRng,
-    )
-    .expect("SHA-256 proof generation should not fail");
+    let inner_proof =
+        prove::<ShaCircuit, PoseidonState<F>>(&sha_srs, &sha_pk, &ShaCircuit, &sha_x, sha_w, OsRng)
+            .expect("SHA-256 proof generation should not fail");
     let witness = AggregationWitness::new::<ShaCircuit>(sha_vk.clone(), sha_x, inner_proof);
 
     let start = Instant::now();
@@ -99,12 +101,12 @@ fn main() {
     println!("Aggregate a SHA2-256 proof: {:.2?}", start.elapsed());
 
     // --- Aggregate a Poseidon preimage proof (circuit introduced just now) ---
-    let poseidon_vk = setup_vk(&inner_srs, &PoseidonCircuit);
+    let poseidon_vk = setup_vk(&poseidon_srs, &PoseidonCircuit);
     let poseidon_pk = setup_pk(&PoseidonCircuit, &poseidon_vk);
 
     let (poseidon_x, poseidon_w) = aggregatable_poseidon_preimage::random_instance();
     let inner_proof = prove::<PoseidonCircuit, PoseidonState<F>>(
-        &inner_srs,
+        &poseidon_srs,
         &poseidon_pk,
         &PoseidonCircuit,
         &poseidon_x,
@@ -121,15 +123,9 @@ fn main() {
 
     // --- Aggregate another SHA-256 preimage proof ---
     let (sha_x, sha_w) = aggregatable_sha_preimage::random_instance();
-    let inner_proof = prove::<ShaCircuit, PoseidonState<F>>(
-        &inner_srs,
-        &sha_pk,
-        &ShaCircuit,
-        &sha_x,
-        sha_w,
-        OsRng,
-    )
-    .expect("SHA-256 proof generation should not fail");
+    let inner_proof =
+        prove::<ShaCircuit, PoseidonState<F>>(&sha_srs, &sha_pk, &ShaCircuit, &sha_x, sha_w, OsRng)
+            .expect("SHA-256 proof generation should not fail");
     let witness = AggregationWitness::new::<ShaCircuit>(sha_vk, sha_x, inner_proof);
 
     let start = Instant::now();

--- a/aggregation/examples/multi_circuit_aggregation.rs
+++ b/aggregation/examples/multi_circuit_aggregation.rs
@@ -13,9 +13,7 @@
 //! - It must use the [`ZkStdLibArch`] chosen at IVC setup time.
 //! - It must encode its statement as a single formatted public input.
 //!
-//! Inner circuits may have *different* sizes `K`: the verifier gadget
-//! witnesses each VK's evaluation domain (`k`, `omega`), so a single shared
-//! constraint system (whose shape is independent of `K`) suffices. This
+//! Inner circuits may have *different* sizes `K`. Concretely, this
 //! example aggregates a SHA-256 circuit and a Poseidon circuit of different
 //! sizes.
 //!
@@ -64,18 +62,18 @@ fn main() {
     const IVC_K: u32 = 19;
 
     // Inner circuits may have different sizes.
-    const SHA_K: u32 = 13;
-    const POSEIDON_K: u32 = 14;
+    const SHA_CIRCUIT_K: u32 = 13;
+    const POSEIDON_CIRCUIT_K: u32 = 14;
 
     // The IVC aggregator only requires a shared SRS and architecture. It does
     // not need to know which circuits will be aggregated. Inner circuits can be
     // introduced, proved and folded in on-the-fly, after IVC initialization.
     // Each circuit is proved against an SRS of its own size.
-    let sha_srs = load_srs(SrsSource::Filecoin, SHA_K, cs_degree(inner_arch()));
-    let poseidon_srs = load_srs(SrsSource::Filecoin, POSEIDON_K, cs_degree(inner_arch()));
+    let sha_srs = load_srs(SrsSource::Filecoin, SHA_CIRCUIT_K, cs_degree(inner_arch()));
+    let poseidon_srs = load_srs(SrsSource::Filecoin, POSEIDON_CIRCUIT_K, cs_degree(inner_arch()));
     // Note: verifier params from the SRS do not depend on `k`.
     let inner_ctx =
-        InnerCircuitsContext::new(inner_arch(), POSEIDON_K, poseidon_srs.verifier_params());
+        InnerCircuitsContext::new(inner_arch(), POSEIDON_CIRCUIT_K, poseidon_srs.verifier_params());
 
     let aggregator_srs = load_srs(
         SrsSource::Midnight,

--- a/aggregation/examples/multi_circuit_aggregation.rs
+++ b/aggregation/examples/multi_circuit_aggregation.rs
@@ -67,20 +67,19 @@ fn main() {
 
     // The IVC aggregator only requires a shared SRS and architecture. It does
     // not need to know which circuits will be aggregated. Inner circuits can be
-    // introduced, proved and folded in on-the-fly, after IVC initialization.
-    // Each circuit is proved against an SRS of its own size.
-    let sha_srs = load_srs(SrsSource::Filecoin, SHA_CIRCUIT_K, cs_degree(inner_arch()));
-    let poseidon_srs = load_srs(
-        SrsSource::Filecoin,
-        POSEIDON_CIRCUIT_K,
-        cs_degree(inner_arch()),
-    );
+    // introduced, proved and folded on-the-fly, after IVC initialization.
+    // Each circuit is proved against an SRS of its own size whose source (i.e.
+    // toxic waste) is the same.
+    let d = cs_degree(inner_arch());
+
+    let sha_srs = load_srs(SrsSource::Filecoin, SHA_CIRCUIT_K, d);
+    let poseidon_srs = load_srs(SrsSource::Filecoin, POSEIDON_CIRCUIT_K, d);
+
     // Note: verifier params from the SRS do not depend on `k`.
-    let inner_ctx = InnerCircuitsContext::new(
-        inner_arch(),
-        POSEIDON_CIRCUIT_K,
-        poseidon_srs.verifier_params(),
-    );
+    let inner_verifier_params = poseidon_srs.verifier_params();
+
+    let inner_ctx =
+        InnerCircuitsContext::new(inner_arch(), POSEIDON_CIRCUIT_K, inner_verifier_params);
 
     let aggregator_srs = load_srs(
         SrsSource::Midnight,

--- a/aggregation/examples/multi_circuit_aggregation.rs
+++ b/aggregation/examples/multi_circuit_aggregation.rs
@@ -70,10 +70,17 @@ fn main() {
     // introduced, proved and folded in on-the-fly, after IVC initialization.
     // Each circuit is proved against an SRS of its own size.
     let sha_srs = load_srs(SrsSource::Filecoin, SHA_CIRCUIT_K, cs_degree(inner_arch()));
-    let poseidon_srs = load_srs(SrsSource::Filecoin, POSEIDON_CIRCUIT_K, cs_degree(inner_arch()));
+    let poseidon_srs = load_srs(
+        SrsSource::Filecoin,
+        POSEIDON_CIRCUIT_K,
+        cs_degree(inner_arch()),
+    );
     // Note: verifier params from the SRS do not depend on `k`.
-    let inner_ctx =
-        InnerCircuitsContext::new(inner_arch(), POSEIDON_CIRCUIT_K, poseidon_srs.verifier_params());
+    let inner_ctx = InnerCircuitsContext::new(
+        inner_arch(),
+        POSEIDON_CIRCUIT_K,
+        poseidon_srs.verifier_params(),
+    );
 
     let aggregator_srs = load_srs(
         SrsSource::Midnight,

--- a/aggregation/examples/single_circuit_aggregation.rs
+++ b/aggregation/examples/single_circuit_aggregation.rs
@@ -288,8 +288,8 @@ impl IvcTransition for ProofAggregation {
         // Assign inner VK as a hard-coded constant.
         let inner_vk: AssignedVk<S, InCircuitKZG<S>> = self.std_lib.verifier().assign_fixed_vk(
             layouter,
-            &self.inner_ctx.domain,
             &self.inner_ctx.cs,
+            &self.inner_ctx.domain,
             self.inner_ctx.vk.vk().transcript_repr(),
         )?;
 

--- a/aggregation/examples/single_circuit_aggregation.rs
+++ b/aggregation/examples/single_circuit_aggregation.rs
@@ -33,10 +33,10 @@ use midnight_circuits::{
 };
 use midnight_proofs::{
     circuit::{Layouter, Value},
-    plonk::{self, ConstraintSystem, Error},
+    plonk::{self, Error},
     poly::{
         kzg::{commitment::KZGMultiCommitment, params::ParamsVerifierKZG, KZGCommitmentScheme},
-        EvaluationDomain, PolynomialLabel,
+        PolynomialLabel,
     },
     transcript::{CircuitTranscript, Transcript},
 };
@@ -58,10 +58,6 @@ type InnerCircuit = ShaPreimageCircuit;
 /// Setup data for the inner circuit, threaded as IVC context.
 #[derive(Clone, Debug)]
 pub struct InnerCircuitContext {
-    /// Constraint system used by the inner proofs (to be aggregated).
-    cs: ConstraintSystem<F>,
-    /// Evaluation domain for the inner circuit.
-    domain: EvaluationDomain<F>,
     /// Verifying key.
     vk: MidnightVK,
     /// SRS verifier parameters (for off-circuit proof preparation).
@@ -286,12 +282,8 @@ impl IvcTransition for ProofAggregation {
         witness: Value<Self::Witness>,
     ) -> Result<Self::AssignedState, Error> {
         // Assign inner VK as a hard-coded constant.
-        let inner_vk: AssignedVk<S, InCircuitKZG<S>> = self.std_lib.verifier().assign_fixed_vk(
-            layouter,
-            &self.inner_ctx.cs,
-            &self.inner_ctx.domain,
-            self.inner_ctx.vk.vk().transcript_repr(),
-        )?;
+        let inner_vk: AssignedVk<S, InCircuitKZG<S>> =
+            self.std_lib.verifier().assign_fixed_vk(layouter, self.inner_ctx.vk.vk())?;
 
         // Assign the inner statement as a witness.
         let statement_pis = self.std_lib.assign_many(
@@ -356,18 +348,9 @@ fn main() {
     let inner_srs = load_srs(SrsSource::Filecoin, sha_preimage::K, cs_degree(inner_arch));
     let inner_vk = setup_vk(&inner_srs, &ShaPreimageCircuit);
     let inner_pk = setup_pk(&ShaPreimageCircuit, &inner_vk);
-    let inner_ctx = {
-        let k = sha_preimage::K;
-        let mut cs = midnight_proofs::plonk::ConstraintSystem::default();
-        ZkStdLib::configure(&mut cs, (inner_arch, (k - 1) as u8));
-        let domain = midnight_proofs::poly::EvaluationDomain::new(cs.degree() as u32, k);
-
-        InnerCircuitContext {
-            cs,
-            domain,
-            vk: inner_vk,
-            params_verifier: inner_srs.verifier_params(),
-        }
+    let inner_ctx = InnerCircuitContext {
+        vk: inner_vk,
+        params_verifier: inner_srs.verifier_params(),
     };
 
     // Generate random inner statements and prove them.

--- a/aggregation/src/ivc/circuit.rs
+++ b/aggregation/src/ivc/circuit.rs
@@ -38,6 +38,11 @@ use super::{Ivc, IvcError, C, F, S};
 #[derive(Clone, Debug)]
 pub struct IvcInstance<T: Ivc> {
     pub(crate) vk_repr: F,
+    // Evaluation domain (`k`, `omega`) of the IVC vk. It is a compile-time
+    // constant, but the circuit emits it as a public input (alongside
+    // `vk_repr`). See [IvcCircuit::format_instance].
+    pub(crate) domain_k: F,
+    pub(crate) domain_omega: F,
     pub(crate) state: T::State,
     pub(crate) acc: Accumulator<S>,
 }
@@ -126,7 +131,7 @@ impl<T: Ivc> Relation for IvcCircuit<T> {
 
     fn format_instance(instance: &Self::Instance) -> Result<Vec<F>, IvcError> {
         Ok([
-            vec![instance.vk_repr],
+            vec![instance.vk_repr, instance.domain_k, instance.domain_omega],
             T::format_public_input(&instance.state),
             AssignedAccumulator::<S>::as_public_input(&instance.acc),
         ]

--- a/aggregation/src/ivc/circuit.rs
+++ b/aggregation/src/ivc/circuit.rs
@@ -145,7 +145,7 @@ impl<T: Ivc> Relation for IvcCircuit<T> {
 
         let assigned_self_vk: AssignedVk<S> = verifier_gadget.assign_vk_as_public_input(
             layouter,
-            &self.domain,
+            Value::known(self.domain.clone()),
             &self.cs,
             instance.as_ref().map(|x| x.vk_repr),
         )?;

--- a/aggregation/src/ivc/circuit.rs
+++ b/aggregation/src/ivc/circuit.rs
@@ -146,12 +146,13 @@ impl<T: Ivc> Relation for IvcCircuit<T> {
         let verifier_gadget = std_lib.verifier();
         let ivc_gadget = T::new(std_lib.clone(), &self.ctx);
 
-        let assigned_self_vk:AssignedVk<S, InCircuitKZG<S>> = verifier_gadget.assign_vk_as_public_input(
-            layouter,
-            &self.cs,
-            Value::known(self.domain.clone()),
-            instance.as_ref().map(|x| x.vk_repr),
-        )?;
+        let assigned_self_vk: AssignedVk<S, InCircuitKZG<S>> = verifier_gadget
+            .assign_vk_as_public_input(
+                layouter,
+                &self.cs,
+                Value::known(self.domain.clone()),
+                instance.as_ref().map(|x| x.vk_repr),
+            )?;
 
         let prev_state_val = witness.as_ref().map(|w| w.prev_state.clone());
         let prev_state = ivc_gadget.assign(layouter, prev_state_val)?;

--- a/aggregation/src/ivc/circuit.rs
+++ b/aggregation/src/ivc/circuit.rs
@@ -129,7 +129,7 @@ impl<T: Ivc> Relation for IvcCircuit<T> {
 
     fn format_instance(instance: &Self::Instance) -> Result<Vec<F>, IvcError> {
         Ok([
-            vec![instance.domain_k, instance.domain_omega, instance.vk_repr],
+            vec![instance.vk_repr, instance.domain_k, instance.domain_omega],
             T::format_public_input(&instance.state),
             AssignedAccumulator::<S>::as_public_input(&instance.acc),
         ]

--- a/aggregation/src/ivc/circuit.rs
+++ b/aggregation/src/ivc/circuit.rs
@@ -39,9 +39,6 @@ use super::{Ivc, IvcError, F, S};
 #[derive(Clone, Debug)]
 pub struct IvcInstance<T: Ivc> {
     pub(crate) vk_repr: F,
-    // Evaluation domain (`k`, `omega`) of the IVC vk. It is a compile-time
-    // constant, but the circuit emits it as a public input (alongside
-    // `vk_repr`). See [IvcCircuit::format_instance].
     pub(crate) domain_k: F,
     pub(crate) domain_omega: F,
     pub(crate) state: T::State,
@@ -132,7 +129,7 @@ impl<T: Ivc> Relation for IvcCircuit<T> {
 
     fn format_instance(instance: &Self::Instance) -> Result<Vec<F>, IvcError> {
         Ok([
-            vec![instance.vk_repr, instance.domain_k, instance.domain_omega],
+            vec![instance.domain_k, instance.domain_omega, instance.vk_repr],
             T::format_public_input(&instance.state),
             AssignedAccumulator::<S>::as_public_input(&instance.acc),
         ]
@@ -151,8 +148,8 @@ impl<T: Ivc> Relation for IvcCircuit<T> {
 
         let assigned_self_vk:AssignedVk<S, InCircuitKZG<S>> = verifier_gadget.assign_vk_as_public_input(
             layouter,
-            Value::known(self.domain.clone()),
             &self.cs,
+            Value::known(self.domain.clone()),
             instance.as_ref().map(|x| x.vk_repr),
         )?;
 

--- a/aggregation/src/ivc/circuit.rs
+++ b/aggregation/src/ivc/circuit.rs
@@ -144,13 +144,12 @@ impl<T: Ivc> Relation for IvcCircuit<T> {
         let verifier_gadget = std_lib.verifier();
         let ivc_gadget = T::new(std_lib.clone(), &self.ctx);
 
-        let assigned_self_vk: AssignedVk<S, InCircuitKZG<S>> = verifier_gadget
-            .assign_vk_as_public_input(
-                layouter,
-                &self.domain,
-                &self.cs,
-                instance.as_ref().map(|x| x.vk_repr),
-            )?;
+        let assigned_self_vk:AssignedVk<S, InCircuitKZG<S>> = verifier_gadget.assign_vk_as_public_input(
+            layouter,
+            Value::known(self.domain.clone()),
+            &self.cs,
+            instance.as_ref().map(|x| x.vk_repr),
+        )?;
 
         let prev_state_val = witness.as_ref().map(|w| w.prev_state.clone());
         let prev_state = ivc_gadget.assign(layouter, prev_state_val)?;

--- a/aggregation/src/ivc/circuit.rs
+++ b/aggregation/src/ivc/circuit.rs
@@ -39,6 +39,11 @@ use super::{Ivc, IvcError, F, S};
 #[derive(Clone, Debug)]
 pub struct IvcInstance<T: Ivc> {
     pub(crate) vk_repr: F,
+    // Evaluation domain (`k`, `omega`) of the IVC vk. It is a compile-time
+    // constant, but the circuit emits it as a public input (alongside
+    // `vk_repr`). See [IvcCircuit::format_instance].
+    pub(crate) domain_k: F,
+    pub(crate) domain_omega: F,
     pub(crate) state: T::State,
     pub(crate) acc: Accumulator<S>,
 }
@@ -127,7 +132,7 @@ impl<T: Ivc> Relation for IvcCircuit<T> {
 
     fn format_instance(instance: &Self::Instance) -> Result<Vec<F>, IvcError> {
         Ok([
-            vec![instance.vk_repr],
+            vec![instance.vk_repr, instance.domain_k, instance.domain_omega],
             T::format_public_input(&instance.state),
             AssignedAccumulator::<S>::as_public_input(&instance.acc),
         ]

--- a/aggregation/src/ivc/prover.rs
+++ b/aggregation/src/ivc/prover.rs
@@ -66,6 +66,8 @@ impl<T: Ivc> IvcProver<T> {
 
         let vk = self.pk.pk().get_vk();
         let vk_repr = vk.transcript_repr();
+        let domain_k = F::from(vk.get_domain().k() as u64);
+        let domain_omega = vk.get_domain().get_omega();
 
         let fixed_bases = midnight_circuits::verifier::fixed_bases::<S>(vk);
 
@@ -121,6 +123,8 @@ impl<T: Ivc> IvcProver<T> {
 
         let instance = IvcInstance {
             vk_repr,
+            domain_k,
+            domain_omega,
             state: next_state.clone(),
             acc: next_acc.clone(),
         };
@@ -155,8 +159,11 @@ impl<T: Ivc> IvcProver<T> {
     /// existence of a valid chain of transitions from genesis to the
     /// current state.
     pub fn instance(&self) -> IvcInstance<T> {
+        let vk = self.pk.pk().get_vk();
         IvcInstance {
-            vk_repr: self.pk.pk().get_vk().transcript_repr(),
+            vk_repr: vk.transcript_repr(),
+            domain_k: F::from(vk.get_domain().k() as u64),
+            domain_omega: vk.get_domain().get_omega(),
             state: self.state.clone(),
             acc: self.acc.clone(),
         }

--- a/aggregation/src/ivc/prover.rs
+++ b/aggregation/src/ivc/prover.rs
@@ -65,6 +65,8 @@ impl<T: Ivc> IvcProver<T> {
 
         let vk = self.pk.pk().get_vk();
         let vk_repr = vk.transcript_repr();
+        let domain_k = F::from(vk.get_domain().k() as u64);
+        let domain_omega = vk.get_domain().get_omega();
 
         let fixed_bases = midnight_circuits::verifier::fixed_bases::<S>(vk);
 
@@ -119,6 +121,8 @@ impl<T: Ivc> IvcProver<T> {
 
         let instance = IvcInstance {
             vk_repr,
+            domain_k,
+            domain_omega,
             state: next_state.clone(),
             acc: next_acc.clone(),
         };
@@ -153,8 +157,11 @@ impl<T: Ivc> IvcProver<T> {
     /// existence of a valid chain of transitions from genesis to the
     /// current state.
     pub fn instance(&self) -> IvcInstance<T> {
+        let vk = self.pk.pk().get_vk();
         IvcInstance {
-            vk_repr: self.pk.pk().get_vk().transcript_repr(),
+            vk_repr: vk.transcript_repr(),
+            domain_k: F::from(vk.get_domain().k() as u64),
+            domain_omega: vk.get_domain().get_omega(),
             state: self.state.clone(),
             acc: self.acc.clone(),
         }

--- a/aggregation/src/ivc/verifier.rs
+++ b/aggregation/src/ivc/verifier.rs
@@ -48,8 +48,15 @@ impl<T: Ivc> IvcVerifier<T> {
     /// under a different (potentially malicious) circuit could pass
     /// verification.
     pub fn verify(&self, instance: &IvcInstance<T>, proof: &[u8]) -> Result<(), IvcError> {
-        // Reject proofs whose instance claims a different verifying key.
-        if instance.vk_repr != self.vk.vk().transcript_repr() {
+        // Reject proofs whose instance claims a different verifying key or a
+        // different evaluation domain than the canonical one. The domain is a
+        // public input, so it must be pinned to the real vk here (it is not
+        // otherwise tied to `vk_repr` in-circuit).
+        let domain = self.vk.vk().get_domain();
+        if instance.vk_repr != self.vk.vk().transcript_repr()
+            || instance.domain_k != F::from(domain.k() as u64)
+            || instance.domain_omega != domain.get_omega()
+        {
             return Err(IvcError::VkMismatch);
         }
 

--- a/aggregation/src/ivc/verifier.rs
+++ b/aggregation/src/ivc/verifier.rs
@@ -47,8 +47,15 @@ impl<T: Ivc> IvcVerifier<T> {
     /// under a different (potentially malicious) circuit could pass
     /// verification.
     pub fn verify(&self, instance: &IvcInstance<T>, proof: &[u8]) -> Result<(), IvcError> {
-        // Reject proofs whose instance claims a different verifying key.
-        if instance.vk_repr != self.vk.vk().transcript_repr() {
+        // Reject proofs whose instance claims a different verifying key or a
+        // different evaluation domain than the canonical one. The domain is a
+        // public input, so it must be pinned to the real vk here (it is not
+        // otherwise tied to `vk_repr` in-circuit).
+        let domain = self.vk.vk().get_domain();
+        if instance.vk_repr != self.vk.vk().transcript_repr()
+            || instance.domain_k != F::from(domain.k() as u64)
+            || instance.domain_omega != domain.get_omega()
+        {
             return Err(IvcError::VkMismatch);
         }
 

--- a/aggregation/src/ivc/verifier.rs
+++ b/aggregation/src/ivc/verifier.rs
@@ -47,10 +47,13 @@ impl<T: Ivc> IvcVerifier<T> {
     /// under a different (potentially malicious) circuit could pass
     /// verification.
     pub fn verify(&self, instance: &IvcInstance<T>, proof: &[u8]) -> Result<(), IvcError> {
-        // Reject proofs whose instance claims a different verifying key or a
-        // different evaluation domain than the canonical one. The domain is a
-        // public input, so it must be pinned to the real vk here (it is not
-        // otherwise tied to `vk_repr` in-circuit).
+        // `instance.vk_repr`, `instance.domain_k` and `instance.domain_omega`
+        // are public inputs chosen by the prover: the circuit uses them to
+        // verify the previous step, but nothing forces them to describe the
+        // key this verifier was set up with. Hence we compare all three against
+        // `self.vk` and reject any mismatch; otherwise a proof produced under
+        // a different (possibly malicious) circuit or domain would verify
+        // here.
         let domain = self.vk.vk().get_domain();
         if instance.vk_repr != self.vk.vk().transcript_repr()
             || instance.domain_k != F::from(domain.k() as u64)

--- a/aggregation/src/multi_circuit_aggregator/circuit.rs
+++ b/aggregation/src/multi_circuit_aggregator/circuit.rs
@@ -70,6 +70,8 @@ impl State {
 #[derive(Clone, Debug)]
 pub struct AssignedState {
     last_vk_repr: AssignedNative<F>,
+    last_vk_k: AssignedNative<F>,
+    last_vk_omega: AssignedNative<F>,
     claims_hash: AssignedNative<F>,
     inner_acc: AssignedAccumulator<S>,
 }
@@ -184,6 +186,21 @@ impl IvcIO for ProofAggregation {
                 .as_ref()
                 .map(|s| s.claims.last().map(|c| c.vk.vk().transcript_repr()).unwrap_or(F::ZERO)),
         )?;
+        let last_vk_k = self.std_lib.assign(
+            layouter,
+            value.as_ref().map(|s| {
+                s.claims
+                    .last()
+                    .map(|c| F::from(c.vk.vk().get_domain().k() as u64))
+                    .unwrap_or(F::ZERO)
+            }),
+        )?;
+        let last_vk_omega = self.std_lib.assign(
+            layouter,
+            value.as_ref().map(|s| {
+                s.claims.last().map(|c| c.vk.vk().get_domain().get_omega()).unwrap_or(F::ZERO)
+            }),
+        )?;
         let claims_hash = self.std_lib.assign(layouter, value.as_ref().map(|s| s.claims_hash))?;
 
         let inner_acc = self.std_lib.verifier().assign_collapsed_accumulator(
@@ -194,6 +211,8 @@ impl IvcIO for ProofAggregation {
 
         Ok(AssignedState {
             last_vk_repr,
+            last_vk_k,
+            last_vk_omega,
             claims_hash,
             inner_acc,
         })
@@ -215,6 +234,8 @@ impl IvcIO for ProofAggregation {
     ) -> Result<Vec<AssignedNative<F>>, Error> {
         Ok([
             self.std_lib.as_public_input(layouter, &state.last_vk_repr)?,
+            self.std_lib.as_public_input(layouter, &state.last_vk_k)?,
+            self.std_lib.as_public_input(layouter, &state.last_vk_omega)?,
             self.std_lib.as_public_input(layouter, &state.claims_hash)?,
             self.std_lib.verifier().as_public_input(layouter, &state.inner_acc)?,
         ]
@@ -222,10 +243,16 @@ impl IvcIO for ProofAggregation {
     }
 
     fn format_public_input(state: &State) -> Vec<F> {
-        let last_vk_repr =
-            state.claims.last().map(|c| c.vk.vk().transcript_repr()).unwrap_or(F::ZERO);
+        let last_claim = state.claims.last();
+        let last_vk_repr = last_claim.map(|c| c.vk.vk().transcript_repr()).unwrap_or(F::ZERO);
+        let (last_vk_k, last_vk_omega) = last_claim
+            .map(|c| {
+                let d = c.vk.vk().get_domain();
+                (F::from(d.k() as u64), d.get_omega())
+            })
+            .unwrap_or((F::ZERO, F::ZERO));
         [
-            vec![last_vk_repr],
+            vec![last_vk_repr, last_vk_k, last_vk_omega],
             vec![state.claims_hash],
             AssignedAccumulator::<S>::as_public_input(&state.inner_acc),
         ]
@@ -316,7 +343,6 @@ impl IvcTransition for ProofAggregation {
         let (assigned_vk, vk_hash, fixed_bases_map) = assign_as_public_inputs_and_hash_vk(
             layouter,
             &self.std_lib,
-            &self.inner_ctx.domain,
             &self.inner_ctx.cs,
             witness.as_ref().map(|w| &w.claim.vk),
         )?;
@@ -375,6 +401,8 @@ impl IvcTransition for ProofAggregation {
 
         Ok(AssignedState {
             last_vk_repr: assigned_vk.transcript_repr().clone(),
+            last_vk_k: assigned_vk.k().clone(),
+            last_vk_omega: assigned_vk.omega().clone(),
             claims_hash,
             inner_acc,
         })

--- a/aggregation/src/multi_circuit_aggregator/circuit.rs
+++ b/aggregation/src/multi_circuit_aggregator/circuit.rs
@@ -69,6 +69,8 @@ impl State {
 #[derive(Clone, Debug)]
 pub struct AssignedState {
     last_vk_repr: AssignedNative<F>,
+    last_vk_k: AssignedNative<F>,
+    last_vk_omega: AssignedNative<F>,
     claims_hash: AssignedNative<F>,
     inner_acc: AssignedAccumulator<S>,
 }
@@ -183,6 +185,21 @@ impl IvcIO for ProofAggregation {
                 .as_ref()
                 .map(|s| s.claims.last().map(|c| c.vk.vk().transcript_repr()).unwrap_or(F::ZERO)),
         )?;
+        let last_vk_k = self.std_lib.assign(
+            layouter,
+            value.as_ref().map(|s| {
+                s.claims
+                    .last()
+                    .map(|c| F::from(c.vk.vk().get_domain().k() as u64))
+                    .unwrap_or(F::ZERO)
+            }),
+        )?;
+        let last_vk_omega = self.std_lib.assign(
+            layouter,
+            value.as_ref().map(|s| {
+                s.claims.last().map(|c| c.vk.vk().get_domain().get_omega()).unwrap_or(F::ZERO)
+            }),
+        )?;
         let claims_hash = self.std_lib.assign(layouter, value.as_ref().map(|s| s.claims_hash))?;
 
         let inner_acc = self.std_lib.verifier().assign_collapsed_accumulator(
@@ -193,6 +210,8 @@ impl IvcIO for ProofAggregation {
 
         Ok(AssignedState {
             last_vk_repr,
+            last_vk_k,
+            last_vk_omega,
             claims_hash,
             inner_acc,
         })
@@ -214,6 +233,8 @@ impl IvcIO for ProofAggregation {
     ) -> Result<Vec<AssignedNative<F>>, Error> {
         Ok([
             self.std_lib.as_public_input(layouter, &state.last_vk_repr)?,
+            self.std_lib.as_public_input(layouter, &state.last_vk_k)?,
+            self.std_lib.as_public_input(layouter, &state.last_vk_omega)?,
             self.std_lib.as_public_input(layouter, &state.claims_hash)?,
             self.std_lib.verifier().as_public_input(layouter, &state.inner_acc)?,
         ]
@@ -221,10 +242,16 @@ impl IvcIO for ProofAggregation {
     }
 
     fn format_public_input(state: &State) -> Vec<F> {
-        let last_vk_repr =
-            state.claims.last().map(|c| c.vk.vk().transcript_repr()).unwrap_or(F::ZERO);
+        let last_claim = state.claims.last();
+        let last_vk_repr = last_claim.map(|c| c.vk.vk().transcript_repr()).unwrap_or(F::ZERO);
+        let (last_vk_k, last_vk_omega) = last_claim
+            .map(|c| {
+                let d = c.vk.vk().get_domain();
+                (F::from(d.k() as u64), d.get_omega())
+            })
+            .unwrap_or((F::ZERO, F::ZERO));
         [
-            vec![last_vk_repr],
+            vec![last_vk_repr, last_vk_k, last_vk_omega],
             vec![state.claims_hash],
             AssignedAccumulator::<S>::as_public_input(&state.inner_acc),
         ]
@@ -314,7 +341,6 @@ impl IvcTransition for ProofAggregation {
         let (assigned_vk, vk_hash, fixed_bases_map) = assign_as_public_inputs_and_hash_vk(
             layouter,
             &self.std_lib,
-            &self.inner_ctx.domain,
             &self.inner_ctx.cs,
             witness.as_ref().map(|w| &w.claim.vk),
         )?;
@@ -374,6 +400,8 @@ impl IvcTransition for ProofAggregation {
 
         Ok(AssignedState {
             last_vk_repr: assigned_vk.transcript_repr().clone(),
+            last_vk_k: assigned_vk.k().clone(),
+            last_vk_omega: assigned_vk.omega().clone(),
             claims_hash,
             inner_acc,
         })

--- a/aggregation/src/multi_circuit_aggregator/circuit.rs
+++ b/aggregation/src/multi_circuit_aggregator/circuit.rs
@@ -185,6 +185,11 @@ impl IvcIO for ProofAggregation {
         layouter: &mut impl Layouter<F>,
         value: Value<State>,
     ) -> Result<AssignedState, Error> {
+        // There is no integrity checks performed in the VK (`vk_repr`, `k` and
+        // `omega`), as those are guaranteed to be correct by the hash-chain,
+        // which is checked in the decider. The hash-chain is enforced to be
+        // correctly computed by hashing the previous `claims_hash`
+        // together with the `vk_repr`, `k` and `omega` of the current circuit.
         let last_vk_repr = self.std_lib.assign(
             layouter,
             value
@@ -200,10 +205,13 @@ impl IvcIO for ProofAggregation {
                     .unwrap_or(F::ZERO)
             }),
         )?;
+        // Base case (no claims yet): the placeholders below are arbitrary, nothing
+        // consumes them. We use the degenerate domain of size 1, i.e. k = 0 and
+        // omega = 1.
         let last_vk_omega = self.std_lib.assign(
             layouter,
             value.as_ref().map(|s| {
-                s.claims.last().map(|c| c.vk.vk().get_domain().get_omega()).unwrap_or(F::ZERO)
+                s.claims.last().map(|c| c.vk.vk().get_domain().get_omega()).unwrap_or(F::ONE)
             }),
         )?;
         let claims_hash = self.std_lib.assign(layouter, value.as_ref().map(|s| s.claims_hash))?;
@@ -252,6 +260,10 @@ impl IvcIO for ProofAggregation {
     }
 
     fn format_public_input(state: &State) -> Vec<F> {
+        // In the base case (no claims yet) there is no last vk, so the values below
+        // are arbitrary placeholders: nothing consumes them, they just need to match
+        // what the base-case circuit assigns. We use the degenerate domain of size 1,
+        // i.e. k = 0 and omega = 1.
         let last_claim = state.claims.last();
         let last_vk_repr = last_claim.map(|c| c.vk.vk().transcript_repr()).unwrap_or(F::ZERO);
         let (last_vk_k, last_vk_omega) = last_claim
@@ -259,7 +271,7 @@ impl IvcIO for ProofAggregation {
                 let d = c.vk.vk().get_domain();
                 (F::from(d.k() as u64), d.get_omega())
             })
-            .unwrap_or((F::ZERO, F::ZERO));
+            .unwrap_or((F::ZERO, F::ONE));
         [
             vec![last_vk_repr, last_vk_k, last_vk_omega],
             vec![state.claims_hash],

--- a/aggregation/src/multi_circuit_aggregator/circuit.rs
+++ b/aggregation/src/multi_circuit_aggregator/circuit.rs
@@ -62,15 +62,21 @@ impl State {
     }
 }
 
+/// In-circuit representation of a verifying key.
+#[derive(Clone, Debug)]
+struct AssignedVk {
+    repr: AssignedNative<F>,
+    k: AssignedNative<F>,
+    omega: AssignedNative<F>,
+}
+
 /// In-circuit counterpart of [`State`] (constant size).
 ///
 /// Contains only the vk from the last claim, the claims hash and the
 /// accumulator, the full list of claims is not represented in-circuit.
 #[derive(Clone, Debug)]
 pub struct AssignedState {
-    last_vk_repr: AssignedNative<F>,
-    last_vk_k: AssignedNative<F>,
-    last_vk_omega: AssignedNative<F>,
+    last_vk: AssignedVk,
     claims_hash: AssignedNative<F>,
     inner_acc: AssignedAccumulator<S>,
 }
@@ -208,10 +214,14 @@ impl IvcIO for ProofAggregation {
             value.as_ref().map(|s| s.inner_acc.clone()),
         )?;
 
+        let last_vk = AssignedVk {
+            repr: last_vk_repr,
+            omega: last_vk_omega,
+            k: last_vk_k,
+        };
+
         Ok(AssignedState {
-            last_vk_repr,
-            last_vk_k,
-            last_vk_omega,
+            last_vk,
             claims_hash,
             inner_acc,
         })
@@ -232,9 +242,9 @@ impl IvcIO for ProofAggregation {
         state: &AssignedState,
     ) -> Result<Vec<AssignedNative<F>>, Error> {
         Ok([
-            self.std_lib.as_public_input(layouter, &state.last_vk_repr)?,
-            self.std_lib.as_public_input(layouter, &state.last_vk_k)?,
-            self.std_lib.as_public_input(layouter, &state.last_vk_omega)?,
+            self.std_lib.as_public_input(layouter, &state.last_vk.repr)?,
+            self.std_lib.as_public_input(layouter, &state.last_vk.k)?,
+            self.std_lib.as_public_input(layouter, &state.last_vk.omega)?,
             self.std_lib.as_public_input(layouter, &state.claims_hash)?,
             self.std_lib.verifier().as_public_input(layouter, &state.inner_acc)?,
         ]
@@ -399,9 +409,11 @@ impl IvcTransition for ProofAggregation {
             .poseidon(layouter, &[vk_hash, statement, state.claims_hash.clone()])?;
 
         Ok(AssignedState {
-            last_vk_repr: assigned_vk.transcript_repr().clone(),
-            last_vk_k: assigned_vk.k().clone(),
-            last_vk_omega: assigned_vk.omega().clone(),
+            last_vk: AssignedVk {
+                repr: assigned_vk.transcript_repr().clone(),
+                k: assigned_vk.k().clone(),
+                omega: assigned_vk.omega().clone(),
+            },
             claims_hash,
             inner_acc,
         })

--- a/aggregation/src/multi_circuit_aggregator/utils.rs
+++ b/aggregation/src/multi_circuit_aggregator/utils.rs
@@ -20,7 +20,7 @@ use midnight_circuits::{
 use midnight_proofs::{
     circuit::{Layouter, Value},
     plonk::{ConstraintSystem, Error},
-    poly::{EvaluationDomain, PolynomialLabel},
+    poly::PolynomialLabel,
     transcript::Hashable,
 };
 use midnight_zk_stdlib::{MidnightVK, ZkStdLib};
@@ -46,7 +46,12 @@ pub fn compute_vk_hash(vk: &MidnightVK) -> F {
     let vk = vk.vk();
     let to_raw = Hashable::<PoseidonState<F>>::to_input;
 
-    let vk_repr = vec![vk.transcript_repr()];
+    let domain = vk.get_domain();
+    let vk_repr = vec![
+        vk.transcript_repr(),
+        F::from(domain.k() as u64),
+        domain.get_omega(),
+    ];
     let fixed_coms: Vec<F> = vk.fixed_commitments().iter().flat_map(to_raw).collect();
     let perm_coms: Vec<F> = vk.permutation().commitments().iter().flat_map(to_raw).collect();
 
@@ -61,7 +66,6 @@ pub fn compute_vk_hash(vk: &MidnightVK) -> F {
 pub fn assign_as_public_inputs_and_hash_vk(
     layouter: &mut impl Layouter<F>,
     std_lib: &ZkStdLib,
-    domain: &EvaluationDomain<F>,
     cs: &ConstraintSystem<F>,
     vk: Value<&MidnightVK>,
 ) -> Result<VkHashAndBases, Error> {
@@ -86,6 +90,7 @@ pub fn assign_as_public_inputs_and_hash_vk(
 
     // Assign the VK, witnessing its transcript_repr. The same repr cell is folded
     // into the hash below, binding the verified VK to the hashed one.
+    let domain = vk.map(|vk| vk.vk().get_domain().clone());
     let assigned_vk = std_lib.verifier().assign_vk_as_public_input(
         layouter,
         domain,
@@ -93,8 +98,12 @@ pub fn assign_as_public_inputs_and_hash_vk(
         vk.map(|vk| vk.vk().transcript_repr()),
     )?;
 
-    // Compute the hash: Poseidon(transcript_repr || bases...).
-    let mut input = vec![assigned_vk.transcript_repr().clone()];
+    // Compute the hash: Poseidon(transcript_repr || k || omega || bases...).
+    let mut input = vec![
+        assigned_vk.transcript_repr().clone(),
+        assigned_vk.k().clone(),
+        assigned_vk.omega().clone(),
+    ];
     for base in &assigned_bases {
         input.extend(curve_chip.as_public_input(layouter, base)?);
     }

--- a/aggregation/src/multi_circuit_aggregator/utils.rs
+++ b/aggregation/src/multi_circuit_aggregator/utils.rs
@@ -47,7 +47,7 @@ pub fn compute_vk_hash(vk: &MidnightVK) -> F {
     let to_raw = Hashable::<PoseidonState<F>>::to_input;
 
     let domain = vk.get_domain();
-    let in_circuit_vk = vec![
+    let vk_as_public_inputs = vec![
         vk.transcript_repr(),
         F::from(domain.k() as u64),
         domain.get_omega(),
@@ -55,7 +55,7 @@ pub fn compute_vk_hash(vk: &MidnightVK) -> F {
     let fixed_coms: Vec<F> = vk.fixed_commitments().iter().flat_map(to_raw).collect();
     let perm_coms: Vec<F> = vk.permutation().commitments().iter().flat_map(to_raw).collect();
 
-    <PoseidonChip<F> as HashCPU<F, F>>::hash(&[in_circuit_vk, fixed_coms, perm_coms].concat())
+    <PoseidonChip<F> as HashCPU<F, F>>::hash(&[vk_as_public_inputs, fixed_coms, perm_coms].concat())
 }
 
 /// In-circuit counterpart of [`compute_vk_hash`].

--- a/aggregation/src/multi_circuit_aggregator/utils.rs
+++ b/aggregation/src/multi_circuit_aggregator/utils.rs
@@ -47,7 +47,7 @@ pub fn compute_vk_hash(vk: &MidnightVK) -> F {
     let to_raw = Hashable::<PoseidonState<F>>::to_input;
 
     let domain = vk.get_domain();
-    let vk_repr = vec![
+    let in_circuit_vk = vec![
         vk.transcript_repr(),
         F::from(domain.k() as u64),
         domain.get_omega(),
@@ -55,7 +55,7 @@ pub fn compute_vk_hash(vk: &MidnightVK) -> F {
     let fixed_coms: Vec<F> = vk.fixed_commitments().iter().flat_map(to_raw).collect();
     let perm_coms: Vec<F> = vk.permutation().commitments().iter().flat_map(to_raw).collect();
 
-    <PoseidonChip<F> as HashCPU<F, F>>::hash(&[vk_repr, fixed_coms, perm_coms].concat())
+    <PoseidonChip<F> as HashCPU<F, F>>::hash(&[in_circuit_vk, fixed_coms, perm_coms].concat())
 }
 
 /// In-circuit counterpart of [`compute_vk_hash`].
@@ -93,8 +93,8 @@ pub fn assign_as_public_inputs_and_hash_vk(
     let domain = vk.map(|vk| vk.vk().get_domain().clone());
     let assigned_vk = std_lib.verifier().assign_vk_as_public_input(
         layouter,
-        domain,
         cs,
+        domain,
         vk.map(|vk| vk.vk().transcript_repr()),
     )?;
 

--- a/circuits/CHANGELOG.md
+++ b/circuits/CHANGELOG.md
@@ -17,6 +17,7 @@ We use [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 * Fix cost model to pass correct number of committed instances [#280](https://github.com/midnightntwrk/midnight-zk/pull/280)
 
 ### Changed
+* `AssignedVk` holds an `AssignedEvaluationDomain` with assigned `k` and `omega` (and in-circuit derived `omega_inv` and `n = 2^k`) [#461](https://github.com/midnightntwrk/midnight-zk/pull/461)
 * `circuit_modeling` derives the commitment byte length from `KZGCommitmentScheme` via `circuit_model_with` instead of hard-coded sizes [#440](https://github.com/midnightntwrk/midnight-zk/pull/440)
 * Panic loudly in `from_dual_msm` when a `NoLabel` commitment reaches the MSM layer [#392](https://github.com/midnightntwrk/midnight-zk/pull/392)
 * Adapt verifier gadget to single-proof prover API [#375](https://github.com/midnightntwrk/midnight-zk/pull/375)

--- a/circuits/src/verifier/mod.rs
+++ b/circuits/src/verifier/mod.rs
@@ -19,7 +19,7 @@ use group::Group;
 use midnight_proofs::{
     circuit::Value,
     plonk::{self, ConstraintSystem},
-    poly::{PolynomialLabel, kzg::KZGCommitmentScheme},
+    poly::{kzg::KZGCommitmentScheme, PolynomialLabel},
 };
 
 use crate::{
@@ -51,12 +51,12 @@ pub use verifier_gadget::VerifierGadget;
 type VerifyingKey<S> =
     plonk::VerifyingKey<<S as SelfEmulation>::F, KZGCommitmentScheme<<S as SelfEmulation>::Engine>>;
 
-/// Type for in-circuit Evaluation Domain. 
-/// 
-/// This type carries only the information needed for the verifier, `k` 
+/// Type for in-circuit Evaluation Domain.
+///
+/// This type carries only the information needed for the verifier, `k`
 /// and `omega`, and values `omega^{-1}` and `n = 2^k`, computed in-circuit.
-/// 
-/// The only entry points are via the assignment functions of Verifying Keys. 
+///
+/// The only entry points are via the assignment functions of Verifying Keys.
 #[derive(Clone, Debug)]
 struct AssignedEvaluationDomain<S: SelfEmulation> {
     k: AssignedNative<S::F>,
@@ -68,8 +68,8 @@ struct AssignedEvaluationDomain<S: SelfEmulation> {
 /// Type for in-circuit verifying keys.
 ///
 /// This type carries off-circuit the information about the constraint system.
-/// The in-circuit fields are the transcript representation, the fixed 
-/// commitments, permutation commitments, and the evaluation domain. 
+/// The in-circuit fields are the transcript representation, the fixed
+/// commitments, permutation commitments, and the evaluation domain.
 ///
 /// The only entry-point for this function is intended to be
 /// [VerifierGadget::assign_vk_as_public_input]. This is possible because fixed

--- a/circuits/src/verifier/mod.rs
+++ b/circuits/src/verifier/mod.rs
@@ -18,9 +18,8 @@ use std::collections::BTreeMap;
 use group::Group;
 use midnight_proofs::{
     circuit::Value,
-    plonk,
-    plonk::ConstraintSystem,
-    poly::{kzg::KZGCommitmentScheme, EvaluationDomain, PolynomialLabel},
+    plonk::{self, ConstraintSystem},
+    poly::{PolynomialLabel, kzg::KZGCommitmentScheme},
 };
 
 use crate::{
@@ -52,10 +51,25 @@ pub use verifier_gadget::VerifierGadget;
 type VerifyingKey<S> =
     plonk::VerifyingKey<<S as SelfEmulation>::F, KZGCommitmentScheme<<S as SelfEmulation>::Engine>>;
 
+/// Type for in-circuit Evaluation Domain. 
+/// 
+/// This type carries only the information needed for the verifier, `k` 
+/// and `omega`, and values `omega^{-1}` and `n = 2^k`, computed in-circuit.
+/// 
+/// The only entry points are via the assignment functions of Verifying Keys. 
+#[derive(Clone, Debug)]
+struct AssignedEvaluationDomain<S: SelfEmulation> {
+    k: AssignedNative<S::F>,
+    omega: AssignedNative<S::F>,
+    omega_inv: AssignedNative<S::F>,
+    n: AssignedNative<S::F>,
+}
+
 /// Type for in-circuit verifying keys.
 ///
-/// This type carries off-circuit a lot of the information about the vk.
-/// The only in-circuit field is the `transcript_repr`.
+/// This type carries off-circuit the information about the constraint system.
+/// The in-circuit fields are the transcript representation, the fixed 
+/// commitments, permutation commitments, and the evaluation domain. 
 ///
 /// The only entry-point for this function is intended to be
 /// [VerifierGadget::assign_vk_as_public_input]. This is possible because fixed
@@ -64,7 +78,7 @@ type VerifyingKey<S> =
 /// fixed-commitments, in the `fixed_base_scalars` field (of its RHS).
 #[derive(Clone, Debug)]
 pub struct AssignedVk<S: SelfEmulation> {
-    domain: EvaluationDomain<S::F>,
+    domain: AssignedEvaluationDomain<S>,
     fixed_commitments: Vec<AssignedKZGCommitment<S>>,
     perm_commitments: Vec<AssignedKZGCommitment<S>>,
     cs: ConstraintSystem<S::F>,
@@ -85,7 +99,13 @@ impl<S: SelfEmulation> InnerValue for AssignedVk<S> {
 
 impl<S: SelfEmulation> Instantiable<S::F> for AssignedVk<S> {
     fn as_public_input(vk: &VerifyingKey<S>) -> Vec<S::F> {
-        AssignedNative::<S::F>::as_public_input(&vk.transcript_repr())
+        let domain = vk.get_domain();
+        [
+            AssignedNative::<S::F>::as_public_input(&vk.transcript_repr()),
+            AssignedNative::<S::F>::as_public_input(&S::F::from(domain.k() as u64)),
+            AssignedNative::<S::F>::as_public_input(&domain.get_omega()),
+        ]
+        .concat()
     }
 
     #[cfg(any(test, feature = "testing"))]
@@ -98,6 +118,16 @@ impl<S: SelfEmulation> AssignedVk<S> {
     /// The assigned `transcript_repr` cell of this verifying key.
     pub fn transcript_repr(&self) -> &AssignedNative<S::F> {
         &self.transcript_repr
+    }
+
+    /// The assigned `k` cell.
+    pub fn k(&self) -> &AssignedNative<S::F> {
+        &self.domain.k
+    }
+
+    /// The assigned `omega` cell.
+    pub fn omega(&self) -> &AssignedNative<S::F> {
+        &self.domain.omega
     }
 }
 

--- a/circuits/src/verifier/mod.rs
+++ b/circuits/src/verifier/mod.rs
@@ -75,11 +75,14 @@ struct AssignedEvaluationDomain<S: SelfEmulation> {
 /// [AssignedKZGCommitment], but they are "empty", i.e. of the `Fixed` variant:
 /// they only carry a label, no assigned point.
 ///
+/// This is fine because the verifier only adds them to an MSM: the accumulator
+/// of [VerifierGadget::prepare] just records their scalars in
+/// `fixed_base_scalars`, and the actual commitments are provided off-circuit by
+/// the final verifier (the decider), via [Accumulator::resolve_fixed_bases].
+/// The key remains bound in-circuit through `transcript_repr`.
+///
 /// The only entry-point for this function is intended to be
-/// [VerifierGadget::assign_vk_as_public_input]. This is possible because fixed
-/// commitments are dealt with off-circuit, i.e., the resulting accumulator of
-/// [VerifierGadget::prepare] contains the scalars of the
-/// fixed-commitments, in the `fixed_base_scalars` field (of its RHS).
+/// [VerifierGadget::assign_vk_as_public_input].
 #[derive(Clone, Debug)]
 pub struct AssignedVk<S: SelfEmulation, PCS: InCircuitPCS<S>> {
     domain: AssignedEvaluationDomain<S>,
@@ -105,9 +108,9 @@ impl<S: SelfEmulation, PCS: InCircuitPCS<S>> Instantiable<S::F> for AssignedVk<S
     fn as_public_input(vk: &VerifyingKey<S>) -> Vec<S::F> {
         let domain = vk.get_domain();
         [
+            AssignedNative::<S::F>::as_public_input(&vk.transcript_repr()),
             AssignedNative::<S::F>::as_public_input(&S::F::from(domain.k() as u64)),
             AssignedNative::<S::F>::as_public_input(&domain.get_omega()),
-            AssignedNative::<S::F>::as_public_input(&vk.transcript_repr()),
         ]
         .concat()
     }

--- a/circuits/src/verifier/mod.rs
+++ b/circuits/src/verifier/mod.rs
@@ -19,7 +19,7 @@ use group::Group;
 use midnight_proofs::{
     circuit::Value,
     plonk::{self, ConstraintSystem},
-    poly::{PolynomialLabel, kzg::KZGCommitmentScheme},
+    poly::{kzg::KZGCommitmentScheme, PolynomialLabel},
 };
 
 use crate::{
@@ -53,12 +53,12 @@ pub use verifier_gadget::VerifierGadget;
 type VerifyingKey<S> =
     plonk::VerifyingKey<<S as SelfEmulation>::F, KZGCommitmentScheme<<S as SelfEmulation>::Engine>>;
 
-/// Type for in-circuit Evaluation Domain. 
-/// 
-/// This type carries only the information needed for the verifier, `k` 
+/// Type for in-circuit Evaluation Domain.
+///
+/// This type carries only the information needed for the verifier, `k`
 /// and `omega`, and values `omega^{-1}` and `n = 2^k`, computed in-circuit.
-/// 
-/// The only entry points are via the assignment functions of Verifying Keys. 
+///
+/// The only entry points are via the assignment functions of Verifying Keys.
 #[derive(Clone, Debug)]
 struct AssignedEvaluationDomain<S: SelfEmulation> {
     k: AssignedNative<S::F>,
@@ -70,8 +70,8 @@ struct AssignedEvaluationDomain<S: SelfEmulation> {
 /// Type for in-circuit verifying keys.
 ///
 /// This type carries off-circuit the information about the constraint system.
-/// The in-circuit fields are the transcript representation, the fixed 
-/// commitments, permutation commitments, and the evaluation domain. 
+/// The in-circuit fields are the transcript representation, the fixed
+/// commitments, permutation commitments, and the evaluation domain.
 ///
 /// The only entry-point for this function is intended to be
 /// [VerifierGadget::assign_vk_as_public_input]. This is possible because fixed

--- a/circuits/src/verifier/mod.rs
+++ b/circuits/src/verifier/mod.rs
@@ -70,8 +70,10 @@ struct AssignedEvaluationDomain<S: SelfEmulation> {
 /// Type for in-circuit verifying keys.
 ///
 /// This type carries off-circuit the information about the constraint system.
-/// The in-circuit fields are the transcript representation, the fixed
-/// commitments, permutation commitments, and the evaluation domain.
+/// The in-circuit fields are the transcript representation and the evaluation
+/// domain. The fixed and permutation commitments are typed as
+/// [AssignedKZGCommitment], but they are "empty", i.e. of the `Fixed` variant:
+/// they only carry a label, no assigned point.
 ///
 /// The only entry-point for this function is intended to be
 /// [VerifierGadget::assign_vk_as_public_input]. This is possible because fixed
@@ -103,9 +105,9 @@ impl<S: SelfEmulation, PCS: InCircuitPCS<S>> Instantiable<S::F> for AssignedVk<S
     fn as_public_input(vk: &VerifyingKey<S>) -> Vec<S::F> {
         let domain = vk.get_domain();
         [
-            AssignedNative::<S::F>::as_public_input(&vk.transcript_repr()),
             AssignedNative::<S::F>::as_public_input(&S::F::from(domain.k() as u64)),
             AssignedNative::<S::F>::as_public_input(&domain.get_omega()),
+            AssignedNative::<S::F>::as_public_input(&vk.transcript_repr()),
         ]
         .concat()
     }
@@ -117,17 +119,17 @@ impl<S: SelfEmulation, PCS: InCircuitPCS<S>> Instantiable<S::F> for AssignedVk<S
 }
 
 impl<S: SelfEmulation, PCS: InCircuitPCS<S>> AssignedVk<S, PCS> {
-    /// The assigned `transcript_repr` cell of this verifying key.
+    /// The assigned `transcript_repr` of this verifying key.
     pub fn transcript_repr(&self) -> &AssignedNative<S::F> {
         &self.transcript_repr
     }
 
-    /// The assigned `k` cell.
+    /// The assigned `k`.
     pub fn k(&self) -> &AssignedNative<S::F> {
         &self.domain.k
     }
 
-    /// The assigned `omega` cell.
+    /// The assigned `omega`.
     pub fn omega(&self) -> &AssignedNative<S::F> {
         &self.domain.omega
     }

--- a/circuits/src/verifier/mod.rs
+++ b/circuits/src/verifier/mod.rs
@@ -18,9 +18,8 @@ use std::collections::BTreeMap;
 use group::Group;
 use midnight_proofs::{
     circuit::Value,
-    plonk,
-    plonk::ConstraintSystem,
-    poly::{kzg::KZGCommitmentScheme, EvaluationDomain, PolynomialLabel},
+    plonk::{self, ConstraintSystem},
+    poly::{PolynomialLabel, kzg::KZGCommitmentScheme},
 };
 
 use crate::{
@@ -54,10 +53,25 @@ pub use verifier_gadget::VerifierGadget;
 type VerifyingKey<S> =
     plonk::VerifyingKey<<S as SelfEmulation>::F, KZGCommitmentScheme<<S as SelfEmulation>::Engine>>;
 
+/// Type for in-circuit Evaluation Domain. 
+/// 
+/// This type carries only the information needed for the verifier, `k` 
+/// and `omega`, and values `omega^{-1}` and `n = 2^k`, computed in-circuit.
+/// 
+/// The only entry points are via the assignment functions of Verifying Keys. 
+#[derive(Clone, Debug)]
+struct AssignedEvaluationDomain<S: SelfEmulation> {
+    k: AssignedNative<S::F>,
+    omega: AssignedNative<S::F>,
+    omega_inv: AssignedNative<S::F>,
+    n: AssignedNative<S::F>,
+}
+
 /// Type for in-circuit verifying keys.
 ///
-/// This type carries off-circuit a lot of the information about the vk.
-/// The only in-circuit field is the `transcript_repr`.
+/// This type carries off-circuit the information about the constraint system.
+/// The in-circuit fields are the transcript representation, the fixed 
+/// commitments, permutation commitments, and the evaluation domain. 
 ///
 /// The only entry-point for this function is intended to be
 /// [VerifierGadget::assign_vk_as_public_input]. This is possible because fixed
@@ -66,7 +80,7 @@ type VerifyingKey<S> =
 /// fixed-commitments, in the `fixed_base_scalars` field (of its RHS).
 #[derive(Clone, Debug)]
 pub struct AssignedVk<S: SelfEmulation, PCS: InCircuitPCS<S>> {
-    domain: EvaluationDomain<S::F>,
+    domain: AssignedEvaluationDomain<S>,
     fixed_commitments: Vec<PCS::AssignedCommitment>,
     perm_commitments: Vec<PCS::AssignedCommitment>,
     cs: ConstraintSystem<S::F>,
@@ -87,7 +101,13 @@ impl<S: SelfEmulation, PCS: InCircuitPCS<S>> InnerValue for AssignedVk<S, PCS> {
 
 impl<S: SelfEmulation, PCS: InCircuitPCS<S>> Instantiable<S::F> for AssignedVk<S, PCS> {
     fn as_public_input(vk: &VerifyingKey<S>) -> Vec<S::F> {
-        AssignedNative::<S::F>::as_public_input(&vk.transcript_repr())
+        let domain = vk.get_domain();
+        [
+            AssignedNative::<S::F>::as_public_input(&vk.transcript_repr()),
+            AssignedNative::<S::F>::as_public_input(&S::F::from(domain.k() as u64)),
+            AssignedNative::<S::F>::as_public_input(&domain.get_omega()),
+        ]
+        .concat()
     }
 
     #[cfg(any(test, feature = "testing"))]
@@ -100,6 +120,16 @@ impl<S: SelfEmulation, PCS: InCircuitPCS<S>> AssignedVk<S, PCS> {
     /// The assigned `transcript_repr` cell of this verifying key.
     pub fn transcript_repr(&self) -> &AssignedNative<S::F> {
         &self.transcript_repr
+    }
+
+    /// The assigned `k` cell.
+    pub fn k(&self) -> &AssignedNative<S::F> {
+        &self.domain.k
+    }
+
+    /// The assigned `omega` cell.
+    pub fn omega(&self) -> &AssignedNative<S::F> {
+        &self.domain.omega
     }
 }
 

--- a/circuits/src/verifier/utils.rs
+++ b/circuits/src/verifier/utils.rs
@@ -169,7 +169,6 @@ pub fn evaluate_lagrange_polynomials<F: CircuitField>(
             };
             let x_minus_wi = scalar_chip.sub(layouter, x, &wi)?;
             let quotient = scalar_chip.div(layouter, &xn_minus_one, &x_minus_wi)?;
-            // quotient * w^i / n
             let wi_over_n = scalar_chip.mul(layouter, &wi, &n_inv, None)?;
             scalar_chip.mul(layouter, &quotient, &wi_over_n, None)
         })

--- a/circuits/src/verifier/utils.rs
+++ b/circuits/src/verifier/utils.rs
@@ -138,10 +138,11 @@ pub(crate) fn truncate<F: CircuitField>(
     Ok(AssignedBoundedScalar::new(&scalar, Some(bound)))
 }
 
-/// Evaluates the i-th Lagrange polynomial (with respect to the `n`-th root of unity `ω`)
-/// at the given point `x`, for all the given `i_indices`. That is, for every `i ∈ i_indices`, computes
-/// `L_i(x)` where `L_i(X)` is the degree-`n` polynomial such that `L_i(ωⁱ) = 1` and
-/// `L_i(ωʲ) = 0` for all `j ∈ {1, ..., n} \ {i}`.
+/// Evaluates the i-th Lagrange polynomial (with respect to the `n`-th root of
+/// unity `ω`) at the given point `x`, for all the given `i_indices`. That is,
+/// for every `i ∈ i_indices`, computes `L_i(x)` where `L_i(X)` is the
+/// degree-`n` polynomial such that `L_i(ωⁱ) = 1` and `L_i(ωʲ) = 0` for all
+/// `j ∈ {1, ..., n} \ {i}`.
 ///
 /// # Unsatisfiable Circuit
 ///

--- a/circuits/src/verifier/utils.rs
+++ b/circuits/src/verifier/utils.rs
@@ -20,13 +20,11 @@ use midnight_proofs::{
 use num_bigint::BigUint;
 use num_traits::One;
 
-#[cfg(not(feature = "truncated-challenges"))]
-use crate::instructions::FieldInstructions;
 #[cfg(feature = "truncated-challenges")]
 use crate::instructions::NativeInstructions;
 use crate::{
     field::AssignedNative,
-    instructions::{ArithInstructions, AssignmentInstructions},
+    instructions::{ArithInstructions, AssignmentInstructions, FieldInstructions},
     CircuitField,
 };
 
@@ -140,36 +138,40 @@ pub(crate) fn truncate<F: CircuitField>(
     Ok(AssignedBoundedScalar::new(&scalar, Some(bound)))
 }
 
-/// Evaluates the i-th Lagrange polynomial (with respect to n-root of unity w)
-/// at the given point x, for all the given i. That is, for every i, computes
-/// Li(x) where Li(X) is the degree-n polynomial such that Li(w^i) = 1 and
-/// Li(w^j) = 0 for all j in {1, ..., n} \ {i}.
+/// Evaluates the i-th Lagrange polynomial (with respect to the `n`-th root of unity `ω`)
+/// at the given point `x`, for all the given `i_indices`. That is, for every `i ∈ i_indices`, computes
+/// `L_i(x)` where `L_i(X)` is the degree-`n` polynomial such that `L_i(ωⁱ) = 1` and
+/// `L_i(ωʲ) = 0` for all `j ∈ {1, ..., n} \ {i}`.
 ///
 /// # Unsatisfiable Circuit
 ///
 /// If x^n = 1.
 pub fn evaluate_lagrange_polynomials<F: CircuitField>(
     layouter: &mut impl Layouter<F>,
-    scalar_chip: &impl ArithInstructions<F, AssignedNative<F>>,
-    n: u64,
-    w: F,
-    i_indices: Range<i32>,
+    scalar_chip: &impl FieldInstructions<F, AssignedNative<F>>,
+    w: &AssignedNative<F>,
+    n: &AssignedNative<F>,
     x: &AssignedNative<F>,
+    xn: &AssignedNative<F>,
+    i_indices: Range<i32>,
 ) -> Result<Vec<AssignedNative<F>>, Error> {
-    // For every i, Li(X) := (w^i / n) * (X^n - 1) / (X - w^i).
-
-    let n_inv = F::from(n).invert().unwrap();
-    let xn = scalar_chip.pow(layouter, x, n)?;
-    let xn_minus_one = scalar_chip.add_constant(layouter, &xn, -F::ONE)?;
+    // For every i, L_i(X) := (ωⁱ / n) · (Xⁿ - 1) / (X - ωⁱ).
+    let w_inv = scalar_chip.inv(layouter, w)?;
+    let n_inv = scalar_chip.inv(layouter, n)?;
+    let xn_minus_one = scalar_chip.add_constant(layouter, xn, -F::ONE)?;
 
     i_indices
         .map(|i| {
-            assert!(-(n as i32) <= i);
-            let i = if i < 0 { n as i32 + i } else { i };
-            let wi = w.pow([i as u64, 0, 0, 0]);
-            let x_minus_wi = scalar_chip.add_constant(layouter, x, -wi)?;
+            let wi = if i >= 0 {
+                scalar_chip.pow(layouter, w, i as u64)?
+            } else {
+                scalar_chip.pow(layouter, &w_inv, (-i) as u64)?
+            };
+            let x_minus_wi = scalar_chip.sub(layouter, x, &wi)?;
             let quotient = scalar_chip.div(layouter, &xn_minus_one, &x_minus_wi)?;
-            scalar_chip.mul_by_constant(layouter, &quotient, wi * n_inv)
+            // quotient * w^i / n
+            let wi_over_n = scalar_chip.mul(layouter, &wi, &n_inv, None)?;
+            scalar_chip.mul(layouter, &quotient, &wi_over_n, None)
         })
         .collect()
 }
@@ -264,6 +266,46 @@ pub(crate) fn inner_product<F: CircuitField>(
     iter.try_fold(init, |acc, (xi, yi)| {
         mul_add(layouter, scalar_chip, xi, yi, &acc)
     })
+}
+
+/// Computes `2^k` in-circuit, where `k` is an assigned value known to lie in
+/// the range `[0, F::S]` (`F::S` is the field's 2-adicity).
+pub(crate) fn pow_of_two<F: CircuitField>(
+    layouter: &mut impl Layouter<F>,
+    scalar_chip: &impl FieldInstructions<F, AssignedNative<F>>,
+    k: &AssignedNative<F>,
+) -> Result<AssignedNative<F>, Error> {
+    let mut acc: AssignedNative<F> = scalar_chip.assign_fixed(layouter, F::ONE)?;
+    let mut result = acc.clone();
+
+    for i in 1..=F::S as usize {
+        acc = scalar_chip.add(layouter, &acc, &acc)?;
+        let is_k = scalar_chip.is_equal_to_fixed(layouter, k, F::from(i as u64))?;
+        result = scalar_chip.select(layouter, &is_k, &acc, &result)?;
+    }
+
+    Ok(result)
+}
+
+/// Computes `x^(2^k)` in-circuit by repeated squaring, where `k` is an
+/// assigned value known to lie in the range `[0, F::S]` (the field's
+/// 2-adicity).
+pub(crate) fn pow_2_pow_k<F: CircuitField>(
+    layouter: &mut impl Layouter<F>,
+    scalar_chip: &impl FieldInstructions<F, AssignedNative<F>>,
+    x: &AssignedNative<F>,
+    k: &AssignedNative<F>,
+) -> Result<AssignedNative<F>, Error> {
+    let mut acc = x.clone();
+    let mut result = acc.clone();
+
+    for i in 1..=F::S as usize {
+        acc = scalar_chip.mul(layouter, &acc, &acc, None)?;
+        let is_k = scalar_chip.is_equal_to_fixed(layouter, k, F::from(i as u64))?;
+        result = scalar_chip.select(layouter, &is_k, &acc, &result)?;
+    }
+
+    Ok(result)
 }
 
 /// Computes n powers of the given scalar x, starting from the 0-th power: 1.

--- a/circuits/src/verifier/utils.rs
+++ b/circuits/src/verifier/utils.rs
@@ -144,21 +144,29 @@ pub(crate) fn truncate<F: CircuitField>(
 /// degree-`n` polynomial such that `L_i(ωⁱ) = 1` and `L_i(ωʲ) = 0` for all
 /// `j ∈ {1, ..., n} \ {i}`.
 ///
+/// The values `w_inv`, `n_inv` and `xn` are taken as arguments (instead of
+/// being derived here) so that they can be computed once and shared by all
+/// calls over the same domain and evaluation point. It is the caller's
+/// responsibility to guarantee that `w_inv = ω⁻¹`, `n_inv = n⁻¹` and `xn = xⁿ`.
+///
+/// It is also the caller's responsibility to guarantee that `|i| < n` for every
+/// `i ∈ i_indices`.
+///
 /// # Unsatisfiable Circuit
 ///
 /// If x^n = 1.
+#[allow(clippy::too_many_arguments)]
 pub fn evaluate_lagrange_polynomials<F: CircuitField>(
     layouter: &mut impl Layouter<F>,
     scalar_chip: &impl FieldInstructions<F, AssignedNative<F>>,
     w: &AssignedNative<F>,
-    n: &AssignedNative<F>,
+    w_inv: &AssignedNative<F>,
+    n_inv: &AssignedNative<F>,
     x: &AssignedNative<F>,
     xn: &AssignedNative<F>,
     i_indices: Range<i32>,
 ) -> Result<Vec<AssignedNative<F>>, Error> {
     // For every i, L_i(X) := (ωⁱ / n) · (Xⁿ - 1) / (X - ωⁱ).
-    let w_inv = scalar_chip.inv(layouter, w)?;
-    let n_inv = scalar_chip.inv(layouter, n)?;
     let xn_minus_one = scalar_chip.add_constant(layouter, xn, -F::ONE)?;
 
     i_indices
@@ -166,11 +174,11 @@ pub fn evaluate_lagrange_polynomials<F: CircuitField>(
             let wi = if i >= 0 {
                 scalar_chip.pow(layouter, w, i as u64)?
             } else {
-                scalar_chip.pow(layouter, &w_inv, (-i) as u64)?
+                scalar_chip.pow(layouter, w_inv, (-i) as u64)?
             };
             let x_minus_wi = scalar_chip.sub(layouter, x, &wi)?;
             let quotient = scalar_chip.div(layouter, &xn_minus_one, &x_minus_wi)?;
-            let wi_over_n = scalar_chip.mul(layouter, &wi, &n_inv, None)?;
+            let wi_over_n = scalar_chip.mul(layouter, &wi, n_inv, None)?;
             scalar_chip.mul(layouter, &quotient, &wi_over_n, None)
         })
         .collect()

--- a/circuits/src/verifier/verifier_gadget.rs
+++ b/circuits/src/verifier/verifier_gadget.rs
@@ -84,7 +84,12 @@ impl<S: SelfEmulation> PublicInputInstructions<S::F, AssignedVk<S>> for Verifier
         layouter: &mut impl Layouter<S::F>,
         assigned_vk: &AssignedVk<S>,
     ) -> Result<Vec<AssignedNative<S::F>>, Error> {
-        self.scalar_chip.as_public_input(layouter, &assigned_vk.transcript_repr)
+        Ok([
+            self.scalar_chip.as_public_input(layouter, &assigned_vk.transcript_repr)?,
+            self.scalar_chip.as_public_input(layouter, assigned_vk.k())?,
+            self.scalar_chip.as_public_input(layouter, assigned_vk.omega())?,
+        ]
+        .concat())
     }
 
     fn constrain_as_public_input(

--- a/circuits/src/verifier/verifier_gadget.rs
+++ b/circuits/src/verifier/verifier_gadget.rs
@@ -31,13 +31,22 @@ use midnight_proofs::{
 use crate::{
     field::AssignedNative,
     instructions::{
-        ArithInstructions, PublicInputInstructions, assignments::AssignmentInstructions
+        assignments::AssignmentInstructions, ArithInstructions, PublicInputInstructions,
     },
     verifier::{
-        Accumulator, AssignedAccumulator, AssignedEvaluationDomain, AssignedVk, SelfEmulation, VerifyingKey, expressions::{
+        expressions::{
             eval_expression, lookup::lookup_expressions, permutation::permutation_expressions,
             trash::trash_expressions,
-        }, kzg::{self, AssignedKZGCommitment, VerifierQuery}, lookup, permutation::{self, evaluate_permutation_common}, traces::VerifierTrace, transcript_gadget::TranscriptGadget, trash, utils::{evaluate_lagrange_polynomials, inner_product, pow_2_pow_k, pow_of_two, sum}
+        },
+        kzg::{self, AssignedKZGCommitment, VerifierQuery},
+        lookup,
+        permutation::{self, evaluate_permutation_common},
+        traces::VerifierTrace,
+        transcript_gadget::TranscriptGadget,
+        trash,
+        utils::{evaluate_lagrange_polynomials, inner_product, pow_2_pow_k, pow_of_two, sum},
+        Accumulator, AssignedAccumulator, AssignedEvaluationDomain, AssignedVk, SelfEmulation,
+        VerifyingKey,
     },
 };
 
@@ -234,7 +243,8 @@ impl<S: SelfEmulation> VerifierGadget<S> {
         let transcript_repr =
             self.scalar_chip.assign_as_public_input(layouter, transcript_repr_value)?;
 
-        let [k, omega] = domain.map(|d| [S::F::from(d.k()as u64), d.get_omega()]).transpose_array();
+        let [k, omega] =
+            domain.map(|d| [S::F::from(d.k() as u64), d.get_omega()]).transpose_array();
         let k = self.scalar_chip.assign_as_public_input(layouter, k)?;
         let omega = self.scalar_chip.assign_as_public_input(layouter, omega)?;
         let domain = self.derive_domain(layouter, k, omega)?;
@@ -269,7 +279,12 @@ impl<S: SelfEmulation> VerifierGadget<S> {
     ) -> Result<AssignedEvaluationDomain<S>, Error> {
         let omega_inv = self.scalar_chip.inv(layouter, &omega)?;
         let n = pow_of_two(layouter, &self.scalar_chip, &k)?;
-        Ok(AssignedEvaluationDomain { k, omega, omega_inv, n })
+        Ok(AssignedEvaluationDomain {
+            k,
+            omega,
+            omega_inv,
+            n,
+        })
     }
 
     /// Builds the `AssignedVk`.
@@ -1008,7 +1023,8 @@ pub(crate) mod tests {
 
     #[derive(Clone, Debug)]
     pub struct TestCircuit {
-        inner_vk: (Value<EvaluationDomain<F>>, ConstraintSystem<F>, Value<F>), // (domain, cs, vk_repr)
+        // (domain, cs, vk_repr)
+        inner_vk: (Value<EvaluationDomain<F>>, ConstraintSystem<F>, Value<F>),
         inner_committed_instance: Value<C>,
         inner_instances: Value<[F; NB_INNER_INSTANCES]>,
         inner_proof: Value<Vec<u8>>,

--- a/circuits/src/verifier/verifier_gadget.rs
+++ b/circuits/src/verifier/verifier_gadget.rs
@@ -31,21 +31,13 @@ use midnight_proofs::{
 use crate::{
     field::AssignedNative,
     instructions::{
-        assignments::AssignmentInstructions, ArithInstructions, PublicInputInstructions,
+        ArithInstructions, PublicInputInstructions, assignments::AssignmentInstructions
     },
     verifier::{
-        expressions::{
+        Accumulator, AssignedAccumulator, AssignedEvaluationDomain, AssignedVk, SelfEmulation, VerifyingKey, expressions::{
             eval_expression, lookup::lookup_expressions, permutation::permutation_expressions,
             trash::trash_expressions,
-        },
-        kzg::{self, AssignedKZGCommitment, VerifierQuery},
-        lookup,
-        permutation::{self, evaluate_permutation_common},
-        traces::VerifierTrace,
-        transcript_gadget::TranscriptGadget,
-        trash,
-        utils::{evaluate_lagrange_polynomials, inner_product, sum},
-        Accumulator, AssignedAccumulator, AssignedVk, SelfEmulation, VerifyingKey,
+        }, kzg::{self, AssignedKZGCommitment, VerifierQuery}, lookup, permutation::{self, evaluate_permutation_common}, traces::VerifierTrace, transcript_gadget::TranscriptGadget, trash, utils::{evaluate_lagrange_polynomials, inner_product, pow_2_pow_k, pow_of_two, sum}
     },
 };
 
@@ -225,17 +217,63 @@ impl<S: SelfEmulation> VerifierGadget<S> {
 
 impl<S: SelfEmulation> VerifierGadget<S> {
     /// Assigns a verifying key as a public input. All the necessary information
-    /// is required off-circuit, except for the `transcript_repr` value.
+    /// is required off-circuit, except for the `transcript_repr` and the
+    /// evaluation domain.
     pub fn assign_vk_as_public_input(
+        &self,
+        layouter: &mut impl Layouter<S::F>,
+        domain: Value<EvaluationDomain<S::F>>,
+        cs: &ConstraintSystem<S::F>,
+        transcript_repr_value: Value<S::F>,
+    ) -> Result<AssignedVk<S>, Error> {
+        let transcript_repr =
+            self.scalar_chip.assign_as_public_input(layouter, transcript_repr_value)?;
+
+        let [k, omega] = domain.map(|d| [S::F::from(d.k()as u64), d.get_omega()]).transpose_array();
+        let k = self.scalar_chip.assign_as_public_input(layouter, k)?;
+        let omega = self.scalar_chip.assign_as_public_input(layouter, omega)?;
+        let domain = self.derive_domain(layouter, k, omega)?;
+
+        self.assemble_vk(cs, domain, transcript_repr)
+    }
+
+    /// Assigns a verifying key as a constant. All the necessary information is
+    /// available off-circuit, except for the `transcript_repr` which is
+    /// "assigned fixed".
+    pub fn assign_fixed_vk(
         &self,
         layouter: &mut impl Layouter<S::F>,
         domain: &EvaluationDomain<S::F>,
         cs: &ConstraintSystem<S::F>,
-        transcript_repr_value: Value<S::F>,
+        transcript_repr_constant: S::F,
     ) -> Result<AssignedVk<S>, Error> {
-        let transcript_repr: AssignedNative<S::F> =
-            self.scalar_chip.assign_as_public_input(layouter, transcript_repr_value)?;
+        let transcript_repr = self.scalar_chip.assign_fixed(layouter, transcript_repr_constant)?;
+        let k = self.scalar_chip.assign_fixed(layouter, S::F::from(domain.k() as u64))?;
+        let omega = self.scalar_chip.assign_fixed(layouter, domain.get_omega())?;
+        let domain = self.derive_domain(layouter, k, omega)?;
+        self.assemble_vk(cs, domain, transcript_repr)
+    }
 
+    /// Completes the assigned domain by deriving `omega_inv` and `n = 2^k` from
+    /// assigned `k` and `omega` cells (in-circuit).
+    fn derive_domain(
+        &self,
+        layouter: &mut impl Layouter<S::F>,
+        k: AssignedNative<S::F>,
+        omega: AssignedNative<S::F>,
+    ) -> Result<AssignedEvaluationDomain<S>, Error> {
+        let omega_inv = self.scalar_chip.inv(layouter, &omega)?;
+        let n = pow_of_two(layouter, &self.scalar_chip, &k)?;
+        Ok(AssignedEvaluationDomain { k, omega, omega_inv, n })
+    }
+
+    /// Builds the `AssignedVk`.
+    fn assemble_vk(
+        &self,
+        cs: &ConstraintSystem<S::F>,
+        domain: AssignedEvaluationDomain<S>,
+        transcript_repr: AssignedNative<S::F>,
+    ) -> Result<AssignedVk<S>, Error> {
         // We expect a finalized cs with no selectors, i.e. whose selectors have been
         // converted into fixed columns. In the context of IVC, the constraint system
         // might still contain selectors.
@@ -254,48 +292,14 @@ impl<S: SelfEmulation> VerifierGadget<S> {
             .map(|i| AssignedKZGCommitment::fixed(PolynomialLabel::PermutationFixed(i)))
             .collect();
 
-        let assigned_vk = AssignedVk {
-            domain: domain.clone(),
+        Ok(AssignedVk {
+            domain,
             fixed_commitments,
             perm_commitments,
-            cs: cs.clone(),
             cs_degree: cs.degree(),
+            cs,
             transcript_repr,
-        };
-
-        Ok(assigned_vk)
-    }
-
-    /// Assigns a verifying key as a constant. All the necessary information is
-    /// available off-circuit, except for the `transcript_repr` which is
-    /// "assigned fixed".
-    pub fn assign_fixed_vk(
-        &self,
-        layouter: &mut impl Layouter<S::F>,
-        domain: &EvaluationDomain<S::F>,
-        cs: &ConstraintSystem<S::F>,
-        transcript_repr_constant: S::F,
-    ) -> Result<AssignedVk<S>, Error> {
-        let transcript_repr = self.scalar_chip.assign_fixed(layouter, transcript_repr_constant)?;
-
-        let fixed_commitments = (0..cs.num_fixed_columns() + cs.num_selectors())
-            .map(|i| AssignedKZGCommitment::fixed(PolynomialLabel::Fixed(i)))
-            .collect();
-
-        let perm_commitments = (0..cs.permutation().columns.len())
-            .map(|i| AssignedKZGCommitment::fixed(PolynomialLabel::PermutationFixed(i)))
-            .collect();
-
-        let assigned_vk = AssignedVk {
-            domain: domain.clone(),
-            fixed_commitments,
-            perm_commitments,
-            cs: cs.clone(),
-            cs_degree: cs.degree(),
-            transcript_repr,
-        };
-
-        Ok(assigned_vk)
+        })
     }
 }
 
@@ -516,7 +520,7 @@ impl<S: SelfEmulation> VerifierGadget<S> {
         mut transcript: TranscriptGadget<S>,
     ) -> Result<AssignedAccumulator<S>, Error> {
         let cs = &assigned_vk.cs;
-        let k = assigned_vk.domain.k();
+        let k = &assigned_vk.domain.k;
         let nb_committed_instances = assigned_committed_instances.len();
 
         let VerifierTrace {
@@ -536,7 +540,7 @@ impl<S: SelfEmulation> VerifierGadget<S> {
         // commits to h(X) as a single polynomial (one commitment); otherwise it
         // splits h(X) into `quotient_poly_degree` limbs (one commitment each).
         #[cfg(not(feature = "single-h-commitment"))]
-        let nb_quotient_coms = assigned_vk.domain.get_quotient_poly_degree();
+        let nb_quotient_coms = assigned_vk.cs_degree - 1;
         #[cfg(feature = "single-h-commitment")]
         let nb_quotient_coms = 1;
         let limb_commitments = {
@@ -559,6 +563,11 @@ impl<S: SelfEmulation> VerifierGadget<S> {
         // high probability
         let x = transcript.squeeze_challenge(layouter)?;
 
+        let omega = &assigned_vk.domain.omega;
+        let omega_inv = &assigned_vk.domain.omega_inv;
+        let n = &assigned_vk.domain.n;
+        let xn = pow_2_pow_k(layouter, &self.scalar_chip, &x, k)?;
+
         let instance_evals = {
             let instance_queries = cs.instance_queries();
             let min_rotation = instance_queries.iter().map(|(_, rot)| rot.0).min().unwrap();
@@ -570,10 +579,11 @@ impl<S: SelfEmulation> VerifierGadget<S> {
             let l_i_s = evaluate_lagrange_polynomials(
                 layouter,
                 &self.scalar_chip,
-                1 << k,
-                assigned_vk.domain.get_omega(),
-                (-max_rotation)..(max_instance_len as i32 + min_rotation.abs()),
+                omega,
+                n,
                 &x,
+                &xn,
+                (-max_rotation)..(max_instance_len as i32 + min_rotation.abs()),
             )?;
 
             instance_queries
@@ -636,10 +646,11 @@ impl<S: SelfEmulation> VerifierGadget<S> {
         let l_evals = evaluate_lagrange_polynomials(
             layouter,
             &self.scalar_chip,
-            1 << k,
-            assigned_vk.domain.get_omega(),
-            (-((nr_blinding_factors + 1) as i32))..1,
+            omega,
+            n,
             &x,
+            &xn,
+            (-((nr_blinding_factors + 1) as i32))..1,
         )?;
         assert_eq!(l_evals.len(), 2 + nr_blinding_factors);
         let l_last = l_evals[0].clone();
@@ -745,9 +756,7 @@ impl<S: SelfEmulation> VerifierGadget<S> {
             .into_iter()
             .for_each(|trash_id| expressions.push((None, trash_id)));
 
-        let splitting_factor =
-            ArithInstructions::pow(&self.scalar_chip, layouter, &x, (1 << k) - 1)?;
-        let xn = self.scalar_chip.mul(layouter, &x, &splitting_factor, None)?;
+        let splitting_factor = self.scalar_chip.div(layouter, &xn, &x)?;
 
         let (lin_commitment, lin_eval) = Self::compute_linearization_commitment(
             layouter,
@@ -760,12 +769,11 @@ impl<S: SelfEmulation> VerifierGadget<S> {
             &limb_commitments,
         )?;
 
-        let omega = assigned_vk.domain.get_omega();
-        let omega_inv = omega.invert().unwrap();
-        let omega_last = omega_inv.pow([cs.blinding_factors() as u64 + 1]);
-        let x_next = self.scalar_chip.mul_by_constant(layouter, &x, omega)?;
-        let x_prev = self.scalar_chip.mul_by_constant(layouter, &x, omega_inv)?;
-        let x_last = self.scalar_chip.mul_by_constant(layouter, &x, omega_last)?;
+        let omega_last =
+            self.scalar_chip.pow(layouter, omega_inv, cs.blinding_factors() as u64 + 1)?;
+        let x_next = self.scalar_chip.mul(layouter, &x, omega, None)?;
+        let x_prev = self.scalar_chip.mul(layouter, &x, omega_inv, None)?;
+        let x_last = self.scalar_chip.mul(layouter, &x, &omega_last, None)?;
 
         // Gets the evaluation point for a query at the given rotation.
         let get_point = |rotation: &Rotation| -> &AssignedNative<S::F> {
@@ -995,7 +1003,7 @@ pub(crate) mod tests {
 
     #[derive(Clone, Debug)]
     pub struct TestCircuit {
-        inner_vk: (EvaluationDomain<F>, ConstraintSystem<F>, Value<F>), // (domain, cs, vk_repr)
+        inner_vk: (Value<EvaluationDomain<F>>, ConstraintSystem<F>, Value<F>), // (domain, cs, vk_repr)
         inner_committed_instance: Value<C>,
         inner_instances: Value<[F; NB_INNER_INSTANCES]>,
         inner_proof: Value<Vec<u8>>,
@@ -1092,7 +1100,7 @@ pub(crate) mod tests {
 
             let assigned_inner_vk: AssignedVk<S> = verifier_chip.assign_vk_as_public_input(
                 &mut layouter,
-                &self.inner_vk.0,
+                self.inner_vk.0.clone(),
                 &self.inner_vk.1,
                 self.inner_vk.2,
             )?;
@@ -1200,7 +1208,7 @@ pub(crate) mod tests {
 
         let circuit = TestCircuit {
             inner_vk: (
-                inner_vk.get_domain().clone(),
+                Value::known(inner_vk.get_domain().clone()),
                 inner_vk.cs().clone(),
                 Value::known(inner_vk.transcript_repr()),
             ),

--- a/circuits/src/verifier/verifier_gadget.rs
+++ b/circuits/src/verifier/verifier_gadget.rs
@@ -96,9 +96,9 @@ impl<S: SelfEmulation, PCS: InCircuitPCS<S>> PublicInputInstructions<S::F, Assig
         assigned_vk: &AssignedVk<S, PCS>,
     ) -> Result<Vec<AssignedNative<S::F>>, Error> {
         Ok([
+            self.scalar_chip.as_public_input(layouter, &assigned_vk.transcript_repr)?,
             self.scalar_chip.as_public_input(layouter, assigned_vk.k())?,
             self.scalar_chip.as_public_input(layouter, assigned_vk.omega())?,
-            self.scalar_chip.as_public_input(layouter, &assigned_vk.transcript_repr)?,
         ]
         .concat())
     }
@@ -236,6 +236,11 @@ impl<S: SelfEmulation> VerifierGadget<S> {
     /// is required off-circuit, except for the `transcript_repr` and the
     /// evaluation domain.
     ///
+    /// These are taken as separate values (instead of a `Value<VerifyingKey>`)
+    /// because a circuit may need to verify its *own* key, in which case no
+    /// verifying key exists yet: the values are then supplied by the prover
+    /// through the public inputs.
+    ///
     /// The domain values `k` and `omega` are *trusted* at this point: this
     /// function does not check that they are consistent (i.e. that `omega` is a
     /// primitive `2^k`-th root of unity), nor that they are the ones of the
@@ -248,12 +253,12 @@ impl<S: SelfEmulation> VerifierGadget<S> {
         domain: Value<EvaluationDomain<S::F>>,
         transcript_repr_value: Value<S::F>,
     ) -> Result<AssignedVk<S, PCS>, Error> {
-        let [k, omega] =
+        let [k_value, omega_value] =
             domain.map(|d| [S::F::from(d.k() as u64), d.get_omega()]).transpose_array();
-        let k = self.scalar_chip.assign_as_public_input(layouter, k)?;
-        let omega = self.scalar_chip.assign_as_public_input(layouter, omega)?;
         let transcript_repr =
             self.scalar_chip.assign_as_public_input(layouter, transcript_repr_value)?;
+        let k = self.scalar_chip.assign_as_public_input(layouter, k_value)?;
+        let omega = self.scalar_chip.assign_as_public_input(layouter, omega_value)?;
 
         let domain = self.derive_domain(layouter, k, omega)?;
 
@@ -266,15 +271,14 @@ impl<S: SelfEmulation> VerifierGadget<S> {
     pub fn assign_fixed_vk<PCS: InCircuitPCS<S>>(
         &self,
         layouter: &mut impl Layouter<S::F>,
-        cs: &ConstraintSystem<S::F>,
-        domain: &EvaluationDomain<S::F>,
-        transcript_repr_constant: S::F,
+        vk: &VerifyingKey<S>,
     ) -> Result<AssignedVk<S, PCS>, Error> {
-        let transcript_repr = self.scalar_chip.assign_fixed(layouter, transcript_repr_constant)?;
+        let domain = vk.get_domain();
+        let transcript_repr = self.scalar_chip.assign_fixed(layouter, vk.transcript_repr())?;
         let k = self.scalar_chip.assign_fixed(layouter, S::F::from(domain.k() as u64))?;
         let omega = self.scalar_chip.assign_fixed(layouter, domain.get_omega())?;
         let domain = self.derive_domain(layouter, k, omega)?;
-        self.assemble_vk(cs, domain, transcript_repr)
+        self.assemble_vk(vk.cs(), domain, transcript_repr)
     }
 
     /// Completes the assigned domain by deriving `omega_inv` and `n = 2^k` from
@@ -597,6 +601,12 @@ impl<S: SelfEmulation> VerifierGadget<S> {
 
         let omega = &assigned_vk.domain.omega;
         let omega_inv = &assigned_vk.domain.omega_inv;
+        // `n = 2^k` is larger than the rotation bounds computed below, and than the
+        // length of any instance column: rotations are compile-time constants of the
+        // verified circuit's `cs`, and its instance rows must fit in its own domain.
+        // Thus the range of Lagrange polynomials evaluated below spans less than one
+        // period of `omega` (which has order `n`), i.e. the powers `omega^i` involved
+        // are pair-wise distinct and never wrap around the domain.
         let n = &assigned_vk.domain.n;
         let xn = pow_2_pow_k(layouter, &self.scalar_chip, &x, k)?;
         // Shared by all calls to `evaluate_lagrange_polynomials` below.

--- a/circuits/src/verifier/verifier_gadget.rs
+++ b/circuits/src/verifier/verifier_gadget.rs
@@ -31,7 +31,7 @@ use midnight_proofs::{
 use crate::{
     field::AssignedNative,
     instructions::{
-        ArithInstructions, PublicInputInstructions, assignments::AssignmentInstructions
+        assignments::AssignmentInstructions, ArithInstructions, PublicInputInstructions,
     },
     verifier::{
         Accumulator, AssignedAccumulator, AssignedEvaluationDomain, AssignedVk, SelfEmulation,
@@ -247,7 +247,8 @@ impl<S: SelfEmulation> VerifierGadget<S> {
         let transcript_repr =
             self.scalar_chip.assign_as_public_input(layouter, transcript_repr_value)?;
 
-        let [k, omega] = domain.map(|d| [S::F::from(d.k()as u64), d.get_omega()]).transpose_array();
+        let [k, omega] =
+            domain.map(|d| [S::F::from(d.k() as u64), d.get_omega()]).transpose_array();
         let k = self.scalar_chip.assign_as_public_input(layouter, k)?;
         let omega = self.scalar_chip.assign_as_public_input(layouter, omega)?;
         let domain = self.derive_domain(layouter, k, omega)?;
@@ -282,7 +283,12 @@ impl<S: SelfEmulation> VerifierGadget<S> {
     ) -> Result<AssignedEvaluationDomain<S>, Error> {
         let omega_inv = self.scalar_chip.inv(layouter, &omega)?;
         let n = pow_of_two(layouter, &self.scalar_chip, &k)?;
-        Ok(AssignedEvaluationDomain { k, omega, omega_inv, n })
+        Ok(AssignedEvaluationDomain {
+            k,
+            omega,
+            omega_inv,
+            n,
+        })
     }
 
     /// Builds the `AssignedVk`.
@@ -1031,7 +1037,8 @@ pub(crate) mod tests {
 
     #[derive(Clone, Debug)]
     pub struct TestCircuit {
-        inner_vk: (Value<EvaluationDomain<F>>, ConstraintSystem<F>, Value<F>), // (domain, cs, vk_repr)
+        // (domain, cs, vk_repr)
+        inner_vk: (Value<EvaluationDomain<F>>, ConstraintSystem<F>, Value<F>),
         inner_committed_instance: Value<C>,
         inner_instances: Value<[F; NB_INNER_INSTANCES]>,
         inner_proof: Value<Vec<u8>>,

--- a/circuits/src/verifier/verifier_gadget.rs
+++ b/circuits/src/verifier/verifier_gadget.rs
@@ -98,9 +98,9 @@ impl<S: SelfEmulation, PCS: InCircuitPCS<S>> PublicInputInstructions<S::F, Assig
         assigned_vk: &AssignedVk<S, PCS>,
     ) -> Result<Vec<AssignedNative<S::F>>, Error> {
         Ok([
-            self.scalar_chip.as_public_input(layouter, &assigned_vk.transcript_repr)?,
             self.scalar_chip.as_public_input(layouter, assigned_vk.k())?,
             self.scalar_chip.as_public_input(layouter, assigned_vk.omega())?,
+            self.scalar_chip.as_public_input(layouter, &assigned_vk.transcript_repr)?,
         ]
         .concat())
     }
@@ -237,20 +237,26 @@ impl<S: SelfEmulation> VerifierGadget<S> {
     /// Assigns a verifying key as a public input. All the necessary information
     /// is required off-circuit, except for the `transcript_repr` and the
     /// evaluation domain.
+    ///
+    /// The domain values `k` and `omega` are *trusted* at this point: this
+    /// function does not check that they are consistent (i.e. that `omega` is a
+    /// primitive `2^k`-th root of unity), nor that they are the ones of the
+    /// verifying key identified by `transcript_repr`. It is the caller's
+    /// responsibility to constrain them.
     pub fn assign_vk_as_public_input<PCS: InCircuitPCS<S>>(
         &self,
         layouter: &mut impl Layouter<S::F>,
-        domain: Value<EvaluationDomain<S::F>>,
         cs: &ConstraintSystem<S::F>,
+        domain: Value<EvaluationDomain<S::F>>,
         transcript_repr_value: Value<S::F>,
     ) -> Result<AssignedVk<S, PCS>, Error> {
-        let transcript_repr =
-            self.scalar_chip.assign_as_public_input(layouter, transcript_repr_value)?;
-
         let [k, omega] =
             domain.map(|d| [S::F::from(d.k() as u64), d.get_omega()]).transpose_array();
         let k = self.scalar_chip.assign_as_public_input(layouter, k)?;
         let omega = self.scalar_chip.assign_as_public_input(layouter, omega)?;
+        let transcript_repr =
+            self.scalar_chip.assign_as_public_input(layouter, transcript_repr_value)?;
+
         let domain = self.derive_domain(layouter, k, omega)?;
 
         self.assemble_vk(cs, domain, transcript_repr)
@@ -262,8 +268,8 @@ impl<S: SelfEmulation> VerifierGadget<S> {
     pub fn assign_fixed_vk<PCS: InCircuitPCS<S>>(
         &self,
         layouter: &mut impl Layouter<S::F>,
-        domain: &EvaluationDomain<S::F>,
         cs: &ConstraintSystem<S::F>,
+        domain: &EvaluationDomain<S::F>,
         transcript_repr_constant: S::F,
     ) -> Result<AssignedVk<S, PCS>, Error> {
         let transcript_repr = self.scalar_chip.assign_fixed(layouter, transcript_repr_constant)?;
@@ -595,6 +601,8 @@ impl<S: SelfEmulation> VerifierGadget<S> {
         let omega_inv = &assigned_vk.domain.omega_inv;
         let n = &assigned_vk.domain.n;
         let xn = pow_2_pow_k(layouter, &self.scalar_chip, &x, k)?;
+        // Shared by all calls to `evaluate_lagrange_polynomials` below.
+        let n_inv = self.scalar_chip.inv(layouter, n)?;
 
         let instance_evals = {
             let instance_queries = cs.instance_queries();
@@ -608,7 +616,8 @@ impl<S: SelfEmulation> VerifierGadget<S> {
                 layouter,
                 &self.scalar_chip,
                 omega,
-                n,
+                omega_inv,
+                &n_inv,
                 &x,
                 &xn,
                 (-max_rotation)..(max_instance_len as i32 + min_rotation.abs()),
@@ -675,7 +684,8 @@ impl<S: SelfEmulation> VerifierGadget<S> {
             layouter,
             &self.scalar_chip,
             omega,
-            n,
+            omega_inv,
+            &n_inv,
             &x,
             &xn,
             (-((nr_blinding_factors + 1) as i32))..1,
@@ -1037,8 +1047,8 @@ pub(crate) mod tests {
 
     #[derive(Clone, Debug)]
     pub struct TestCircuit {
-        // (domain, cs, vk_repr)
-        inner_vk: (Value<EvaluationDomain<F>>, ConstraintSystem<F>, Value<F>),
+        // (cs, domain, vk_repr)
+        inner_vk: (ConstraintSystem<F>, Value<EvaluationDomain<F>>, Value<F>),
         inner_committed_instance: Value<C>,
         inner_instances: Value<[F; NB_INNER_INSTANCES]>,
         inner_proof: Value<Vec<u8>>,
@@ -1133,13 +1143,12 @@ pub(crate) mod tests {
             let verifier_chip =
                 VerifierGadget::<S>::new(&curve_chip, &native_gadget, &poseidon_chip);
 
-            let assigned_inner_vk: AssignedVk<S, InCircuitKZG<S>> = verifier_chip
-                .assign_vk_as_public_input(
-                    &mut layouter,
-                    self.inner_vk.0.clone(),
-                    &self.inner_vk.1,
-                    self.inner_vk.2,
-                )?;
+            let assigned_inner_vk: AssignedVk<S, InCircuitKZG<S>> = verifier_chip.assign_vk_as_public_input(
+                &mut layouter,
+                &self.inner_vk.0,
+                self.inner_vk.1.clone(),
+                self.inner_vk.2,
+            )?;
 
             let assigned_committed_instance =
                 AssignedKZGMultiCommitment(vec![AssignedKZGCommitment::assign(
@@ -1244,8 +1253,8 @@ pub(crate) mod tests {
 
         let circuit = TestCircuit {
             inner_vk: (
-                Value::known(inner_vk.get_domain().clone()),
                 inner_vk.cs().clone(),
+                Value::known(inner_vk.get_domain().clone()),
                 Value::known(inner_vk.transcript_repr()),
             ),
             inner_committed_instance: Value::known(C::identity()),

--- a/circuits/src/verifier/verifier_gadget.rs
+++ b/circuits/src/verifier/verifier_gadget.rs
@@ -97,7 +97,12 @@ impl<S: SelfEmulation, PCS: InCircuitPCS<S>> PublicInputInstructions<S::F, Assig
         layouter: &mut impl Layouter<S::F>,
         assigned_vk: &AssignedVk<S, PCS>,
     ) -> Result<Vec<AssignedNative<S::F>>, Error> {
-        self.scalar_chip.as_public_input(layouter, &assigned_vk.transcript_repr)
+        Ok([
+            self.scalar_chip.as_public_input(layouter, &assigned_vk.transcript_repr)?,
+            self.scalar_chip.as_public_input(layouter, assigned_vk.k())?,
+            self.scalar_chip.as_public_input(layouter, assigned_vk.omega())?,
+        ]
+        .concat())
     }
 
     fn constrain_as_public_input(

--- a/circuits/src/verifier/verifier_gadget.rs
+++ b/circuits/src/verifier/verifier_gadget.rs
@@ -31,9 +31,11 @@ use midnight_proofs::{
 use crate::{
     field::AssignedNative,
     instructions::{
-        assignments::AssignmentInstructions, ArithInstructions, PublicInputInstructions,
+        ArithInstructions, PublicInputInstructions, assignments::AssignmentInstructions
     },
     verifier::{
+        Accumulator, AssignedAccumulator, AssignedEvaluationDomain, AssignedVk, SelfEmulation,
+        VerifyingKey,
         expressions::{
             eval_expression, lookup::lookup_expressions, permutation::permutation_expressions,
             trash::trash_expressions,
@@ -44,8 +46,9 @@ use crate::{
         traces::VerifierTrace,
         transcript_gadget::TranscriptGadget,
         trash,
-        utils::{evaluate_lagrange_polynomials, inner_product, sum},
-        Accumulator, AssignedAccumulator, AssignedVk, SelfEmulation, VerifyingKey,
+        utils::{
+            evaluate_lagrange_polynomials, inner_product, pow_2_pow_k, pow_of_two, sum,
+        },
     },
 };
 
@@ -227,17 +230,63 @@ impl<S: SelfEmulation> VerifierGadget<S> {
 
 impl<S: SelfEmulation> VerifierGadget<S> {
     /// Assigns a verifying key as a public input. All the necessary information
-    /// is required off-circuit, except for the `transcript_repr` value.
+    /// is required off-circuit, except for the `transcript_repr` and the
+    /// evaluation domain.
     pub fn assign_vk_as_public_input<PCS: InCircuitPCS<S>>(
+        &self,
+        layouter: &mut impl Layouter<S::F>,
+        domain: Value<EvaluationDomain<S::F>>,
+        cs: &ConstraintSystem<S::F>,
+        transcript_repr_value: Value<S::F>,
+    ) -> Result<AssignedVk<S, PCS>, Error> {
+        let transcript_repr =
+            self.scalar_chip.assign_as_public_input(layouter, transcript_repr_value)?;
+
+        let [k, omega] = domain.map(|d| [S::F::from(d.k()as u64), d.get_omega()]).transpose_array();
+        let k = self.scalar_chip.assign_as_public_input(layouter, k)?;
+        let omega = self.scalar_chip.assign_as_public_input(layouter, omega)?;
+        let domain = self.derive_domain(layouter, k, omega)?;
+
+        self.assemble_vk(cs, domain, transcript_repr)
+    }
+
+    /// Assigns a verifying key as a constant. All the necessary information is
+    /// available off-circuit, except for the `transcript_repr` which is
+    /// "assigned fixed".
+    pub fn assign_fixed_vk<PCS: InCircuitPCS<S>>(
         &self,
         layouter: &mut impl Layouter<S::F>,
         domain: &EvaluationDomain<S::F>,
         cs: &ConstraintSystem<S::F>,
-        transcript_repr_value: Value<S::F>,
+        transcript_repr_constant: S::F,
     ) -> Result<AssignedVk<S, PCS>, Error> {
-        let transcript_repr: AssignedNative<S::F> =
-            self.scalar_chip.assign_as_public_input(layouter, transcript_repr_value)?;
+        let transcript_repr = self.scalar_chip.assign_fixed(layouter, transcript_repr_constant)?;
+        let k = self.scalar_chip.assign_fixed(layouter, S::F::from(domain.k() as u64))?;
+        let omega = self.scalar_chip.assign_fixed(layouter, domain.get_omega())?;
+        let domain = self.derive_domain(layouter, k, omega)?;
+        self.assemble_vk(cs, domain, transcript_repr)
+    }
 
+    /// Completes the assigned domain by deriving `omega_inv` and `n = 2^k` from
+    /// assigned `k` and `omega` cells (in-circuit).
+    fn derive_domain(
+        &self,
+        layouter: &mut impl Layouter<S::F>,
+        k: AssignedNative<S::F>,
+        omega: AssignedNative<S::F>,
+    ) -> Result<AssignedEvaluationDomain<S>, Error> {
+        let omega_inv = self.scalar_chip.inv(layouter, &omega)?;
+        let n = pow_of_two(layouter, &self.scalar_chip, &k)?;
+        Ok(AssignedEvaluationDomain { k, omega, omega_inv, n })
+    }
+
+    /// Builds the `AssignedVk`.
+    fn assemble_vk<PCS: InCircuitPCS<S>>(
+        &self,
+        cs: &ConstraintSystem<S::F>,
+        domain: AssignedEvaluationDomain<S>,
+        transcript_repr: AssignedNative<S::F>,
+    ) -> Result<AssignedVk<S, PCS>, Error> {
         // We expect a finalized cs with no selectors, i.e. whose selectors have been
         // converted into fixed columns. In the context of IVC, the constraint system
         // might still contain selectors.
@@ -256,48 +305,14 @@ impl<S: SelfEmulation> VerifierGadget<S> {
             .map(|i| PCS::fixed_commitment(PolynomialLabel::PermutationFixed(i)))
             .collect();
 
-        let assigned_vk = AssignedVk {
-            domain: domain.clone(),
+        Ok(AssignedVk {
+            domain,
             fixed_commitments,
             perm_commitments,
-            cs: cs.clone(),
             cs_degree: cs.degree(),
+            cs,
             transcript_repr,
-        };
-
-        Ok(assigned_vk)
-    }
-
-    /// Assigns a verifying key as a constant. All the necessary information is
-    /// available off-circuit, except for the `transcript_repr` which is
-    /// "assigned fixed".
-    pub fn assign_fixed_vk<PCS: InCircuitPCS<S>>(
-        &self,
-        layouter: &mut impl Layouter<S::F>,
-        domain: &EvaluationDomain<S::F>,
-        cs: &ConstraintSystem<S::F>,
-        transcript_repr_constant: S::F,
-    ) -> Result<AssignedVk<S, PCS>, Error> {
-        let transcript_repr = self.scalar_chip.assign_fixed(layouter, transcript_repr_constant)?;
-
-        let fixed_commitments = (0..cs.num_fixed_columns() + cs.num_selectors())
-            .map(|i| PCS::fixed_commitment(PolynomialLabel::Fixed(i)))
-            .collect();
-
-        let perm_commitments = (0..cs.permutation().columns.len())
-            .map(|i| PCS::fixed_commitment(PolynomialLabel::PermutationFixed(i)))
-            .collect();
-
-        let assigned_vk = AssignedVk {
-            domain: domain.clone(),
-            fixed_commitments,
-            perm_commitments,
-            cs: cs.clone(),
-            cs_degree: cs.degree(),
-            transcript_repr,
-        };
-
-        Ok(assigned_vk)
+        })
     }
 }
 
@@ -520,7 +535,7 @@ impl<S: SelfEmulation> VerifierGadget<S> {
         mut transcript: TranscriptGadget<S>,
     ) -> Result<AssignedAccumulator<S>, Error> {
         let cs = &assigned_vk.cs;
-        let k = assigned_vk.domain.k();
+        let k = &assigned_vk.domain.k;
         let nb_committed_instances = assigned_committed_instances.len();
 
         let VerifierTrace {
@@ -540,7 +555,7 @@ impl<S: SelfEmulation> VerifierGadget<S> {
         // commits to h(X) as a single polynomial (one commitment); otherwise it
         // splits h(X) into `quotient_poly_degree` limbs (one commitment each).
         #[cfg(not(feature = "single-h-commitment"))]
-        let nb_quotient_coms = assigned_vk.domain.get_quotient_poly_degree();
+        let nb_quotient_coms = assigned_vk.cs_degree - 1;
         #[cfg(feature = "single-h-commitment")]
         let nb_quotient_coms = 1;
         let limb_commitments = {
@@ -565,6 +580,11 @@ impl<S: SelfEmulation> VerifierGadget<S> {
         // high probability
         let x = transcript.squeeze_challenge(layouter)?;
 
+        let omega = &assigned_vk.domain.omega;
+        let omega_inv = &assigned_vk.domain.omega_inv;
+        let n = &assigned_vk.domain.n;
+        let xn = pow_2_pow_k(layouter, &self.scalar_chip, &x, k)?;
+
         let instance_evals = {
             let instance_queries = cs.instance_queries();
             let min_rotation = instance_queries.iter().map(|(_, rot)| rot.0).min().unwrap();
@@ -576,10 +596,11 @@ impl<S: SelfEmulation> VerifierGadget<S> {
             let l_i_s = evaluate_lagrange_polynomials(
                 layouter,
                 &self.scalar_chip,
-                1 << k,
-                assigned_vk.domain.get_omega(),
-                (-max_rotation)..(max_instance_len as i32 + min_rotation.abs()),
+                omega,
+                n,
                 &x,
+                &xn,
+                (-max_rotation)..(max_instance_len as i32 + min_rotation.abs()),
             )?;
 
             instance_queries
@@ -642,10 +663,11 @@ impl<S: SelfEmulation> VerifierGadget<S> {
         let l_evals = evaluate_lagrange_polynomials(
             layouter,
             &self.scalar_chip,
-            1 << k,
-            assigned_vk.domain.get_omega(),
-            (-((nr_blinding_factors + 1) as i32))..1,
+            omega,
+            n,
             &x,
+            &xn,
+            (-((nr_blinding_factors + 1) as i32))..1,
         )?;
         assert_eq!(l_evals.len(), 2 + nr_blinding_factors);
         let l_last = l_evals[0].clone();
@@ -751,9 +773,7 @@ impl<S: SelfEmulation> VerifierGadget<S> {
             .into_iter()
             .for_each(|trash_id| expressions.push((None, trash_id)));
 
-        let splitting_factor =
-            ArithInstructions::pow(&self.scalar_chip, layouter, &x, (1 << k) - 1)?;
-        let xn = self.scalar_chip.mul(layouter, &x, &splitting_factor, None)?;
+        let splitting_factor = self.scalar_chip.div(layouter, &xn, &x)?;
 
         let (lin_commitment, lin_eval) = Self::compute_linearization_commitment(
             layouter,
@@ -766,12 +786,11 @@ impl<S: SelfEmulation> VerifierGadget<S> {
             &limb_commitments,
         )?;
 
-        let omega = assigned_vk.domain.get_omega();
-        let omega_inv = omega.invert().unwrap();
-        let omega_last = omega_inv.pow([cs.blinding_factors() as u64 + 1]);
-        let x_next = self.scalar_chip.mul_by_constant(layouter, &x, omega)?;
-        let x_prev = self.scalar_chip.mul_by_constant(layouter, &x, omega_inv)?;
-        let x_last = self.scalar_chip.mul_by_constant(layouter, &x, omega_last)?;
+        let omega_last =
+            self.scalar_chip.pow(layouter, omega_inv, cs.blinding_factors() as u64 + 1)?;
+        let x_next = self.scalar_chip.mul(layouter, &x, omega, None)?;
+        let x_prev = self.scalar_chip.mul(layouter, &x, omega_inv, None)?;
+        let x_last = self.scalar_chip.mul(layouter, &x, &omega_last, None)?;
 
         // Gets the evaluation point for a query at the given rotation.
         let get_point = |rotation: &Rotation| -> &AssignedNative<S::F> {
@@ -1007,7 +1026,7 @@ pub(crate) mod tests {
 
     #[derive(Clone, Debug)]
     pub struct TestCircuit {
-        inner_vk: (EvaluationDomain<F>, ConstraintSystem<F>, Value<F>), // (domain, cs, vk_repr)
+        inner_vk: (Value<EvaluationDomain<F>>, ConstraintSystem<F>, Value<F>), // (domain, cs, vk_repr)
         inner_committed_instance: Value<C>,
         inner_instances: Value<[F; NB_INNER_INSTANCES]>,
         inner_proof: Value<Vec<u8>>,
@@ -1105,7 +1124,7 @@ pub(crate) mod tests {
             let assigned_inner_vk: AssignedVk<S, InCircuitKZG<S>> = verifier_chip
                 .assign_vk_as_public_input(
                     &mut layouter,
-                    &self.inner_vk.0,
+                    self.inner_vk.0.clone(),
                     &self.inner_vk.1,
                     self.inner_vk.2,
                 )?;
@@ -1213,7 +1232,7 @@ pub(crate) mod tests {
 
         let circuit = TestCircuit {
             inner_vk: (
-                inner_vk.get_domain().clone(),
+                Value::known(inner_vk.get_domain().clone()),
                 inner_vk.cs().clone(),
                 Value::known(inner_vk.transcript_repr()),
             ),

--- a/circuits/src/verifier/verifier_gadget.rs
+++ b/circuits/src/verifier/verifier_gadget.rs
@@ -34,8 +34,6 @@ use crate::{
         assignments::AssignmentInstructions, ArithInstructions, PublicInputInstructions,
     },
     verifier::{
-        Accumulator, AssignedAccumulator, AssignedEvaluationDomain, AssignedVk, SelfEmulation,
-        VerifyingKey,
         expressions::{
             eval_expression, lookup::lookup_expressions, permutation::permutation_expressions,
             trash::trash_expressions,
@@ -46,9 +44,9 @@ use crate::{
         traces::VerifierTrace,
         transcript_gadget::TranscriptGadget,
         trash,
-        utils::{
-            evaluate_lagrange_polynomials, inner_product, pow_2_pow_k, pow_of_two, sum,
-        },
+        utils::{evaluate_lagrange_polynomials, inner_product, pow_2_pow_k, pow_of_two, sum},
+        Accumulator, AssignedAccumulator, AssignedEvaluationDomain, AssignedVk, SelfEmulation,
+        VerifyingKey,
     },
 };
 
@@ -1143,12 +1141,13 @@ pub(crate) mod tests {
             let verifier_chip =
                 VerifierGadget::<S>::new(&curve_chip, &native_gadget, &poseidon_chip);
 
-            let assigned_inner_vk: AssignedVk<S, InCircuitKZG<S>> = verifier_chip.assign_vk_as_public_input(
-                &mut layouter,
-                &self.inner_vk.0,
-                self.inner_vk.1.clone(),
-                self.inner_vk.2,
-            )?;
+            let assigned_inner_vk: AssignedVk<S, InCircuitKZG<S>> = verifier_chip
+                .assign_vk_as_public_input(
+                    &mut layouter,
+                    &self.inner_vk.0,
+                    self.inner_vk.1.clone(),
+                    self.inner_vk.2,
+                )?;
 
             let assigned_committed_instance =
                 AssignedKZGMultiCommitment(vec![AssignedKZGCommitment::assign(


### PR DESCRIPTION
Closes #458 

This PR treats the domain (concretely `k` and `w`) as proof runtime variables, rather than circuit compile time variables. The regression is 750 rows.

```diff
CircuitModel {
    k: 17,
-   rows: 120830,
+   rows: 121580,
    table_rows: 122899,
    nb_unusable_rows: 11,
    max_deg: 5,
    advice_columns: 15,
    fixed_columns: 49,
    lookups: 2,
    trashcans: 1,
    permutations: 18,
    column_queries: 52,
    point_sets: 5,
    size: 5264,
}
```

