### PR TITLE
Update dependabot settings

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -15,6 +15,35 @@ updates:
       interval: "daily"
     cooldown:
       default-days: 7
+    # Blocked as ONE coordinated migration: the crypto stack (pairing 0.23, k256 0.13,
+    # p256/primeorder 0.13, curve25519-dalek 4.1, blstrs/halo2curves) pins ff 0.13 /
+    # group 0.13 / elliptic-curve 0.13 / rand_core 0.6 / getrandom 0.2 / digest 0.10.
+    # None of the below can land until all of those publish 0.14-generation releases.
+    ignore:
+      - dependency-name: "num-bigint"    # 0.5 drops rand 0.8 support (needs rand_core 0.9).
+        versions: ["0.5.x"]
+      - dependency-name: "rand"
+        versions: ["0.9.x"]
+      - dependency-name: "rand_core"
+        versions: ["0.9.x"]
+      - dependency-name: "rand_chacha"
+        versions: ["0.9.x"]
+      - dependency-name: "getrandom"     # 0.3+ also drops the `js` feature.
+        versions: [">=0.3"]
+      - dependency-name: "ff"
+        versions: ["0.14.x"]
+      - dependency-name: "group"
+        versions: ["0.14.x"]
+      - dependency-name: "p256"
+        versions: ["0.14.x"]
+      - dependency-name: "primeorder"
+        versions: ["0.14.x"]
+      - dependency-name: "digest"
+        versions: ["0.11.x"]
+      # bincode 3.0.0 is a protest release: its lib.rs is a bare
+      # `compile_error!("https://xkcd.com/2347/")` and cannot build. Stay on 2.x.
+      - dependency-name: "bincode"
+        versions: ["3.0.x"]
 #
 #  - package-ecosystem: "npm"
 #    directory: "/"

--- a/circuits/Cargo.toml
+++ b/circuits/Cargo.toml
@@ -33,7 +33,7 @@ goldenfile = { version = "=1.8.0", optional = true }
 rand_chacha = { workspace = true, optional = true }
 
 [dev-dependencies]
-criterion = "0.7"
+criterion = "0.8"
 rand_chacha = "0.3.1"
 goldenfile = "=1.8.0"
 num-bigint = { workspace = true, features = ["rand"] }

--- a/curves/Cargo.toml
+++ b/curves/Cargo.toml
@@ -48,7 +48,7 @@ primeorder = "0.13"
 [dev-dependencies]
 rand_xorshift = "0.3.0"
 rand = "0.8"
-criterion = { version = "0.7", features = ["html_reports"] }
+criterion = { version = "0.8", features = ["html_reports"] }
 ark-std = "0.6"
 halo2derive = "0.2.0"
 [target.'cfg(all(target_arch = "wasm32", target_os = "unknown"))'.dependencies]

--- a/proofs/Cargo.toml
+++ b/proofs/Cargo.toml
@@ -40,7 +40,7 @@ itertools = "0.15"
 serde = { workspace = true }
 serde_derive = { workspace = true }
 rayon = { workspace = true }
-criterion = { version = "0.7", optional = true }
+criterion = { version = "0.8", optional = true }
 rustc-hash = "2"
 
 # Developer tooling dependencies
@@ -55,7 +55,7 @@ midnight-circuits = { path = "../circuits" }
 midnight-zk-stdlib = { path = "../zk_stdlib" }
 sha2 = { workspace = true }
 rand = { workspace = true }
-criterion = "0.7"
+criterion = "0.8"
 
 [target.'cfg(all(target_arch = "wasm32", target_os = "unknown"))'.dependencies]
 getrandom = { version = "0.2", features = ["js"] }

--- a/zk_stdlib/Cargo.toml
+++ b/zk_stdlib/Cargo.toml
@@ -33,7 +33,7 @@ bincode = "2.0"
 hex-literal = "1.1"
 
 [dev-dependencies]
-criterion = "0.7"
+criterion = "0.8"
 rand_chacha = { workspace = true }
 goldenfile = "=1.8.0"
 num-bigint = { workspace = true, features = ["rand"] }


### PR DESCRIPTION
- Update dependabot settings to stop the bump alerts on crates that cannot be bumped.
- Bump criterion 0.7 -> 0.8

The CI failures are just the CHANGELOG checks.