### PR TITLE
Vector gadget improvements.

### DIFF
--- a/circuits/CHANGELOG.md
+++ b/circuits/CHANGELOG.md
@@ -11,6 +11,7 @@ We use [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 * `Point`/`AssignedPoint` enums and flat-triple `Msm`/`AssignedMsm` representation to distinguish variable-base from globally-fixed bases [#430](https://github.com/midnightntwrk/midnight-zk/pull/430)
 * `AssignedKZGCommitment` enum as the in-circuit analog of `KZGCommitment` [#430](https://github.com/midnightntwrk/midnight-zk/pull/430)
 * `fixed_base_msm` on the foreign Edwards chip: public fixed-base MSM for compile-time-constant bases, backed by the internal Lim-Lee comb `fixed_base_comb_msm` with a fixed comb width [#467](https://github.com/midnightntwrk/midnight-zk/pull/467)
+* Add tests compile time generics checks for `VectorGadget` and tests for `resize` [#464](https://github.com/midnightntwrk/midnight-zk/pull/465)
 
 ### Fixed
 * Fix cost model to pass correct number of committed instances [#280](https://github.com/midnightntwrk/midnight-zk/pull/280)

--- a/circuits/src/hash/poseidon/poseidon_varlen.rs
+++ b/circuits/src/hash/poseidon/poseidon_varlen.rs
@@ -131,7 +131,7 @@ impl<F: PoseidonField> VarLenPoseidonGadget<F> {
     ) -> Result<AssignedNative<F>, Error> {
         assert_eq!(MAX_LEN % RATE, 0);
         let ng = &self.native_gadget;
-        let len = &input.len;
+        let len = input.len();
 
         ng.assert_lower_than_fixed(layouter, len, &BigUint::from(MAX_LEN + 1))?;
 
@@ -156,7 +156,7 @@ impl<F: PoseidonField> VarLenPoseidonGadget<F> {
             ng.select(layouter, &is_zero, &len_round, &len_round_extra)
         }?;
 
-        for (i, chunk) in input.buffer.chunks(RATE).enumerate() {
+        for (i, chunk) in input.buffer().chunks(RATE).enumerate() {
             // Determines when we have arrived at the first chunk of input.
             let b = ng.is_equal_to_fixed(
                 layouter,

--- a/circuits/src/hash/sha256/sha256_varlen.rs
+++ b/circuits/src/hash/sha256/sha256_varlen.rs
@@ -263,13 +263,13 @@ impl<F: CircuitField> VarLenSha256Gadget<F> {
         let ng = self.ng();
 
         // Compute the block where the effective data starts.
-        let (final_block_len, extra_block) = self.final_block_len::<M>(layouter, &inputs.len)?;
+        let (final_block_len, extra_block) = self.final_block_len::<M>(layouter, inputs.len())?;
 
         // Length of the input rounded up to the chunk size.
         let rounded_len = {
             let fc_len = ng.element_of_bounded(layouter, &final_block_len)?;
             let is_zero = ng.is_zero(layouter, &fc_len)?;
-            let len_round = ng.sub(layouter, &inputs.len, &fc_len)?;
+            let len_round = ng.sub(layouter, inputs.len(), &fc_len)?;
             let len_round_extra = ng.add_constant(layouter, &len_round, F::from(64u64))?;
             ng.select(layouter, &is_zero, &len_round, &len_round_extra)
         }?;
@@ -281,7 +281,7 @@ impl<F: CircuitField> VarLenSha256Gadget<F> {
         let mut state = CompressionState::<F>::fixed(layouter, ng, IV)?;
 
         // Process input in chunks.
-        let mut block_iter = inputs.buffer.chunks_exact(64);
+        let mut block_iter = inputs.buffer().chunks_exact(64);
         let mut block = block_iter.next().expect("At least one block.");
 
         // Conditional update loop. Stops 1 chunk before the end.
@@ -306,7 +306,7 @@ impl<F: CircuitField> VarLenSha256Gadget<F> {
         // Padding
         let padding_data = self.compute_padding(
             layouter,
-            &inputs.len,
+            inputs.len(),
             &final_block_len,
             final_block,
             &extra_block,

--- a/circuits/src/parsing/base64_chip.rs
+++ b/circuits/src/parsing/base64_chip.rs
@@ -182,10 +182,7 @@ impl<F: CircuitField, const M: usize, const A: usize> Base64VarInstructions<F, M
             .collect::<Result<Vec<_>, Error>>()?
             .try_into()
             .unwrap();
-        Ok(Base64Vec(AssignedVector {
-            buffer: result,
-            len: vec.len.clone(),
-        }))
+        Ok(Base64Vec(AssignedVector::new(result, vec.len.clone())))
     }
 
     fn var_decode_base64url<const M_OUT: usize, const A_OUT: usize>(
@@ -195,10 +192,10 @@ impl<F: CircuitField, const M: usize, const A: usize> Base64VarInstructions<F, M
     ) -> Result<AssignedVector<F, AssignedByte<F>, M_OUT, A_OUT>, Error> {
         let vec = self.url_to_standard(layouter, &*b64url_input.0.buffer)?;
 
-        let b64_input = Base64Vec::<F, M, A>(AssignedVector {
-            buffer: Box::new(vec.try_into().unwrap()),
-            len: b64url_input.0.len.clone(),
-        });
+        let b64_input = Base64Vec::<F, M, A>(AssignedVector::new(
+            Box::new(vec.try_into().unwrap()),
+            b64url_input.0.len.clone(),
+        ));
 
         self.var_decode_base64(layouter, &b64_input)
     }

--- a/circuits/src/parsing/base64_chip.rs
+++ b/circuits/src/parsing/base64_chip.rs
@@ -157,7 +157,7 @@ impl<F: CircuitField, const M: usize, const A: usize> Base64VarInstructions<F, M
 
         let check = ng.linear_combination(
             layouter,
-            &[(F::from(4u64), q), (-F::ONE, vec.len.clone())],
+            &[(F::from(4u64), q), (-F::ONE, vec.len().clone())],
             F::ZERO,
         )?;
         ng.assert_zero(layouter, &check)?;
@@ -175,14 +175,14 @@ impl<F: CircuitField, const M: usize, const A: usize> Base64VarInstructions<F, M
         let filler = ng.assign_fixed(layouter, ALT_PAD as u8)?;
         let (flags, _limits) = vg.padding_flag(layouter, vec)?;
         let result = vec
-            .buffer
+            .buffer()
             .iter()
             .zip(flags.iter())
             .map(|(elem, is_padding)| ng.select(layouter, is_padding, &filler, elem))
             .collect::<Result<Vec<_>, Error>>()?
             .try_into()
             .unwrap();
-        Ok(Base64Vec(AssignedVector::new(result, vec.len.clone())))
+        Ok(Base64Vec(AssignedVector::new(result, vec.len().clone())))
     }
 
     fn var_decode_base64url<const M_OUT: usize, const A_OUT: usize>(
@@ -190,11 +190,11 @@ impl<F: CircuitField, const M: usize, const A: usize> Base64VarInstructions<F, M
         layouter: &mut impl Layouter<F>,
         b64url_input: &Base64Vec<F, M, A>,
     ) -> Result<AssignedVector<F, AssignedByte<F>, M_OUT, A_OUT>, Error> {
-        let vec = self.url_to_standard(layouter, &*b64url_input.0.buffer)?;
+        let vec = self.url_to_standard(layouter, b64url_input.0.buffer())?;
 
         let b64_input = Base64Vec::<F, M, A>(AssignedVector::new(
             Box::new(vec.try_into().unwrap()),
-            b64url_input.0.len.clone(),
+            b64url_input.0.len().clone(),
         ));
 
         self.var_decode_base64(layouter, &b64_input)
@@ -215,7 +215,7 @@ impl<F: CircuitField, const M: usize, const A: usize> Base64VarInstructions<F, M
         // Compute and constrain new length.
         let three = F::from(3u64);
         let four = F::from(4u64);
-        let len = &b64_input.0.len;
+        let len = b64_input.0.len();
 
         let new_len: AssignedNative<F> = {
             let len_value = len.value().map(|&l| l * four.invert().unwrap() * three);
@@ -230,12 +230,12 @@ impl<F: CircuitField, const M: usize, const A: usize> Base64VarInstructions<F, M
         self.native_gadget.assert_zero(layouter, &check)?;
 
         // Compute decoded buffer.
-        let out_buffer = self.decode_base64(layouter, &*b64_input.0.buffer, true)?;
+        let out_buffer = self.decode_base64(layouter, b64_input.0.buffer(), true)?;
 
-        Ok(AssignedVector::<_, _, M_OUT, A_OUT> {
-            buffer: Box::new(out_buffer.try_into().unwrap()),
-            len: new_len,
-        })
+        Ok(AssignedVector::new(
+            Box::new(out_buffer.try_into().unwrap()),
+            new_len,
+        ))
     }
 }
 

--- a/circuits/src/parsing/scanner/automaton_chip.rs
+++ b/circuits/src/parsing/scanner/automaton_chip.rs
@@ -449,10 +449,10 @@ where
         // and hit the self-loop transitions (added during NativeAutomaton
         // construction), outputting marker 0.
         let buffer = self.parse_automaton(layouter, &automaton, &*input.buffer)?;
-        Ok(AssignedVector {
-            buffer: Box::new(buffer.try_into().unwrap()),
-            len: input.len().clone(),
-        })
+        Ok(AssignedVector::new(
+            Box::new(buffer.try_into().unwrap()),
+            input.len().clone(),
+        ))
     }
 }
 

--- a/circuits/src/parsing/scanner/automaton_chip.rs
+++ b/circuits/src/parsing/scanner/automaton_chip.rs
@@ -1082,7 +1082,7 @@ mod test {
             )?;
 
             // Pointwise equality on the full buffer.
-            for (out_cell, exp_cell) in parsed.buffer.iter().zip(expected.iter()) {
+            for (out_cell, exp_cell) in parsed.buffer().iter().zip(expected.iter()) {
                 ng.assert_equal(&mut layouter, out_cell, exp_cell)?;
             }
 

--- a/circuits/src/parsing/scanner/varlen.rs
+++ b/circuits/src/parsing/scanner/varlen.rs
@@ -81,10 +81,7 @@ impl<F: CircuitField, const M: usize, const A: usize> From<ScannerVec<F, M, A>>
     for AssignedVector<F, AssignedNative<F>, M, A>
 {
     fn from(value: ScannerVec<F, M, A>) -> Self {
-        AssignedVector {
-            buffer: value.buffer,
-            len: value.length,
-        }
+        AssignedVector::new(value.buffer, value.length)
     }
 }
 
@@ -118,10 +115,10 @@ where
             })
             .collect::<Result<Vec<_>, Error>>()?;
 
-        Ok(AssignedVector {
-            buffer: Box::new(byte_buffer.try_into().unwrap()),
-            len: sv.length.clone(),
-        })
+        Ok(AssignedVector::new(
+            Box::new(byte_buffer.try_into().unwrap()),
+            sv.length.clone(),
+        ))
     }
 
     /// Assigns a variable-length byte vector as a `ScannerVec`.

--- a/circuits/src/parsing/scanner/varlen.rs
+++ b/circuits/src/parsing/scanner/varlen.rs
@@ -155,7 +155,7 @@ where
         let filler =
             self.native_gadget.assign_fixed(layouter, F::from(ALPHABET_MAX_SIZE as u64))?;
         let buffer: Box<[AssignedNative<F>; M]> = Box::new(
-            (vec.buffer.iter().zip(padding_flags.iter()))
+            (vec.buffer().iter().zip(padding_flags.iter()))
                 .map(|(elem, is_padding)| {
                     let native_elem = AssignedNative::from(elem);
                     self.native_gadget.select(layouter, is_padding, &filler, &native_elem)
@@ -166,7 +166,7 @@ where
         );
 
         Ok(ScannerVec {
-            length: vec.len,
+            length: vec.len().clone(),
             buffer,
             limits,
             padding_flags,

--- a/circuits/src/vec/vector.rs
+++ b/circuits/src/vec/vector.rs
@@ -35,13 +35,13 @@ use crate::{
 /// sized chunks. The padding at the end of the payload will have a size in
 /// [0, A) such that | front_pad | + | payload | + | back_pad | = M.
 ///
-/// **Invariant: `M` must be a multiple of `A`** (and `A > 0`, `M >= A`).
-/// Several operations (`padding_flag`, `get_limits`, hashing, …) rely on this
-/// to guarantee that the buffer decomposes into exactly `M / A` full chunks
-/// and that a full-capacity vector (`len == M`) can always be placed without
-/// overflow. This is enforced by the entry points
-/// [`assign_with_filler`](crate::instructions::VectorInstructions::assign_with_filler) and
-/// [`assign`](crate::instructions::AssignmentInstructions::assign).
+/// **Invariant: `A > 0`, `A <= M`, and `M` is a multiple of `A`.** Several
+/// operations (`padding_flag`, `get_limits`, hashing, …) rely on this to
+/// guarantee that the buffer decomposes into exactly `M / A` full chunks and
+/// that a full-capacity vector (`len == M`) can always be placed without
+/// overflow.
+/// The invariant is checked at compile time  by [`AssignedVector::new`],
+/// which is the constructor every `AssignedVector` should be built through.
 #[derive(Clone, Debug)]
 pub struct AssignedVector<F: CircuitField, T: Vectorizable, const M: usize, const A: usize> {
     /// Padded payload of the vector. Boxed to keep large buffers
@@ -52,8 +52,31 @@ pub struct AssignedVector<F: CircuitField, T: Vectorizable, const M: usize, cons
     pub(crate) len: AssignedNative<F>,
 }
 
+impl<F: CircuitField, T: Vectorizable, const M: usize, const A: usize> AssignedVector<F, T, M, A> {
+    /// Construct an `AssignedVector` from an already-assigned `buffer` and
+    /// `len`.
+    ///
+    /// This is the single entry point for building an `AssignedVector`; it
+    /// enforces the type invariant `0 < A <= M` and `A | M` at compile time.
+    pub(crate) fn new(buffer: Box<[T; M]>, len: AssignedNative<F>) -> Self {
+        const {
+            assert!(
+                A > 0 && M >= A && M % A == 0,
+                "AssignedVector requires 0 < A <= M and A | M."
+            )
+        };
+        Self { buffer, len }
+    }
+}
+
 /// Returns the range where the data should be placed in the buffer.
 pub fn get_lims<const M: usize, const A: usize>(len: usize) -> Range<usize> {
+    const {
+        assert!(
+            A > 0 && M >= A && M % A == 0,
+            "AssignedVector requires 0 < A <= M and A | M."
+        )
+    };
     let final_pad_len = (A - (len % A)) % A;
     M - len - final_pad_len..M - final_pad_len
 }

--- a/circuits/src/vec/vector.rs
+++ b/circuits/src/vec/vector.rs
@@ -65,13 +65,11 @@ impl<F: CircuitField, const M: usize, T: Vectorizable, const A: usize> InnerValu
 
     fn value(&self) -> Value<Self::Element> {
         let data = Value::<Vec<T::Element>>::from_iter(self.buffer.iter().map(|v| v.value()));
-        let idxs: Value<_> = self.len.value().map(|len| {
+        let range = self.len.value().map(|len| {
             let len: usize = len.to_biguint().try_into().unwrap();
-
-            let end_pad = (A - (len % A)) % A;
-            (M - len - end_pad, M - end_pad)
+            get_lims::<M, A>(len)
         });
-        data.zip(idxs).map(|(data, idxs)| data[idxs.0..idxs.1].to_vec())
+        data.zip(range).map(|(data, range)| data[range].to_vec())
     }
 }
 

--- a/circuits/src/vec/vector.rs
+++ b/circuits/src/vec/vector.rs
@@ -61,7 +61,7 @@ impl<F: CircuitField, T: Vectorizable, const M: usize, const A: usize> AssignedV
     pub(crate) fn new(buffer: Box<[T; M]>, len: AssignedNative<F>) -> Self {
         const {
             assert!(
-                A > 0 && M >= A && M % A == 0,
+                A > 0 && M >= A && M.is_multiple_of(A),
                 "AssignedVector requires 0 < A <= M and A | M."
             )
         };
@@ -73,7 +73,7 @@ impl<F: CircuitField, T: Vectorizable, const M: usize, const A: usize> AssignedV
 pub fn get_lims<const M: usize, const A: usize>(len: usize) -> Range<usize> {
     const {
         assert!(
-            A > 0 && M >= A && M % A == 0,
+            A > 0 && M >= A && M.is_multiple_of(A),
             "AssignedVector requires 0 < A <= M and A | M."
         )
     };

--- a/circuits/src/vec/vector.rs
+++ b/circuits/src/vec/vector.rs
@@ -46,10 +46,10 @@ use crate::{
 pub struct AssignedVector<F: CircuitField, T: Vectorizable, const M: usize, const A: usize> {
     /// Padded payload of the vector. Boxed to keep large buffers
     /// off the stack.
-    pub(crate) buffer: Box<[T; M]>,
+    buffer: Box<[T; M]>,
 
     /// Effective length of the vector.
-    pub(crate) len: AssignedNative<F>,
+    len: AssignedNative<F>,
 }
 
 impl<F: CircuitField, T: Vectorizable, const M: usize, const A: usize> AssignedVector<F, T, M, A> {
@@ -66,6 +66,21 @@ impl<F: CircuitField, T: Vectorizable, const M: usize, const A: usize> AssignedV
             )
         };
         Self { buffer, len }
+    }
+
+    pub(crate) fn buffer(&self) -> &[T; M] {
+        &self.buffer
+    }
+
+    pub(crate) fn len(&self) -> &AssignedNative<F> {
+        &self.len
+    }
+
+    #[cfg(test)]
+    // Mutates buffer at position i.
+    // Only intended for testing.
+    pub(crate) fn mutate_buffer(&mut self, value: T, pos: usize) {
+        self.buffer[pos] = value;
     }
 }
 

--- a/circuits/src/vec/vector_gadget.rs
+++ b/circuits/src/vec/vector_gadget.rs
@@ -612,6 +612,66 @@ mod tests {
         }
     }
 
+    // Dedicated circuit for `resize`, which changes the size const generic `M -> L`.
+    struct ResizeTestCircuit<F: CircuitField, const M: usize, const A: usize, const L: usize> {
+        input: Vec<F>,
+    }
+
+    impl<F: CircuitField, const M: usize, const A: usize, const L: usize> Circuit<F>
+        for ResizeTestCircuit<F, M, A, L>
+    {
+        type Config = P2RDecompositionConfig;
+
+        type FloorPlanner = SimpleFloorPlanner;
+
+        type Params = ();
+
+        fn without_witnesses(&self) -> Self {
+            unreachable!();
+        }
+
+        fn configure(meta: &mut ConstraintSystem<F>) -> Self::Config {
+            let comm_ic = meta.instance_column();
+            let instance_column = meta.instance_column();
+            NativeGadget::configure_from_scratch(
+                meta,
+                &mut vec![],
+                &mut vec![],
+                &[comm_ic, instance_column],
+            )
+        }
+
+        fn synthesize(
+            &self,
+            config: Self::Config,
+            mut layouter: impl Layouter<F>,
+        ) -> Result<(), Error> {
+            let ng = NG::<F>::new_from_scratch(&config);
+            let vg = VectorGadget::new(&ng);
+
+            let vec_m: AssignedVector<F, AssignedNative<F>, M, A> =
+                vg.assign(&mut layouter, Value::known(self.input.clone()))?;
+            let vec_l: AssignedVector<F, AssignedNative<F>, L, A> =
+                vg.resize::<L>(&mut layouter, vec_m)?;
+
+            // The resized vector must have the same logical value (data and length)
+            // as the input, now placed in an `L`-sized, `A`-aligned buffer.
+            vg.assert_equal_to_fixed(&mut layouter, &vec_l, self.input.clone())?;
+
+            ng.load_from_scratch(&mut layouter)
+        }
+    }
+
+    fn run_resize_vec_test<F, const M: usize, const A: usize, const L: usize>(input: &[F])
+    where
+        F: CircuitField + FromUniformBytes<64> + Ord,
+    {
+        let circuit = ResizeTestCircuit::<F, M, A, L> {
+            input: input.to_vec(),
+        };
+        MockProver::run(&circuit, vec![vec![], vec![]]).unwrap().assert_satisfied();
+    }
+
     fn run_eq_vec_test<F, const M: usize, const A: usize>(
         input_1: &[F],
         input_2: &[F],
@@ -825,5 +885,22 @@ mod tests {
 
         // The particular case of the credentials:
         run_trim_vec_test::<_, 128, 64>(&inputs, 39, false);
+    }
+
+    #[test]
+    fn vector_resize() {
+        type F = midnight_curves::Fq;
+
+        // Create a random number generator
+        let mut rng = ChaCha12Rng::seed_from_u64(0xdeadcafe);
+        let inputs = (0..100).map(|_| F::random(&mut rng)).collect::<Vec<_>>();
+
+        // Grow with different source lengths and alignments.
+        run_resize_vec_test::<_, 64, 2, 128>(&inputs[..40]); // partial, back padding
+        run_resize_vec_test::<_, 64, 2, 128>(&inputs[..64]); // full source vector
+        run_resize_vec_test::<F, 64, 2, 128>(&[]); // empty source vector
+        run_resize_vec_test::<_, 66, 3, 126>(&inputs[..50]); // A = 3
+        run_resize_vec_test::<_, 64, 64, 128>(&inputs[..30]); // single-chunk source (A = M)
+        run_resize_vec_test::<_, 64, 16, 256>(&inputs[..48]); // larger growth
     }
 }

--- a/circuits/src/vec/vector_gadget.rs
+++ b/circuits/src/vec/vector_gadget.rs
@@ -89,10 +89,7 @@ where
         let buffer: Box<[T; L]> =
             Box::new([extra_pad.as_slice(), input.buffer.as_slice()].concat().try_into().unwrap());
 
-        Ok(AssignedVector {
-            buffer,
-            len: input.len.clone(),
-        })
+        Ok(AssignedVector::new(buffer, input.len.clone()))
     }
 
     fn assign_with_filler(
@@ -101,18 +98,11 @@ where
         value: Value<Vec<T::Element>>,
         filler: Option<T::Element>,
     ) -> Result<AssignedVector<F, T, M, A>, Error> {
-        assert!(M >= A, "AssignedVector requires M >= A (got M={M}, A={A})");
-        assert!(A > 0, "AssignedVector requires A positive (A={A})");
-        assert!(
-            M.is_multiple_of(A),
-            "AssignedVector requires M % A == 0 (got M={M}, A={A})"
-        );
         let ng = &self.native_gadget;
         let filler = filler.unwrap_or(T::FILLER);
         let (data_val, len_val) = value
             .map(|v| {
-                // `v` needs to be at most `M - M % A`, i.e., `M` since we require above that it
-                // is a multiple of `A`.
+                // `v` needs to be at most `M`, which is a multiple of `A` by invariant.
                 assert!(v.len() <= M);
                 let len = F::from(v.len() as u64);
                 let mut buffer = [filler; M];
@@ -127,7 +117,7 @@ where
                 .expect("Length mismatch in AssignedVector."),
         );
         let len = ng.assign_lower_than_fixed(layouter, len_val, &(M + 1).into())?;
-        Ok(AssignedVector { buffer: data, len })
+        Ok(AssignedVector::new(data, len))
     }
 
     fn padding_flag(
@@ -167,6 +157,12 @@ where
         layouter: &mut impl Layouter<F>,
         input: &AssignedVector<F, T, M, A>,
     ) -> Result<(AssignedNative<F>, AssignedNative<F>), Error> {
+        const {
+            assert!(
+                A > 0 && M >= A && M % A == 0,
+                "AssignedVector requires 0 < A <= M and A | M."
+            )
+        };
         let ng = &self.native_gadget;
         let end: AssignedNative<F> = {
             // The last data position within the last chunk. Value in [0, A);
@@ -252,7 +248,7 @@ where
         // Compute final length.
         let len = ng.add_constant(layouter, &input.len, -F::from(n_elems as u64))?;
 
-        Ok(AssignedVector { buffer, len })
+        Ok(AssignedVector::new(buffer, len))
     }
 }
 

--- a/circuits/src/vec/vector_gadget.rs
+++ b/circuits/src/vec/vector_gadget.rs
@@ -79,7 +79,7 @@ where
         layouter: &mut impl Layouter<F>,
         input: AssignedVector<F, T, M, A>,
     ) -> Result<AssignedVector<F, T, L, A>, Error> {
-        assert_eq!(L % A, 0);
+        assert!(L.is_multiple_of(A));
         assert!(L > M);
 
         let extra_pad = self
@@ -159,7 +159,7 @@ where
     ) -> Result<(AssignedNative<F>, AssignedNative<F>), Error> {
         const {
             assert!(
-                A > 0 && M >= A && M % A == 0,
+                A > 0 && M >= A && M.is_multiple_of(A),
                 "AssignedVector requires 0 < A <= M and A | M."
             )
         };
@@ -608,7 +608,8 @@ mod tests {
         }
     }
 
-    // Dedicated circuit for `resize`, which changes the size const generic `M -> L`.
+    // Dedicated circuit for `resize`, which changes the size const generic `M ->
+    // L`.
     struct ResizeTestCircuit<F: CircuitField, const M: usize, const A: usize, const L: usize> {
         input: Vec<F>,
     }

--- a/circuits/src/vec/vector_gadget.rs
+++ b/circuits/src/vec/vector_gadget.rs
@@ -86,10 +86,11 @@ where
             .native_gadget
             .assign_many(layouter, &vec![Value::known(T::FILLER); L - M])?;
 
-        let buffer: Box<[T; L]> =
-            Box::new([extra_pad.as_slice(), input.buffer.as_slice()].concat().try_into().unwrap());
+        let buffer: Box<[T; L]> = Box::new(
+            [extra_pad.as_slice(), input.buffer().as_slice()].concat().try_into().unwrap(),
+        );
 
-        Ok(AssignedVector::new(buffer, input.len.clone()))
+        Ok(AssignedVector::new(buffer, input.len().clone()))
     }
 
     fn assign_with_filler(
@@ -167,7 +168,7 @@ where
         let end: AssignedNative<F> = {
             // The last data position within the last chunk. Value in [0, A);
             // 0 means the last chunk is full, all its positions are data.
-            let offset = ng.rem(layouter, &input.len, A.into(), Some(M.into()))?;
+            let offset = ng.rem(layouter, input.len(), A.into(), Some(M.into()))?;
 
             // if offset != 0.  End = M - (A - offset).
             let end1 = ng.add_constant(layouter, &offset, F::from(M as u64 - A as u64))?;
@@ -178,7 +179,7 @@ where
         }?;
 
         // The index where the data starts.
-        let start: AssignedNative<F> = ng.sub(layouter, &end, &input.len)?;
+        let start: AssignedNative<F> = ng.sub(layouter, &end, input.len())?;
 
         Ok((start, end))
     }
@@ -193,8 +194,11 @@ where
         let a_max_bits = (usize::BITS - A.leading_zeros()) as usize;
 
         // Assert input.len >= n_elems.
-        let len_complement =
-            ng.linear_combination(layouter, &[(-F::ONE, input.len.clone())], F::from(M as u64))?;
+        let len_complement = ng.linear_combination(
+            layouter,
+            &[(-F::ONE, input.len().clone())],
+            F::from(M as u64),
+        )?;
         ng.assert_lower_than_fixed(layouter, &len_complement, &BigUint::from(M + 1 - n_elems))?;
 
         // We divide the number of elements to be trimmed in 2 parts.
@@ -208,7 +212,7 @@ where
         let last_trim = n_elems % A;
 
         // Length of last chunk ( or 0 if it is full ).
-        let last_len = ng.rem(layouter, &input.len, A.into(), Some(M.into()))?;
+        let last_len = ng.rem(layouter, input.len(), A.into(), Some(M.into()))?;
 
         // `modulus` already ensures last_len is in [0, A), so unsafe conversion can be
         // used here.
@@ -233,7 +237,7 @@ where
         // right to adjust the padding at the end.
         let buffer = {
             let filler = ng.assign_many_fixed(layouter, &vec![T::FILLER; A + last_trim])?;
-            [&filler[..A], &input.buffer[last_trim..], &filler[A..]].concat()
+            [&filler[..A], &input.buffer()[last_trim..], &filler[A..]].concat()
         };
         debug_assert_eq!(buffer.len(), M + A);
 
@@ -246,7 +250,7 @@ where
         );
 
         // Compute final length.
-        let len = ng.add_constant(layouter, &input.len, -F::from(n_elems as u64))?;
+        let len = ng.add_constant(layouter, input.len(), -F::from(n_elems as u64))?;
 
         Ok(AssignedVector::new(buffer, len))
     }
@@ -301,7 +305,7 @@ where
             .padding_flag(layouter, x)?
             .0
             .into_iter()
-            .zip(x.buffer.iter().zip(y.buffer.iter()))
+            .zip(x.buffer().iter().zip(y.buffer().iter()))
             .map(|(is_padding, (a, b))| {
                 let a_eq_b = ng.is_equal(layouter, a, b)?;
                 ng.or(layouter, &[is_padding, a_eq_b])
@@ -309,7 +313,7 @@ where
             .collect::<Result<Vec<_>, Error>>()?;
 
         // Check lengths are equal.
-        let len_check = ng.is_equal(layouter, &x.len, &y.len)?;
+        let len_check = ng.is_equal(layouter, x.len(), y.len())?;
 
         ng.and(layouter, &[val_checks.as_slice(), &[len_check]].concat())
     }
@@ -333,9 +337,9 @@ where
         let ng = &self.native_gadget;
         let ct_len = constant.len();
 
-        let eq_len = ng.is_equal_to_fixed(layouter, &x.len, F::from(ct_len as u64))?;
+        let eq_len = ng.is_equal_to_fixed(layouter, x.len(), F::from(ct_len as u64))?;
 
-        let mut element_checks = x.buffer[get_lims::<M, A>(ct_len)]
+        let mut element_checks = x.buffer()[get_lims::<M, A>(ct_len)]
             .iter()
             .zip(constant.iter())
             .map(|(a, c)| ng.is_equal_to_fixed(layouter, a, *c))
@@ -398,9 +402,9 @@ where
     ) -> Result<(), Error> {
         let ng = &self.native_gadget;
         let ct_len = constant.len();
-        ng.assert_equal_to_fixed(layouter, &x.len, F::from(ct_len as u64))?;
+        ng.assert_equal_to_fixed(layouter, x.len(), F::from(ct_len as u64))?;
 
-        x.buffer[get_lims::<M, A>(ct_len)]
+        x.buffer()[get_lims::<M, A>(ct_len)]
             .iter()
             .zip(constant.iter())
             .map(|(a, c)| ng.assert_equal_to_fixed(layouter, a, *c))
@@ -534,12 +538,12 @@ mod tests {
                     if mutate_padding {
                         let range = get_lims::<M, A>(self.input_2.len());
                         for i in 0..range.start {
-                            vec_2.buffer[i] =
-                                ng.add_constant(&mut layouter, &vec_2.buffer[i], F::ONE)?;
+                            let val = ng.add_constant(&mut layouter, &vec_2.buffer()[i], F::ONE)?;
+                            vec_2.mutate_buffer(val, i);
                         }
                         for i in range.end..M {
-                            vec_2.buffer[i] =
-                                ng.add_constant(&mut layouter, &vec_2.buffer[i], F::ONE)?;
+                            let val = ng.add_constant(&mut layouter, &vec_2.buffer()[i], F::ONE)?;
+                            vec_2.mutate_buffer(val, i);
                         }
                     }
 
@@ -553,7 +557,7 @@ mod tests {
 
                     let limits = vg.get_limits(&mut layouter, &vec_1)?;
                     let (start, end) = vec_1
-                        .len
+                        .len()
                         .value()
                         .map(|l| {
                             let len: usize = l.to_biguint().try_into().unwrap();
@@ -572,7 +576,7 @@ mod tests {
                         vg.assign(&mut layouter, self.input_1.clone())?;
 
                     let expected: [Value<bool>; M] = vec_1
-                        .len
+                        .len()
                         .value()
                         .map(|l| {
                             let len: usize = l.to_biguint().try_into().unwrap();


### PR DESCRIPTION
Small improvements to prevent misuse of the vector gadget.
 - Add compile-time checks on the invariants that ensure the intended behaviour of the instructions.
 - Add missing tests for `resize()`
 
 - [x] Merge after #462 