### PR TITLE
v2 fixes

### DIFF
--- a/circuits/CHANGELOG.md
+++ b/circuits/CHANGELOG.md
@@ -13,6 +13,10 @@ We use [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Removed
 
+## [7.2.3]
+### Changed
+* Require `midnight-proofs` >= 0.8.2 for the verifier per-proof length check [#482](https://github.com/midnightntwrk/midnight-zk/pull/482)
+
 ## [7.2.2]
 ### Fixed
 * Fix `InnerValue` for `AssignedScalarOfNativeCurve` [#451](https://github.com/midnightntwrk/midnight-zk/pull/451)

--- a/circuits/Cargo.toml
+++ b/circuits/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "midnight-circuits"
-version = "7.2.2"
+version = "7.2.3"
 edition = "2021"
 license-file.workspace = true
 description = "Circuit and gadget implementations for Midnight zero-knowledge proofs"
@@ -12,7 +12,7 @@ group = { workspace = true }
 ff = { workspace = true }
 rustc-hash = "2"
 midnight-curves = "0.3.1"
-midnight-proofs = { version = "0.8.1", default-features = false, features = [
+midnight-proofs = { version = "0.8.2", default-features = false, features = [
     "circuit-params",
     "committed-instances",
 ] }

--- a/proofs/CHANGELOG.md
+++ b/proofs/CHANGELOG.md
@@ -12,6 +12,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Removed
 
+## [0.8.2]
+### Fixed
+* Check per-proof vector lengths in `verify_algebraic_constraints`. [#482](https://github.com/midnightntwrk/midnight-zk/pull/482)
+
 ## [0.8.1]
 ### Fixed
 * Bug fix in midnight-curves [#434](https://github.com/midnightntwrk/midnight-zk/pull/434)
@@ -48,7 +52,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * changed `sha256` name in benches to account for the change of naming convention in `circuits` [#135](https://github.com/midnightntwrk/midnight-zk/pull/135)
 
 ### Changed
-* Interface of `ParamsKZG::from_parts` 
+* Interface of `ParamsKZG::from_parts`
 
 ### Removed
 

--- a/proofs/Cargo.toml
+++ b/proofs/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "midnight-proofs"
-version = "0.8.1"
+version = "0.8.2"
 edition = "2021"
 rust-version = "1.76.0"
 description = """

--- a/proofs/src/plonk/verifier.rs
+++ b/proofs/src/plonk/verifier.rs
@@ -222,6 +222,15 @@ where
         y,
     } = trace;
 
+    if committed_instances.len() != num_proofs
+        || advice_commitments.len() != num_proofs
+        || permutations.len() != num_proofs
+        || lookups.len() != num_proofs
+        || trashcans.len() != num_proofs
+    {
+        return Err(Error::InvalidInstances);
+    }
+
     let vanishing = vanishing.read_commitments_after_y(vk, transcript)?;
 
     // Sample x challenge, which is used to ensure the circuit is

--- a/zk_stdlib/CHANGELOG.md
+++ b/zk_stdlib/CHANGELOG.md
@@ -11,6 +11,10 @@ We use [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 ### Changed
 ### Removed
 
+## [2.3.4]
+### Changed
+* Bump `midnight-circuits` to 7.2.3 and `midnight-proofs` to 0.8.2 for the verifier per-proof length check [#482](https://github.com/midnightntwrk/midnight-zk/pull/482)
+
 ## [2.3.3]
 
 ### Changed

--- a/zk_stdlib/Cargo.toml
+++ b/zk_stdlib/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "midnight-zk-stdlib"
-version = "2.3.3"
+version = "2.3.4"
 edition = "2021"
 license-file.workspace = true
 description = "Standard library of circuits and utilities for Midnight zero-knowledge proofs"
@@ -11,9 +11,9 @@ description = "Standard library of circuits and utilities for Midnight zero-know
 group = { workspace = true }
 ff = { workspace = true }
 blake2b_simd = { workspace = true }
-midnight-circuits = { version = "7.2.2", features = ["testing"] }
+midnight-circuits = { version = "7.2.3", features = ["testing"] }
 midnight-curves = { version = "0.3.1" }
-midnight-proofs = { version = "0.8.1", default-features = false, features = [
+midnight-proofs = { version = "0.8.2", default-features = false, features = [
     "circuit-params",
     "committed-instances",
 ] }


### PR DESCRIPTION

 - Add a check to ensure committed instances match the expected length. If they do not, the verifier returns `Error::InvalidInstances`