### PR TITLE
[Don't review or merge] Batch verifier with error identification

### DIFF
--- a/aggregation/Cargo.toml
+++ b/aggregation/Cargo.toml
@@ -15,15 +15,15 @@ rustdoc-args = ["--cfg", "docsrs", "--html-in-header", "katex-header.html"]
 [dependencies]
 group = { workspace = true }
 ff = { workspace = true }
-midnight-curves = "0.3.0"
-midnight-proofs = { version = "0.8.0", default-features = false, features = [
+midnight-curves = "0.3.1"
+midnight-proofs = { version = "0.8.1", default-features = false, features = [
     "circuit-params",
     "committed-instances",
 ] }
-midnight-circuits = { version = "7.0.0", default-features = false, features = [
+midnight-circuits = { version = "7.2.2", default-features = false, features = [
     "testing",
 ] }
-midnight-zk-stdlib = { path = "../zk_stdlib", version = "2.1.0" }
+midnight-zk-stdlib = { path = "../zk_stdlib", version = "2.3.3" }
 
 rand = { workspace = true }
 blake2b_simd = { workspace = true }

--- a/circuits/Cargo.toml
+++ b/circuits/Cargo.toml
@@ -11,8 +11,8 @@ description = "Circuit and gadget implementations for Midnight zero-knowledge pr
 group = { workspace = true }
 ff = { workspace = true }
 rustc-hash = "2"
-midnight-curves = "0.3.0"
-midnight-proofs = { version = "0.8.0", default-features = false, features = [
+midnight-curves = "0.3.1"
+midnight-proofs = { version = "0.8.1", default-features = false, features = [
     "circuit-params",
     "committed-instances",
 ] }
@@ -42,7 +42,7 @@ itertools = "0.15"
 dhat = "0.3"
 
 [target.'cfg(ci_build)'.dependencies]
-midnight-curves = { version = "0.3.0", features = ["portable"] }
+midnight-curves = { version = "0.3.1", features = ["portable"] }
 
 [features]
 default = []

--- a/circuits/Cargo.toml
+++ b/circuits/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "midnight-circuits"
-version = "7.1.0"
+version = "7.2.2"
 edition = "2021"
 license-file.workspace = true
 description = "Circuit and gadget implementations for Midnight zero-knowledge proofs"

--- a/curves/Cargo.toml
+++ b/curves/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "midnight-curves"
 description = "Implementation of the BLS12-381, JubJub, secp256k1, secp256r1 and Curve25519 curves."
-version = "0.3.0"
+version = "0.3.1"
 authors = ["dignifiedquire <me@dignifiedquire.com>", "Midnight team"]
 edition = "2018"
 license = "MIT/Apache-2.0"

--- a/proofs/CHANGELOG.md
+++ b/proofs/CHANGELOG.md
@@ -20,6 +20,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * Derive `Ord` on `PolynomialLabel`, making it usable as a `BTreeMap` key [#430](https://github.com/midnightntwrk/midnight-zk/pull/430)
 * `commitment_byte_length` method on the `PolynomialCommitmentScheme` trait, defaulting to the per-commitment size times `n` and overridable for schemes that fold polynomials into a single proof element [#440](https://github.com/midnightntwrk/midnight-zk/pull/440)
 * `circuit_model_with` taking an explicit commitment-size closure [#440](https://github.com/midnightntwrk/midnight-zk/pull/440)
+* adds support functions for error handling in batch verification [#479](https://github.com/midnightntwrk/midnight-zk/pull/479)
 
 ### Fixed
 * Fix verifier evals bug [#356](https://github.com/midnightntwrk/midnight-zk/pull/356)

--- a/proofs/Cargo.toml
+++ b/proofs/Cargo.toml
@@ -31,7 +31,7 @@ harness = false
 [dependencies]
 ff = { workspace = true }
 group = { workspace = true }
-midnight-curves = "0.3.0"
+midnight-curves = "0.3.1"
 rand_core = { workspace = true, features = ["getrandom"] }
 tracing = { workspace = true }
 blake2b_simd = { workspace = true }
@@ -61,7 +61,7 @@ criterion = "0.8"
 getrandom = { version = "0.2", features = ["js"] }
 
 [target.'cfg(ci_build)'.dependencies]
-midnight-curves = { version = "0.3.0", features = ["portable"] }
+midnight-curves = { version = "0.3.1", features = ["portable"] }
 
 [features]
 default = ["committed-instances"]

--- a/proofs/Cargo.toml
+++ b/proofs/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "midnight-proofs"
-version = "0.8.0"
+version = "0.8.1"
 edition = "2021"
 rust-version = "1.76.0"
 description = """
@@ -61,9 +61,7 @@ criterion = "0.8"
 getrandom = { version = "0.2", features = ["js"] }
 
 [target.'cfg(ci_build)'.dependencies]
-midnight-curves = { version = "0.3.0", features = [
-  "portable",
-] }
+midnight-curves = { version = "0.3.0", features = ["portable"] }
 
 [features]
 default = ["committed-instances"]

--- a/proofs/src/plonk/error.rs
+++ b/proofs/src/plonk/error.rs
@@ -17,6 +17,9 @@ pub enum Error {
     BoundsFailure,
     /// Opening error
     Opening,
+    /// Batch-opening error: in an attempt to batch-verify several proofs, the
+    /// proofs at these (ascending) indices failed the opening check.
+    BatchOpening(Vec<usize>),
     /// Transcript error
     Transcript(io::Error),
     /// `k` is too small for the given circuit.
@@ -66,6 +69,10 @@ impl fmt::Display for Error {
             Error::ConstraintSystemFailure => write!(f, "The constraint system is not satisfied"),
             Error::BoundsFailure => write!(f, "An out-of-bounds index was passed to the backend"),
             Error::Opening => write!(f, "Multi-opening proof was invalid"),
+            Error::BatchOpening(indices) => write!(
+                f,
+                "Batch verification failed for proofs at indices {indices:?}",
+            ),
             Error::Transcript(e) => write!(f, "Transcript error: {e}"),
             Error::NotEnoughRowsAvailable { current_k } => write!(
                 f,

--- a/proofs/src/poly/kzg/msm.rs
+++ b/proofs/src/poly/kzg/msm.rs
@@ -283,6 +283,21 @@ where
         self.right.scale(e);
     }
 
+    /// Collapse each channel to a single point. Intended for the off-circuit
+    /// final pairing check (thus disregarding labels since they are here
+    /// irrelevant). Once collapsed, the guard can be reused across many subset
+    /// checks cheaply.
+    ///
+    /// # Note
+    ///
+    /// Unlike [`MSMKZG::collapse`], this does not
+    /// assert the absence of `Fixed` labels, since the collapsed points
+    /// feed only into the pairing.
+    pub fn early_collapse(&mut self) {
+        self.left = MSMKZG::from_base(&self.left.eval());
+        self.right = MSMKZG::from_base(&self.right.eval());
+    }
+
     /// Add another multiexp into this one
     pub fn add_msm(&mut self, other: Self) {
         self.left.add_msm(&other.left);

--- a/zk_stdlib/CHANGELOG.md
+++ b/zk_stdlib/CHANGELOG.md
@@ -15,6 +15,7 @@ We use [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 * Add `square`, `mod_square` operations in `BigUintGadget` [#259](https://github.com/midnightntwrk/midnight-zk/pull/259)
 * Add `PartialEq` impl for `AssignedBigUint` [#259](https://github.com/midnightntwrk/midnight-zk/pull/259)
 * BREAKING: Implemented linearization prover [#190](https://github.com/midnightntwrk/midnight-zk/pull/190)
+* Add error identification for batch verification [#479](https://github.com/midnightntwrk/midnight-zk/pull/479)
 
 ### Fixed
 * Fix cost model proof size check to account for committed instance columns [#280](https://github.com/midnightntwrk/midnight-zk/pull/280)

--- a/zk_stdlib/Cargo.toml
+++ b/zk_stdlib/Cargo.toml
@@ -34,6 +34,7 @@ hex-literal = "1.1"
 
 [dev-dependencies]
 criterion = "0.8"
+rayon = { workspace = true }
 rand_chacha = { workspace = true }
 goldenfile = "=1.8.0"
 num-bigint = { workspace = true, features = ["rand"] }

--- a/zk_stdlib/Cargo.toml
+++ b/zk_stdlib/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "midnight-zk-stdlib"
-version = "2.3.3."
+version = "2.3.3"
 edition = "2021"
 license-file.workspace = true
 description = "Standard library of circuits and utilities for Midnight zero-knowledge proofs"

--- a/zk_stdlib/Cargo.toml
+++ b/zk_stdlib/Cargo.toml
@@ -71,6 +71,10 @@ bench = false
 name = "verify"
 harness = false
 
+[[bench]]
+name = "batch_recovery"
+harness = false
+
 [[example]]
 name = "cred_full"
 path = "examples/identity/jwt/full_credential.rs"

--- a/zk_stdlib/Cargo.toml
+++ b/zk_stdlib/Cargo.toml
@@ -11,9 +11,9 @@ description = "Standard library of circuits and utilities for Midnight zero-know
 group = { workspace = true }
 ff = { workspace = true }
 blake2b_simd = { workspace = true }
-midnight-circuits = { version = "7.0.0", features = ["testing"] }
-midnight-curves = { version = "0.3.0" }
-midnight-proofs = { version = "0.8.0", default-features = false, features = [
+midnight-circuits = { version = "7.2.2", features = ["testing"] }
+midnight-curves = { version = "0.3.1" }
+midnight-proofs = { version = "0.8.1", default-features = false, features = [
     "circuit-params",
     "committed-instances",
 ] }
@@ -46,7 +46,7 @@ sha3 = "0.12.0"
 blake2 = "0.10.6"
 
 [target.'cfg(ci_build)'.dependencies]
-midnight-curves = { version = "0.3.0", features = ["portable"] }
+midnight-curves = { version = "0.3.1", features = ["portable"] }
 
 [features]
 default = []

--- a/zk_stdlib/Cargo.toml
+++ b/zk_stdlib/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "midnight-zk-stdlib"
-version = "2.2.0"
+version = "2.3.3."
 edition = "2021"
 license-file.workspace = true
 description = "Standard library of circuits and utilities for Midnight zero-knowledge proofs"

--- a/zk_stdlib/Cargo.toml
+++ b/zk_stdlib/Cargo.toml
@@ -18,7 +18,7 @@ midnight-proofs = { version = "0.8.1", default-features = false, features = [
     "committed-instances",
 ] }
 
-keccak_sha3 = { package = "sha3-circuit", git = "https://github.com/alexandroszacharakis8/sha3-circuit", rev = "1a3ef7d" }
+keccak_sha3 = { package = "sha3-circuit", git = "https://github.com/jsidorenko/sha3-circuit", branch = "throughput-fix" }
 blake2b = { package = "blake2b_halo2", git = "https://github.com/eryxcoop/blake2b_halo2", rev = "257ae18" }
 
 serde = { workspace = true, optional = true }

--- a/zk_stdlib/benches/batch_recovery.rs
+++ b/zk_stdlib/benches/batch_recovery.rs
@@ -1,5 +1,8 @@
 //! Sweeps the number of invalid proofs in a batch and times the three
 //! failure-recovery strategies, emitting a CSV so the curves can be plotted.
+//! The whole sweep is run at a fixed number of CPU cores (see [`MAX_CORES`]),
+//! so re-running at a few core counts shows how each strategy degrades as
+//! parallelism shrinks.
 //!
 //! Strategies (all return the same failing-index set):
 //! - `individual`: verify each proof on its own with `verify`, in parallel with
@@ -18,10 +21,16 @@
 //! path `./examples/assets`); CSV goes to stdout, progress to stderr:
 //!
 //! ```text
-//! cargo bench --bench batch_recovery_sweep > sweep.csv
+//! cargo bench --bench batch_recovery > sweep.csv
 //! ```
 //!
-//! The sweep is dense where the curve bends and coarse where it is flat.
+//! Every row is tagged with the resolved core count (first column), so a
+//! sweep over core counts concatenates into a single dataset. To sweep, edit
+//! [`MAX_CORES`] between runs (or set the `MAX_CORES` env var, which overrides
+//! the constant without recompiling) over e.g. `1, 2, 3, 6, all`.
+//!
+//! The `k`-sweep is dense where the curve bends and coarse where it is flat.
+//! Env overrides (all optional): `MAX_CORES`, `NB_PROOFS`, `REPS`, `EU_CSV`.
 
 use std::{hint::black_box, time::Instant};
 
@@ -40,10 +49,21 @@ use midnight_zk_stdlib::{
 };
 use rand::{rngs::OsRng, RngCore, SeedableRng};
 use rand_chacha::ChaCha8Rng;
-use rayon::iter::{IntoParallelIterator, ParallelIterator};
+use rayon::{
+    iter::{IntoParallelIterator, ParallelIterator},
+    ThreadPoolBuilder,
+};
 
 type F = midnight_curves::Fq;
 type H = blake2b_simd::State;
+
+/// Upper bound on the number of rayon worker threads for the whole run.
+/// `None` uses all logical cores; `Some(n)` caps the global pool at `n`.
+/// Edit this between runs (or set the `MAX_CORES` env var, which takes
+/// precedence) to sweep the core count, e.g. `Some(1)`, `Some(2)`, `Some(3)`,
+/// `Some(6)`, `None`. Each CSV row records the resolved count in its first
+/// column, so the per-core CSVs concatenate into one dataset.
+const MAX_CORES: Option<usize> = None;
 
 const NB_PROOFS: usize = 1000;
 const REPS: usize = 3;
@@ -155,12 +175,12 @@ fn poison(base_pis: &[Vec<F>], k: usize, seed: u64) -> (Vec<Vec<F>>, Vec<usize>)
     (pis, bad)
 }
 
-/// Runs `f` `REPS` times, returning the minimum wall time (ms) and the last
+/// Runs `f` `reps` times, returning the minimum wall time (ms) and the last
 /// result (the minimum is the least noise-perturbed estimate).
-fn bench_min<T>(mut f: impl FnMut() -> T) -> (f64, T) {
+fn bench_min<T>(reps: usize, mut f: impl FnMut() -> T) -> (f64, T) {
     let mut best = f64::INFINITY;
     let mut last = None;
-    for _ in 0..REPS {
+    for _ in 0..reps {
         let t = Instant::now();
         let r = f();
         let ms = t.elapsed().as_secs_f64() * 1e3;
@@ -171,25 +191,54 @@ fn bench_min<T>(mut f: impl FnMut() -> T) -> (f64, T) {
 }
 
 /// Sweep points: every integer 0..=10, then every 10 to 100, then every 50 to
-/// `NB_PROOFS`.
-fn sweep_points() -> Vec<usize> {
-    let mut ks: Vec<usize> = (0..=10).collect();
-    ks.extend((20..100).step_by(10));
-    ks.extend((100..=NB_PROOFS).step_by(50));
+/// `nb_proofs`.
+fn sweep_points(nb_proofs: usize) -> Vec<usize> {
+    let mut ks: Vec<usize> = (0..=10.min(nb_proofs)).collect();
+    ks.extend((20..100).step_by(10).filter(|&k| k <= nb_proofs));
+    ks.extend((100..=nb_proofs).step_by(50));
+    ks.dedup();
     ks
 }
 
+fn env_usize(name: &str, default: usize) -> usize {
+    std::env::var(name).ok().and_then(|v| v.parse().ok()).unwrap_or(default)
+}
+
+/// Joins one CSV row. With `eu` set, uses European conventions so Numbers on a
+/// comma-decimal locale imports the numbers as numbers, not text: `;` as the
+/// field separator and `,` as the decimal mark. Otherwise the plain `,`-and-`.`
+/// form. Fields must contain no separator characters of their own.
+fn csv_row(fields: &[String], eu: bool) -> String {
+    if eu {
+        fields.iter().map(|f| f.replace('.', ",")).collect::<Vec<_>>().join(";")
+    } else {
+        fields.join(",")
+    }
+}
+
 fn main() {
+    // Resolve the core cap: env var wins over the constant, else all cores.
+    let cores = std::env::var("MAX_CORES")
+        .ok()
+        .and_then(|v| v.parse().ok())
+        .or(MAX_CORES)
+        .unwrap_or_else(|| std::thread::available_parallelism().map(|n| n.get()).unwrap_or(1));
+    ThreadPoolBuilder::new().num_threads(cores).build_global().unwrap();
+
+    let nb_proofs = env_usize("NB_PROOFS", NB_PROOFS);
+    let reps = env_usize("REPS", REPS);
+    let eu = std::env::var("EU_CSV").map(|v| !v.is_empty() && v != "0").unwrap_or(false);
+
     let relation = PoseidonBench;
     let srs = srs_for_test(&relation, Some(6));
     let vk = midnight_zk_stdlib::setup_vk(&srs, &relation);
     let pk = midnight_zk_stdlib::setup_pk(&relation, &vk);
     let params = srs.verifier_params();
 
-    eprintln!("generating {NB_PROOFS} proofs (one-time setup)...");
-    let mut instances = Vec::with_capacity(NB_PROOFS);
-    let mut proofs = Vec::with_capacity(NB_PROOFS);
-    for _ in 0..NB_PROOFS {
+    eprintln!("cores={cores}: generating {nb_proofs} proofs (one-time setup)...");
+    let mut instances = Vec::with_capacity(nb_proofs);
+    let mut proofs = Vec::with_capacity(nb_proofs);
+    for _ in 0..nb_proofs {
         let (instance, witness) = random_instance();
         let proof = midnight_zk_stdlib::prove::<PoseidonBench, H>(
             &srs, &pk, &relation, &instance, witness, OsRng,
@@ -199,21 +248,25 @@ fn main() {
         proofs.push(proof);
     }
 
-    let vks: Vec<_> = (0..NB_PROOFS).map(|_| vk.clone()).collect();
+    let vks: Vec<_> = (0..nb_proofs).map(|_| vk.clone()).collect();
     let clean_pis: Vec<Vec<F>> =
         instances.iter().map(|i| PoseidonBench::format_instance(i).unwrap()).collect();
 
     // `individual` is independent of the number of failures: measure it once.
-    let (individual_ms, _) = bench_min(|| locate_individual(&params, &vks, &instances, &proofs));
-    eprintln!("individual (constant reference): {individual_ms:.1} ms");
+    let (individual_ms, _) =
+        bench_min(reps, || locate_individual(&params, &vks, &instances, &proofs));
+    eprintln!("cores={cores}: individual (constant reference): {individual_ms:.1} ms");
 
-    println!("k,individual_ms,reuse_prepare_ms,reuse_prepare_msm_ms");
-    for k in sweep_points() {
+    let header = ["cores", "k", "individual_ms", "reuse_prepare_ms", "reuse_prepare_msm_ms"]
+        .map(String::from);
+    println!("{}", csv_row(&header, eu));
+    for k in sweep_points(nb_proofs) {
         let (pis, bad) = poison(&clean_pis, k, SEED.wrapping_add(k as u64));
 
-        let (prep_ms, prep_res) =
-            bench_min(|| locate_batch(&params, &vks, &pis, &proofs, BatchStrategy::ReusePrepare));
-        let (msm_ms, msm_res) = bench_min(|| {
+        let (prep_ms, prep_res) = bench_min(reps, || {
+            locate_batch(&params, &vks, &pis, &proofs, BatchStrategy::ReusePrepare)
+        });
+        let (msm_ms, msm_res) = bench_min(reps, || {
             locate_batch(&params, &vks, &pis, &proofs, BatchStrategy::ReusePrepareMsm)
         });
 
@@ -223,7 +276,14 @@ fn main() {
         black_box(&prep_res);
         black_box(&msm_res);
 
-        println!("{k},{individual_ms:.3},{prep_ms:.3},{msm_ms:.3}");
-        eprintln!("k={k:>4}: prepare={prep_ms:7.1} ms   prepare+msm={msm_ms:7.1} ms");
+        let row = [
+            format!("{cores}"),
+            format!("{k}"),
+            format!("{individual_ms:.3}"),
+            format!("{prep_ms:.3}"),
+            format!("{msm_ms:.3}"),
+        ];
+        println!("{}", csv_row(&row, eu));
+        eprintln!("cores={cores} k={k:>4}: prepare={prep_ms:7.1} ms   prepare+msm={msm_ms:7.1} ms");
     }
 }

--- a/zk_stdlib/benches/batch_recovery.rs
+++ b/zk_stdlib/benches/batch_recovery.rs
@@ -2,8 +2,10 @@
 //! failure-recovery strategies, emitting a CSV so the curves can be plotted.
 //!
 //! Strategies (all return the same failing-index set):
-//! - `individual`: verify each proof on its own with `verify` (error-count
-//!   independent, so measured once and repeated across every CSV row).
+//! - `individual`: verify each proof on its own with `verify`, in parallel with
+//!   rayon so the baseline gets the same core count as the batch path (whose
+//!   `prepare` step is also parallelised). Error-count independent, so measured
+//!   once and repeated across every CSV row.
 //! - `reuse-prepare` (`BatchStrategy::ReusePrepare`): prepare once, localize by
 //!   binary search that re-evaluates each subset's combined MSM.
 //! - `reuse-prepare+msm` (`BatchStrategy::ReusePrepareMsm`): also collapse each
@@ -38,6 +40,7 @@ use midnight_zk_stdlib::{
 };
 use rand::{rngs::OsRng, RngCore, SeedableRng};
 use rand_chacha::ChaCha8Rng;
+use rayon::iter::{IntoParallelIterator, ParallelIterator};
 
 type F = midnight_curves::Fq;
 type H = blake2b_simd::State;
@@ -94,14 +97,18 @@ fn random_instance() -> (F, [F; 3]) {
     (instance, witness)
 }
 
-/// `individual`: verify each proof on its own, returning the failing indices.
+/// `individual`: verify each proof on its own (in parallel), returning the
+/// failing indices. Parallelised to match the batch path, whose per-proof
+/// `prepare` also runs under rayon — otherwise the baseline would be handicapped
+/// by running serially against a multi-threaded competitor.
 fn locate_individual(
     params: &ParamsVerifierKZG<midnight_curves::Bls12>,
     vks: &[MidnightVK],
     instances: &[F],
     proofs: &[Vec<u8>],
 ) -> Vec<usize> {
-    (0..proofs.len())
+    let mut failures: Vec<usize> = (0..proofs.len())
+        .into_par_iter()
         .filter(|&i| {
             midnight_zk_stdlib::verify::<PoseidonBench, H>(
                 params,
@@ -112,7 +119,9 @@ fn locate_individual(
             )
             .is_err()
         })
-        .collect()
+        .collect();
+    failures.sort_unstable();
+    failures
 }
 
 /// `reuse-prepare*`: guard-sharing binary search under the given strategy.

--- a/zk_stdlib/benches/batch_recovery.rs
+++ b/zk_stdlib/benches/batch_recovery.rs
@@ -1,0 +1,220 @@
+//! Sweeps the number of invalid proofs in a batch and times the three
+//! failure-recovery strategies, emitting a CSV so the curves can be plotted.
+//!
+//! Strategies (all return the same failing-index set):
+//! - `individual`: verify each proof on its own with `verify` (error-count
+//!   independent, so measured once and repeated across every CSV row).
+//! - `reuse-prepare` (`BatchStrategy::ReusePrepare`): prepare once, localize by
+//!   binary search that re-evaluates each subset's combined MSM.
+//! - `reuse-prepare+msm` (`BatchStrategy::ReusePrepareMsm`): also collapse each
+//!   proof's MSM to a point up front, so search nodes only recombine points.
+//!
+//! Invalid proofs are injected by pairing a valid proof with a wrong (but
+//! same-length) public input: `prepare` succeeds, only the opening check fails.
+//!
+//! Run from the crate directory `zk_stdlib` (the SRS loads via the relative
+//! path `./examples/assets`); CSV goes to stdout, progress to stderr:
+//!
+//! ```text
+//! cargo bench --bench batch_recovery_sweep > sweep.csv
+//! ```
+//!
+//! The sweep is dense where the curve bends and coarse where it is flat.
+
+use std::{hint::black_box, time::Instant};
+
+use ff::Field;
+use midnight_circuits::{
+    hash::poseidon::PoseidonChip,
+    instructions::{hash::HashCPU, AssignmentInstructions, PublicInputInstructions},
+};
+use midnight_proofs::{
+    circuit::{Layouter, Value},
+    plonk::Error,
+    poly::kzg::params::ParamsVerifierKZG,
+};
+use midnight_zk_stdlib::{
+    utils::plonk_api::srs_for_test, BatchStrategy, MidnightVK, Relation, ZkStdLib, ZkStdLibArch,
+};
+use rand::{rngs::OsRng, RngCore, SeedableRng};
+use rand_chacha::ChaCha8Rng;
+
+type F = midnight_curves::Fq;
+type H = blake2b_simd::State;
+
+const NB_PROOFS: usize = 1000;
+const REPS: usize = 3;
+const SEED: u64 = 0xB47C;
+
+// --- Relation under test (swap this block to sweep another circuit) ----------
+
+#[derive(Clone, Default)]
+struct PoseidonBench;
+
+impl Relation for PoseidonBench {
+    type Instance = F;
+    type Witness = [F; 3];
+    type Error = Error;
+
+    fn format_instance(instance: &Self::Instance) -> Result<Vec<F>, Error> {
+        Ok(vec![*instance])
+    }
+
+    fn circuit(
+        &self,
+        std_lib: &ZkStdLib,
+        layouter: &mut impl Layouter<F>,
+        _instance: Value<Self::Instance>,
+        witness: Value<Self::Witness>,
+    ) -> Result<(), Error> {
+        let assigned_message = std_lib.assign_many(layouter, &witness.transpose_array())?;
+        let output = std_lib.poseidon(layouter, &assigned_message)?;
+        std_lib.constrain_as_public_input(layouter, &output)
+    }
+
+    fn used_chips(&self) -> ZkStdLibArch {
+        ZkStdLibArch {
+            poseidon: true,
+            ..ZkStdLibArch::default()
+        }
+    }
+
+    fn write_relation<W: std::io::Write>(&self, _writer: &mut W) -> std::io::Result<()> {
+        Ok(())
+    }
+
+    fn read_relation<R: std::io::Read>(_reader: &mut R) -> std::io::Result<Self> {
+        Ok(PoseidonBench)
+    }
+}
+
+fn random_instance() -> (F, [F; 3]) {
+    let witness: [F; 3] = core::array::from_fn(|_| F::random(OsRng));
+    let instance = <PoseidonChip<F> as HashCPU<F, F>>::hash(&witness);
+    (instance, witness)
+}
+
+/// `individual`: verify each proof on its own, returning the failing indices.
+fn locate_individual(
+    params: &ParamsVerifierKZG<midnight_curves::Bls12>,
+    vks: &[MidnightVK],
+    instances: &[F],
+    proofs: &[Vec<u8>],
+) -> Vec<usize> {
+    (0..proofs.len())
+        .filter(|&i| {
+            midnight_zk_stdlib::verify::<PoseidonBench, H>(
+                params,
+                &vks[i],
+                &instances[i],
+                None,
+                &proofs[i],
+            )
+            .is_err()
+        })
+        .collect()
+}
+
+/// `reuse-prepare*`: guard-sharing binary search under the given strategy.
+fn locate_batch(
+    params: &ParamsVerifierKZG<midnight_curves::Bls12>,
+    vks: &[MidnightVK],
+    pis: &[Vec<F>],
+    proofs: &[Vec<u8>],
+    strategy: BatchStrategy,
+) -> Vec<usize> {
+    match midnight_zk_stdlib::batch_verify_with_strategy::<H>(params, vks, pis, proofs, strategy) {
+        Ok(()) => Vec::new(),
+        Err(Error::BatchOpening(f)) => f,
+        Err(e) => panic!("unexpected error: {e:?}"),
+    }
+}
+
+/// Corrupts `k` distinct (seeded) public inputs; returns the poisoned `pis` and
+/// the sorted corrupted indices.
+fn poison(base_pis: &[Vec<F>], k: usize, seed: u64) -> (Vec<Vec<F>>, Vec<usize>) {
+    let mut pis = base_pis.to_vec();
+    let mut rng = ChaCha8Rng::seed_from_u64(seed);
+    let mut set = std::collections::BTreeSet::new();
+    while set.len() < k {
+        set.insert(rng.next_u32() as usize % pis.len());
+    }
+    let bad: Vec<usize> = set.into_iter().collect();
+    for &i in &bad {
+        pis[i] = vec![pis[i][0] + F::ONE];
+    }
+    (pis, bad)
+}
+
+/// Runs `f` `REPS` times, returning the minimum wall time (ms) and the last
+/// result (the minimum is the least noise-perturbed estimate).
+fn bench_min<T>(mut f: impl FnMut() -> T) -> (f64, T) {
+    let mut best = f64::INFINITY;
+    let mut last = None;
+    for _ in 0..REPS {
+        let t = Instant::now();
+        let r = f();
+        let ms = t.elapsed().as_secs_f64() * 1e3;
+        best = best.min(ms);
+        last = Some(r);
+    }
+    (best, last.unwrap())
+}
+
+/// Sweep points: every integer 0..=10, then every 10 to 100, then every 50 to
+/// `NB_PROOFS`.
+fn sweep_points() -> Vec<usize> {
+    let mut ks: Vec<usize> = (0..=10).collect();
+    ks.extend((20..100).step_by(10));
+    ks.extend((100..=NB_PROOFS).step_by(50));
+    ks
+}
+
+fn main() {
+    let relation = PoseidonBench;
+    let srs = srs_for_test(&relation, Some(6));
+    let vk = midnight_zk_stdlib::setup_vk(&srs, &relation);
+    let pk = midnight_zk_stdlib::setup_pk(&relation, &vk);
+    let params = srs.verifier_params();
+
+    eprintln!("generating {NB_PROOFS} proofs (one-time setup)...");
+    let mut instances = Vec::with_capacity(NB_PROOFS);
+    let mut proofs = Vec::with_capacity(NB_PROOFS);
+    for _ in 0..NB_PROOFS {
+        let (instance, witness) = random_instance();
+        let proof = midnight_zk_stdlib::prove::<PoseidonBench, H>(
+            &srs, &pk, &relation, &instance, witness, OsRng,
+        )
+        .expect("proof generation failed");
+        instances.push(instance);
+        proofs.push(proof);
+    }
+
+    let vks: Vec<_> = (0..NB_PROOFS).map(|_| vk.clone()).collect();
+    let clean_pis: Vec<Vec<F>> =
+        instances.iter().map(|i| PoseidonBench::format_instance(i).unwrap()).collect();
+
+    // `individual` is independent of the number of failures: measure it once.
+    let (individual_ms, _) = bench_min(|| locate_individual(&params, &vks, &instances, &proofs));
+    eprintln!("individual (constant reference): {individual_ms:.1} ms");
+
+    println!("k,individual_ms,reuse_prepare_ms,reuse_prepare_msm_ms");
+    for k in sweep_points() {
+        let (pis, bad) = poison(&clean_pis, k, SEED.wrapping_add(k as u64));
+
+        let (prep_ms, prep_res) =
+            bench_min(|| locate_batch(&params, &vks, &pis, &proofs, BatchStrategy::ReusePrepare));
+        let (msm_ms, msm_res) = bench_min(|| {
+            locate_batch(&params, &vks, &pis, &proofs, BatchStrategy::ReusePrepareMsm)
+        });
+
+        // Sanity: both strategies recovered exactly the injected failure set.
+        assert_eq!(prep_res, bad, "reuse-prepare disagrees at k={k}");
+        assert_eq!(msm_res, bad, "reuse-prepare+msm disagrees at k={k}");
+        black_box(&prep_res);
+        black_box(&msm_res);
+
+        println!("{k},{individual_ms:.3},{prep_ms:.3},{msm_ms:.3}");
+        eprintln!("k={k:>4}: prepare={prep_ms:7.1} ms   prepare+msm={msm_ms:7.1} ms");
+    }
+}

--- a/zk_stdlib/src/interface.rs
+++ b/zk_stdlib/src/interface.rs
@@ -26,7 +26,7 @@ use midnight_proofs::{
         self, keygen_vk_with_k, prepare, Circuit, ConstraintSystem, Error, ProvingKey, VerifyingKey,
     },
     poly::{
-        commitment::{Guard, Params},
+        commitment::{Guard, Params, PolynomialCommitmentScheme},
         kzg::{
             params::{ParamsKZG, ParamsVerifierKZG},
             KZGCommitmentScheme,
@@ -36,6 +36,9 @@ use midnight_proofs::{
     utils::SerdeFormat,
 };
 use rand::{CryptoRng, RngCore};
+use rayon::iter::{
+    IndexedParallelIterator, IntoParallelRefIterator, IntoParallelRefMutIterator, ParallelIterator,
+};
 
 use crate::{
     utils::plonk_api::BlstPLONK, ZkStdLib, ZkStdLibArch, ZkStdLibConfig, F, NB_COMMITTED_INSTANCES,
@@ -586,25 +589,47 @@ where
     )?)
 }
 
-/// Verifies a batch of proofs with respect to their corresponding vk.
-/// This method does not need to know the `Relation` the proofs are associated
-/// to and, indeed, it can verify proofs from different `Relation`s.
-/// For that, this function does not take `instance`s, but public inputs
-/// in raw format (`Vec<F>`).
-///
-/// Returns `Ok(())` if all proofs are valid.
-pub fn batch_verify<H: TranscriptHash + Send + Sync>(
-    params_verifier: &ParamsVerifierKZG<midnight_curves::Bls12>,
+/// Strategy used by [`batch_verify_with_strategy`] to localise the failing
+/// proofs of a batch.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum BatchStrategy {
+    /// If either proof of the batch fails verification, a plain
+    /// `Error::Opening` is returned without additional search effort to
+    /// identify the invalid proofs.
+    NoRecovery,
+    /// Prepare every proof once, then localise failures by binary search over
+    /// the guards. Batch verification returns `Error::BatchOpening(v)` upon
+    /// failure, where `v` is the vector of indexes of invalid proofs in the
+    /// batch. Fastest recovery when failures are rare.
+    ReusePrepare,
+    /// Like [`ReusePrepare`], but additionally collapse each proof's guard to
+    /// a single point up front, so every search node only recombines the
+    /// per-proof points instead of all their raw terms. Slower with no/few
+    /// failures (per-proof collapse forgoes the batched MSM's efficiency),
+    /// but markedly cheaper when many proofs fail.
+    ReusePrepareMsm,
+}
+
+/// Concrete verification guard produced by [`prepare`] for the Midnight PCS (a
+/// `DualMSM` accumulator). Retained per proof so batch verification can be
+/// re-run over subsets of a batch without recomputing `prepare`.
+type BatchGuard =
+    <KZGCommitmentScheme<midnight_curves::Bls12> as PolynomialCommitmentScheme<F>>::VerificationGuard;
+
+/// Runs the expensive, per-proof preparation of a batch: replays each proof's
+/// transcript and builds its verification guard (a deferred MSM), in parallel.
+/// Also include the msm for the `BatchStrategy::ReusePrepareMsm` strategy.
+fn compute_reuseable_params<H>(
     vks: &[MidnightVK],
     pis: &[Vec<F>],
     proofs: &[Vec<u8>],
-) -> Result<(), Error>
+    strategy: BatchStrategy,
+) -> Result<Vec<(BatchGuard, F)>, Error>
 where
+    H: TranscriptHash + Send + Sync,
     G1Projective: Hashable<H>,
     F: Hashable<H> + Sampleable<H>,
 {
-    use rayon::prelude::*;
-
     // TODO: For the moment, committed instances are not supported.
     let n = vks.len();
     if pis.len() != n || proofs.len() != n {
@@ -612,7 +637,7 @@ where
         return Err(Error::InvalidInstances);
     }
 
-    let prepared: Vec<(_, F)> = vks
+    let mut prepared = vks
         .par_iter()
         .zip(pis.par_iter())
         .zip(proofs.par_iter())
@@ -642,29 +667,122 @@ where
             Ok((dual_msm, summary))
         })
         .collect::<Result<Vec<_>, Error>>()?;
+    // Collapse each proof's guard to a single point so that later subset checks
+    // recombine points rather than re-evaluating every raw MSM term.
+    if strategy == BatchStrategy::ReusePrepareMsm {
+        prepared.par_iter_mut().for_each(|(guard, _)| guard.early_collapse());
+    };
+    Ok(prepared)
+}
 
-    let mut r_transcript = CircuitTranscript::init();
-    let mut guards = Vec::with_capacity(n);
-    for (guard, summary) in prepared {
-        r_transcript.common(&summary)?;
-        guards.push(guard);
+/// Completes batch verification over an already-prepared set of guards: derives
+/// the batching challenge from their summaries, folds the guards into a single
+/// MSM and runs one pairing check. Performs no `prepare` work, so it can be
+/// called repeatedly over subsets of a batch cheaply.
+///
+/// Returns [`Error::Opening`] (without pinpointing which proof) if the combined
+/// check fails, or `Ok(())` if the (possibly empty) subset verifies.
+fn batch_verify_with_guard<H: TranscriptHash>(
+    params_verifier: &ParamsVerifierKZG<midnight_curves::Bls12>,
+    prepared: &[(BatchGuard, F)],
+) -> Result<(), Error>
+where
+    F: Hashable<H> + Sampleable<H>,
+{
+    let mut r_transcript = CircuitTranscript::<H>::init();
+    for (_, summary) in prepared {
+        r_transcript.common(summary)?;
     }
     let r: F = r_transcript.squeeze_challenge();
 
-    let n_guards = guards.len();
-    let powers: Vec<F> =
-        std::iter::successors(Some(F::ONE), |p| Some(*p * r)).take(n_guards).collect();
-    guards.par_iter_mut().enumerate().for_each(|(i, guard)| guard.scale(powers[i]));
+    let powers: Vec<F> = std::iter::successors(Some(F::ONE), |p| Some(*p * r))
+        .take(prepared.len())
+        .collect();
+
+    // Clone the guards before scaling: the same guard may take part in several
+    // subset checks during failure localization, so we must not mutate it.
+    let mut scaled: Vec<BatchGuard> = prepared
+        .par_iter()
+        .zip(powers.par_iter())
+        .map(|((guard, _), power)| {
+            let mut guard = guard.clone();
+            guard.scale(*power);
+            guard
+        })
+        .collect();
 
     // Add scaled guards sequentially.
-    let Some(mut acc_guard) = guards.pop() else {
+    let Some(mut acc_guard) = scaled.pop() else {
         return Ok(());
     };
-    for guard in guards {
+    for guard in scaled {
         acc_guard.add_msm(guard);
     }
-    // TODO: Have richer error types
     acc_guard.verify(params_verifier).map_err(|_| Error::Opening)
+}
+
+/// Verifies a batch of proofs with respect to their corresponding vk, without
+/// recovery of the invalid proofs. Use `batch_verify_with_strategy` for
+/// specifying different strategies.
+pub fn batch_verify<H: TranscriptHash + Send + Sync>(
+    params_verifier: &ParamsVerifierKZG<midnight_curves::Bls12>,
+    vks: &[MidnightVK],
+    pis: &[Vec<F>],
+    proofs: &[Vec<u8>],
+) -> Result<(), Error>
+where
+    G1Projective: Hashable<H>,
+    F: Hashable<H> + Sampleable<H>,
+{
+    batch_verify_with_strategy::<H>(params_verifier, vks, pis, proofs, BatchStrategy::NoRecovery)
+}
+
+/// Verifies a batch of proofs with respect to their corresponding vk.
+///
+/// Returns `Ok(())` if all proofs are valid, and otherwise either
+/// `Error::Opening` or `Error::BatchOpening` otherwise, depending on the
+/// `BatchStrategy` argument passed.
+pub fn batch_verify_with_strategy<H: TranscriptHash + Send + Sync>(
+    params_verifier: &ParamsVerifierKZG<midnight_curves::Bls12>,
+    vks: &[MidnightVK],
+    pis: &[Vec<F>],
+    proofs: &[Vec<u8>],
+    strategy: BatchStrategy,
+) -> Result<(), Error>
+where
+    G1Projective: Hashable<H>,
+    F: Hashable<H> + Sampleable<H>,
+{
+    let prepared = compute_reuseable_params::<H>(vks, pis, proofs, strategy)?;
+
+    if strategy == BatchStrategy::NoRecovery {
+        batch_verify_with_guard(params_verifier, &prepared)
+    } else {
+        // Binary-search the prepared guards to localise failures, reusing the
+        // guards across subset checks. The first iteration checks the whole batch,
+        // which is the fast path when all proofs are valid.
+        let mut failures = Vec::new();
+        let mut pending = vec![(0usize, prepared.len())];
+        while let Some((start, end)) = pending.pop() {
+            if batch_verify_with_guard(params_verifier, &prepared[start..end]).is_ok() {
+                continue;
+            };
+            if end - start == 1 {
+                failures.push(start);
+            } else {
+                let mid = start + (end - start) / 2;
+                pending.push((start, mid));
+                pending.push((mid, end));
+            }
+        }
+
+        if failures.is_empty() {
+            Ok(())
+        } else {
+            failures.sort_unstable();
+            Err(Error::BatchOpening(failures))
+        }
+    }
 }
 
 /// Returns the constraint-system degree relative to the given [`ZkStdLibArch`].


### PR DESCRIPTION
Experimental branch. Needs to be an open PR for referencing, but does not need to be merged.
---

Adds a variant of `batch_verify` that, when a batch of proofs fails verification, identifies the set of proofs that effectively fail. This is done by a binary search, re-running `batch_verify` recursively on smaller sub-batches. It's called `batch_verify_with_strategy`

Since this operation requires to re-verify sub-batches several times, some computation effort can be re-used. Three straightforward strategies are proposed and can be chosen by the caller:

- `NoRecovery`: corresponds to the behaviour of `batch_verify` in main, i.e., no binary search is conducted.
- `ReusePrepare`: since `batch_verify` calls `prepare` individually on each proof of the batch, we don't need to recompute it during the verification of each sub-batch. This strategy is a binary search exploiting that fact.
- `ReusePrepareMsm`: same as `ReusePrepare`, but the MSM work is also reused. Namely, instead of deferring the MSM of the whole batch, the MSM is collapsed individually for each proof, so that sub-batches can re-use it efficiently. The trade-off is that we lose the efficiency specific to large MSM computations.

The PR also includes benchmarking comparing:
1. verifying each proof individually with `verify`
2. `ReusePrepare`
3. `ReusePrepareMsm`

2. is the most efficient when the batch contains only valid proofs (about 1,75x faster than 3. and 10x faster than 1.), but becomes less efficient than 3. for ≥2 failures, and less efficient than 1. for ≥20-25% failures. 3. is always better than 1.