### PR TITLE
Decider trait

### DIFF
--- a/aggregation/Cargo.toml
+++ b/aggregation/Cargo.toml
@@ -44,6 +44,10 @@ required-features = ["truncated-challenges"]
 name = "multi_circuit_aggregation"
 required-features = ["truncated-challenges"]
 
+[[example]]
+name = "final_ivc_verification"
+required-features = ["truncated-challenges"]
+
 [features]
 truncated-challenges = [
     "midnight-proofs/truncated-challenges",

--- a/aggregation/examples/final_ivc_verification.rs
+++ b/aggregation/examples/final_ivc_verification.rs
@@ -246,7 +246,7 @@ impl<const N: usize> Relation for FinalIvcVerifier<N> {
 
         let committed = vec![AssignedKZGCommitment::simple(
             std_lib.bls12_381().assign_fixed(layouter, C::identity())?,
-            PolynomialLabel::Instance(0),
+            PolynomialLabel::CommittedInstance(0),
         )];
 
         // 5. Run the final chain step (verify + fold + collapse + resolve) via
@@ -304,7 +304,7 @@ fn final_accumulator<const N: usize>(
         &final_vk,
         &[KZGCommitment::Simple(
             C::identity(),
-            PolynomialLabel::Instance(0),
+            PolynomialLabel::CommittedInstance(0),
         )],
         &[&full_pi],
         proof,

--- a/aggregation/examples/final_ivc_verification.rs
+++ b/aggregation/examples/final_ivc_verification.rs
@@ -314,7 +314,7 @@ fn final_accumulator<const N: usize>(
 }
 
 fn main() {
-    const K: u32 = 17;
+    const K: u32 = 18;
     const N: usize = 1;
     const STEPS: usize = 2;
 

--- a/aggregation/examples/final_ivc_verification.rs
+++ b/aggregation/examples/final_ivc_verification.rs
@@ -1,0 +1,394 @@
+//! Verifies a complete IVC proof **in-circuit** and compresses the whole chain
+//! into a single accumulator, following the "final IVC circuit" design:
+//!
+//! 1. Partially verify the IVC proof with the IVC decider ([`IvcDecider`]) —
+//!    prepare only, fixed bases kept symbolic.
+//! 2. Merge the resulting accumulator with the one carried in the IVC proof's
+//!    public inputs (known non-genesis, so no scaling).
+//! 3. Collapse and resolve the fixed bases once.
+//!
+//! The single collapsed accumulator is exposed as a public input; its pairing
+//! (the decider) is discharged off-circuit at the end — the same check
+//! [`IvcVerifier::verify`] performs.
+//!
+//! DO NOT add this example to the CI as it is slow.
+
+use std::collections::BTreeMap;
+
+use ff::Field;
+use group::Group;
+use midnight_aggregation::ivc::{
+    self, circuit::IvcFinalDecider, IvcAssignedFinalVk, IvcCircuit, IvcContext, IvcFinalVk, IvcIO,
+    IvcState, IvcTransition,
+};
+use midnight_circuits::{
+    hash::poseidon::{PoseidonChip, PoseidonState},
+    instructions::{hash::HashCPU, *},
+    types::{AssignedNative, Instantiable},
+    verifier::{
+        fixed_base_labels, fixed_bases, Accumulator, AssignedAccumulator, AssignedKZGCommitment,
+        BlstrsEmulation, SelfEmulation,
+    },
+};
+use midnight_curves::G1Projective as C;
+use midnight_proofs::{
+    circuit::{Layouter, Value},
+    plonk::Error,
+    poly::{kzg::commitment::KZGCommitment, PolynomialLabel},
+};
+use midnight_zk_stdlib::{
+    decider::Decider,
+    prove, setup_pk, setup_vk,
+    utils::plonk_api::{load_srs, SrsSource},
+    MidnightVK, Relation, ZkStdLib, ZkStdLibArch,
+};
+use rand::rngs::OsRng;
+
+type S = BlstrsEmulation;
+type F = <S as SelfEmulation>::F;
+
+// ---------------------------------------------------------------------------
+// A minimal IVC transition: a Poseidon hash-chain with a step counter.
+// (Copied from the `ivc` example.)
+// ---------------------------------------------------------------------------
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct State {
+    cnt: F,
+    val: F,
+}
+
+#[derive(Clone, Debug)]
+pub struct AssignedState {
+    cnt: AssignedNative<F>,
+    val: AssignedNative<F>,
+}
+
+#[derive(Clone, Debug)]
+pub struct PoseidonChain<const N: usize> {
+    std_lib: ZkStdLib,
+}
+
+impl<const N: usize> IvcContext for PoseidonChain<N> {
+    type Context = ();
+    fn new(std_lib: ZkStdLib, _ctx: &()) -> Self {
+        PoseidonChain { std_lib }
+    }
+    fn write_context<W: std::io::Write>(_ctx: &(), _writer: &mut W) -> std::io::Result<()> {
+        Ok(())
+    }
+    fn read_context<R: std::io::Read>(_reader: &mut R) -> std::io::Result<()> {
+        Ok(())
+    }
+}
+
+impl<const N: usize> IvcState for PoseidonChain<N> {
+    type State = State;
+    type AssignedState = AssignedState;
+    fn genesis(_ctx: &()) -> Self::State {
+        State {
+            cnt: F::ZERO,
+            val: F::ZERO,
+        }
+    }
+    fn decider(_ctx: &Self::Context, _state: &Self::State) -> bool {
+        true
+    }
+}
+
+impl<const N: usize> IvcIO for PoseidonChain<N> {
+    fn assign(
+        &self,
+        layouter: &mut impl Layouter<F>,
+        value: Value<State>,
+    ) -> Result<AssignedState, Error> {
+        let scalar_chip = self.std_lib.bls12_381().scalar_field_chip();
+        Ok(AssignedState {
+            cnt: scalar_chip.assign(layouter, value.as_ref().map(|s| s.cnt))?,
+            val: scalar_chip.assign(layouter, value.as_ref().map(|s| s.val))?,
+        })
+    }
+    fn constrain_as_public_input(
+        &self,
+        layouter: &mut impl Layouter<F>,
+        state: &AssignedState,
+    ) -> Result<(), Error> {
+        let scalar_chip = self.std_lib.bls12_381().scalar_field_chip();
+        scalar_chip.constrain_as_public_input(layouter, &state.cnt)?;
+        scalar_chip.constrain_as_public_input(layouter, &state.val)
+    }
+    fn as_public_input(
+        &self,
+        _layouter: &mut impl Layouter<F>,
+        state: &AssignedState,
+    ) -> Result<Vec<AssignedNative<F>>, Error> {
+        Ok(vec![state.cnt.clone(), state.val.clone()])
+    }
+    fn format_public_input(state: &State) -> Vec<F> {
+        vec![state.cnt, state.val]
+    }
+}
+
+impl<const N: usize> IvcTransition for PoseidonChain<N> {
+    type Witness = ();
+    fn arch() -> ZkStdLibArch {
+        ZkStdLibArch {
+            poseidon: true,
+            nb_arith_cols: 9,
+            nr_pow2range_cols: 8,
+            ..ZkStdLibArch::default()
+        }
+    }
+    fn transition(_ctx: &(), state: &Self::State, _witness: Self::Witness) -> Self::State {
+        let mut val = state.val;
+        for _ in 0..N {
+            val = <PoseidonChip<F> as HashCPU<F, F>>::hash(&[val]);
+        }
+        State {
+            cnt: state.cnt + F::from(N as u64),
+            val,
+        }
+    }
+    fn circuit_transition(
+        &self,
+        layouter: &mut impl Layouter<F>,
+        state: &Self::AssignedState,
+        _witness: Value<Self::Witness>,
+    ) -> Result<Self::AssignedState, Error> {
+        let scalar_chip = self.std_lib.bls12_381().scalar_field_chip();
+        let mut val = state.val.clone();
+        for _ in 0..N {
+            val = self.std_lib.poseidon(layouter, &[val])?;
+        }
+        let cnt = scalar_chip.add_constant(layouter, &state.cnt, F::from(N as u64))?;
+        Ok(AssignedState { cnt, val })
+    }
+}
+
+#[derive(Clone, Debug)]
+struct FinalIvcWitness {
+    state: State,
+    carried_acc: Accumulator<S>,
+    proof: Vec<u8>,
+}
+
+/// Relation that verifies a complete IVC proof for `ivc_vk`. It delegates the
+/// verify-fold-collapse to [`IvcCircuit`]'s decider (one final chain step) and
+/// then finalizes: resolves the fixed bases and exposes the single accumulator.
+#[derive(Clone)]
+struct FinalIvcVerifier<const N: usize> {
+    ivc_vk: MidnightVK,
+}
+
+impl<const N: usize> Relation for FinalIvcVerifier<N> {
+    type Instance = Vec<F>;
+    type Witness = FinalIvcWitness;
+    type Error = Error;
+
+    fn format_instance(instance: &Self::Instance) -> Result<Vec<F>, Error> {
+        Ok(instance.clone())
+    }
+
+    fn used_chips(&self) -> ZkStdLibArch {
+        ZkStdLibArch {
+            poseidon: true,
+            bls12_381: true,
+            nb_arith_cols: 9,
+            nr_pow2range_cols: 8,
+            ..ZkStdLibArch::default()
+        }
+    }
+
+    fn circuit(
+        &self,
+        std_lib: &ZkStdLib,
+        layouter: &mut impl Layouter<F>,
+        _instance: Value<Self::Instance>,
+        witness: Value<Self::Witness>,
+    ) -> Result<(), Error> {
+        let verifier = std_lib.verifier();
+        let scalar_chip = std_lib.bls12_381().scalar_field_chip();
+        let plonk_vk = self.ivc_vk.vk();
+        let cs = plonk_vk.cs();
+
+        // 1. Assign the (known) IVC verifying key as a constant.
+        let assigned_vk = verifier.assign_fixed_vk(
+            layouter,
+            plonk_vk.get_domain(),
+            cs,
+            plonk_vk.transcript_repr(),
+        )?;
+
+        // 2. Assign the final state.
+        let cnt = scalar_chip.assign(layouter, witness.as_ref().map(|w| w.state.cnt))?;
+        let val = scalar_chip.assign(layouter, witness.as_ref().map(|w| w.state.val))?;
+
+        // 3. Assign the carried accumulator (collapsed, symbolic fixed bases).
+        let fb_labels = fixed_base_labels::<S>(
+            cs.num_fixed_columns() + cs.num_selectors(),
+            cs.permutation().columns.len(),
+        );
+        let carried = verifier.assign_collapsed_accumulator(
+            layouter,
+            &fb_labels,
+            witness.as_ref().map(|w| w.carried_acc.clone()),
+        )?;
+
+        // 4. Reconstruct the IVC proof's public inputs: vk_repr ++ state ++ acc. Using
+        //    the *same* assigned `carried` for both the PI and the fold is what binds
+        //    it to the proof.
+        let proof_pi = [
+            verifier.as_public_input(layouter, &assigned_vk)?,
+            vec![cnt, val],
+            verifier.as_public_input(layouter, &carried)?,
+        ]
+        .concat();
+
+        let committed = vec![AssignedKZGCommitment::simple(
+            std_lib.bls12_381().assign_fixed(layouter, C::identity())?,
+            PolynomialLabel::Instance(0),
+        )];
+
+        // 5. Run the final chain step (verify + fold + collapse + resolve) via
+        //    IvcCircuit's decider. The `carried` folded here is the *same* assigned
+        //    value used in `proof_pi`, which binds it to the proof.
+        let assigned_bases = fixed_bases::<S>(plonk_vk)
+            .into_iter()
+            .map(|(l, p)| Ok((l, std_lib.bls12_381().assign_fixed(layouter, p)?)))
+            .collect::<Result<BTreeMap<_, _>, Error>>()?;
+        let final_vk = IvcAssignedFinalVk {
+            vk: assigned_vk,
+            carried_acc: carried,
+            fixed_bases: assigned_bases,
+        };
+        let merged = IvcFinalDecider::in_circuit_prepare(
+            std_lib,
+            layouter,
+            &final_vk,
+            &committed,
+            &[&proof_pi],
+            witness.map(|w| w.proof),
+        )?
+        .expect("IvcCircuit decider yields an accumulator");
+
+        // 6. Expose the fully-resolved accumulator for the (off-circuit) pairing.
+        verifier.constrain_as_public_input(layouter, &merged)?;
+        Ok(())
+    }
+
+    fn write_relation<W: std::io::Write>(&self, _writer: &mut W) -> std::io::Result<()> {
+        unimplemented!("not needed for this example")
+    }
+    fn read_relation<R: std::io::Read>(_reader: &mut R) -> std::io::Result<Self> {
+        unimplemented!("not needed for this example")
+    }
+}
+
+/// Off-circuit mirror of [`FinalIvcVerifier::circuit`]: computes the exposed
+/// collapsed-and-resolved accumulator so we can also run the final pairing.
+fn final_accumulator<const N: usize>(
+    ivc_vk: &MidnightVK,
+    state: &State,
+    carried_acc: &Accumulator<S>,
+    proof: &[u8],
+) -> Accumulator<S> {
+    let mut full_pi = vec![ivc_vk.vk().transcript_repr(), state.cnt, state.val];
+    full_pi.extend(AssignedAccumulator::<S>::as_public_input(carried_acc));
+
+    // Verify + fold + collapse + resolve, via IvcCircuit's decider (final step).
+    let final_vk = IvcFinalVk {
+        vk: ivc_vk.clone(),
+        accumulator: carried_acc.clone(),
+    };
+    IvcFinalDecider::prepare(
+        &final_vk,
+        &[KZGCommitment::Simple(
+            C::identity(),
+            PolynomialLabel::Instance(0),
+        )],
+        &[&full_pi],
+        proof,
+    )
+    .expect("off-circuit decide should succeed")
+    .expect("IvcCircuit decider yields an accumulator")
+}
+
+fn main() {
+    const K: u32 = 17;
+    const N: usize = 1;
+    const STEPS: usize = 2;
+
+    // 1. Run a short IVC chain.
+    let srs = load_srs(
+        SrsSource::Midnight,
+        K,
+        IvcCircuit::<PoseidonChain<N>>::cs_degree(),
+    );
+    let (mut prover, verifier) = ivc::setup::<PoseidonChain<N>>(srs, K, ());
+    let mut ivc_proof = Vec::new();
+    for _ in 0..STEPS {
+        ivc_proof = prover.prove_step(()).unwrap();
+    }
+    let ivc_instance = prover.instance();
+    verifier.verify(&ivc_instance, &ivc_proof).unwrap();
+    println!("IVC chain of {STEPS} steps produced and natively verified.");
+
+    // 2. Assemble the final circuit's inputs (the same triple an IVC step consumes:
+    //    the final state, the carried accumulator and the proof).
+    let ivc_vk = verifier.vk().clone();
+    let state = *ivc_instance.state();
+    let carried_acc = ivc_instance.acc().clone();
+
+    // The exposed public input: the collapsed-and-resolved accumulator
+    // (off-circuit mirror of the circuit).
+    let merged = final_accumulator::<N>(&ivc_vk, &state, &carried_acc, &ivc_proof);
+    let exposed_pi = AssignedAccumulator::<S>::as_public_input(&merged);
+
+    // Sanity: the merged accumulator satisfies the pairing (the decider check).
+    assert!(
+        merged.check(
+            verifier.params_verifier(),
+            &std::collections::BTreeMap::new()
+        ),
+        "decider pairing on the compressed accumulator failed"
+    );
+    println!("Off-circuit decider check on the compressed accumulator passed.");
+
+    let witness = FinalIvcWitness {
+        state,
+        carried_acc,
+        proof: ivc_proof,
+    };
+    let relation = FinalIvcVerifier::<N> { ivc_vk };
+
+    // 3. Prove & verify the final circuit in-circuit.
+    let outer_k = 19;
+    let outer_srs = load_srs(
+        SrsSource::Midnight,
+        outer_k,
+        midnight_zk_stdlib::cs_degree(relation.used_chips()),
+    );
+    let outer_vk = setup_vk(&outer_srs, &relation);
+    let outer_pk = setup_pk(&relation, &outer_vk);
+
+    let outer_proof = prove::<FinalIvcVerifier<N>, PoseidonState<F>>(
+        &outer_srs,
+        &outer_pk,
+        &relation,
+        &exposed_pi,
+        witness,
+        OsRng,
+    )
+    .unwrap();
+
+    midnight_zk_stdlib::verify::<FinalIvcVerifier<N>, PoseidonState<F>>(
+        &outer_srs.verifier_params(),
+        &outer_vk,
+        &exposed_pi,
+        None,
+        &outer_proof,
+    )
+    .unwrap();
+
+    println!("In-circuit verification of the complete IVC proof succeeded.");
+}

--- a/aggregation/examples/ivc.rs
+++ b/aggregation/examples/ivc.rs
@@ -169,7 +169,7 @@ fn main() {
     // smaller K might too. Binary-search to find it.
     const K: u32 = 17;
 
-    const N: usize = 1_000; // Number of Poseidon iteration per IVC step.
+    const N: usize = 500; // Number of Poseidon iteration per IVC step.
     const STEPS: usize = 3; // Number of IVC steps to run.
 
     let srs = load_srs(

--- a/aggregation/src/ivc/circuit.rs
+++ b/aggregation/src/ivc/circuit.rs
@@ -22,8 +22,8 @@ use midnight_circuits::{
 };
 use midnight_curves::Bls12;
 use midnight_proofs::{
-    circuit::{Layouter, Value}, plonk::{ConstraintSystem, Error, VerifyingKey}, poly::{
-        EvaluationDomain, PolynomialLabel, kzg::{KZGCommitmentScheme, commitment::KZGCommitment},
+    circuit::{Layouter, Value}, plonk::{ConstraintSystem, Error}, poly::{
+        EvaluationDomain, PolynomialLabel, kzg::commitment::KZGCommitment,
     }, utils::helpers::ProcessedSerdeObject,
 };
 use midnight_zk_stdlib::{

--- a/aggregation/src/ivc/circuit.rs
+++ b/aggregation/src/ivc/circuit.rs
@@ -9,7 +9,7 @@
 //! there is no meaningful prior proof to verify, so the circuit substitutes a
 //! default accumulator that satisfies the verification invariant.
 
-use std::collections::BTreeMap;
+use std::{collections::BTreeMap, io};
 
 use group::Group;
 use midnight_circuits::{
@@ -17,20 +17,22 @@ use midnight_circuits::{
     types::{AssignedNative, Instantiable},
     verifier::{
         fixed_bases, Accumulator, AssignedAccumulator, AssignedKZGCommitment, AssignedVk,
-        SelfEmulation,
+        InCircuitKZG, SelfEmulation,
     },
 };
 use midnight_curves::Bls12;
 use midnight_proofs::{
-    circuit::{Layouter, Value}, plonk::{ConstraintSystem, Error}, poly::{
-        EvaluationDomain, PolynomialLabel, kzg::commitment::KZGCommitment,
-    }, utils::helpers::ProcessedSerdeObject,
+    circuit::{Layouter, Value},
+    plonk::{ConstraintSystem, Error},
+    poly::{kzg::commitment::KZGCommitment, EvaluationDomain, PolynomialLabel},
+    utils::{helpers::ProcessedSerdeObject, SerdeFormat},
 };
 use midnight_zk_stdlib::{
-    MidnightVK, Relation, ZkStdLib, ZkStdLibArch, decidable::{Decider, DeciderKind, IvcDecider},
+    decider::{Decider, DeciderKind, IvcDecider},
+    MidnightVK, Relation, ZkStdLib, ZkStdLibArch,
 };
 
-use super::{Ivc, IvcError, F, S};
+use super::{Ivc, IvcError, C, F, S};
 
 /// The public instance (statement) of an IVC proof.
 ///
@@ -193,11 +195,10 @@ impl<T: Ivc> Relation for IvcCircuit<T> {
         ]
         .concat();
 
-        let instance_com = AssignedKZGMultiCommitment::commitment_to_zero(
-            layouter,
-            std_lib.bls12_381(),
+        let instance_com = AssignedKZGCommitment::simple(
+            std_lib.bls12_381().assign_fixed(layouter, C::identity())?,
             PolynomialLabel::CommittedInstance(0),
-        )?;
+        );
 
         // Verify a witnessed proof that ensures the validity of `prev_state`.
         // The proof is valid iff `prev_proof_acc` satisfies the invariant.
@@ -269,16 +270,19 @@ pub struct IvcFinalVk {
 }
 
 impl ProcessedSerdeObject for IvcFinalVk {
-    fn read<R: std::io::Read>(reader: &mut R, format: midnight_proofs::utils::SerdeFormat) -> std::io::Result<Self> {
-        todo!()
+    fn read<R: io::Read>(reader: &mut R, format: SerdeFormat) -> io::Result<Self> {
+        let vk = MidnightVK::read(reader, format)?;
+        let accumulator = Accumulator::<S>::read(reader, format)?;
+        Ok(IvcFinalVk { vk, accumulator })
     }
 
-    fn write<W: std::io::Write>(&self, writer: &mut W, format: midnight_proofs::utils::SerdeFormat) -> std::io::Result<()> {
-        todo!()
+    fn write<W: io::Write>(&self, writer: &mut W, format: SerdeFormat) -> io::Result<()> {
+        self.vk.write(writer, format)?;
+        self.accumulator.write(writer, format)
     }
 
-    fn byte_length(&self, format: midnight_proofs::utils::SerdeFormat) -> usize {
-        todo!()
+    fn byte_length(&self, format: SerdeFormat) -> usize {
+        self.vk.byte_length(format) + self.accumulator.byte_length(format)
     }
 }
 
@@ -286,7 +290,7 @@ impl ProcessedSerdeObject for IvcFinalVk {
 #[derive(Clone, Debug)]
 pub struct IvcAssignedFinalVk {
     /// Assigned VK.
-    pub vk: AssignedVk<S>,
+    pub vk: AssignedVk<S, InCircuitKZG<S>>,
     /// Assigned accumulator from the IVC instance.
     pub carried_acc: AssignedAccumulator<S>,
     /// Assigned fixed bases map.

--- a/aggregation/src/ivc/circuit.rs
+++ b/aggregation/src/ivc/circuit.rs
@@ -16,15 +16,18 @@ use midnight_circuits::{
     instructions::{AssignmentInstructions, BinaryInstructions, PublicInputInstructions},
     types::{AssignedNative, Instantiable},
     verifier::{
-        fixed_bases, Accumulator, AssignedAccumulator, AssignedKZGCommitment, AssignedVk,
-        InCircuitKZG, SelfEmulation,
+        fixed_base_labels, fixed_bases, Accumulator, AssignedAccumulator, AssignedKZGCommitment,
+        AssignedVk, InCircuitKZG, SelfEmulation,
     },
 };
 use midnight_curves::Bls12;
 use midnight_proofs::{
     circuit::{Layouter, Value},
-    plonk::{ConstraintSystem, Error},
-    poly::{kzg::commitment::KZGCommitment, EvaluationDomain, PolynomialLabel},
+    plonk::{ConstraintSystem, Error, VerifyingKey},
+    poly::{
+        kzg::{commitment::KZGCommitment, KZGCommitmentScheme},
+        EvaluationDomain, PolynomialLabel,
+    },
     utils::{helpers::ProcessedSerdeObject, SerdeFormat},
 };
 use midnight_zk_stdlib::{
@@ -258,6 +261,9 @@ impl<T: Ivc> Relation for IvcCircuit<T> {
     }
 }
 
+/// The underlying midnight-proofs verifying key type wrapped by [`MidnightVK`].
+type PlonkVk = VerifyingKey<midnight_curves::Fq, KZGCommitmentScheme<Bls12>>;
+
 /// Off-circuit verifying context for *finalizing* an IVC chain: the IVC PLONK
 /// verifying key plus the (structured) accumulator carried in the proof's
 /// public inputs.
@@ -267,6 +273,13 @@ pub struct IvcFinalVk {
     pub vk: MidnightVK,
     /// Accumulator from the IVC instance
     pub accumulator: Accumulator<S>,
+}
+
+impl IvcFinalVk {
+    /// The underlying midnight-proofs verifying key of the IVC circuit.
+    fn plonk_vk(&self) -> &PlonkVk {
+        self.vk.vk()
+    }
 }
 
 impl ProcessedSerdeObject for IvcFinalVk {
@@ -305,15 +318,40 @@ pub struct IvcFinalDecider {}
 impl Decider for IvcFinalDecider {
     type Vk = IvcFinalVk;
     type AssignedVk = IvcAssignedFinalVk;
-    
+
     const KIND: DeciderKind = DeciderKind::FinalIVC;
-    
+
     fn assign_vk(
         std_lib: &ZkStdLib,
         layouter: &mut impl Layouter<F>,
         vk: &Self::Vk,
     ) -> Result<Self::AssignedVk, Error> {
-        todo!()
+        let bls = std_lib.bls12_381();
+        let plonk_vk = vk.plonk_vk();
+
+        let assigned_vk = IvcDecider::assign_vk(std_lib, layouter, &vk.vk)?;
+
+        let fixed_bases = fixed_bases::<S>(plonk_vk)
+            .into_iter()
+            .map(|(l, p)| Ok((l, bls.assign_fixed(layouter, p)?)))
+            .collect::<Result<BTreeMap<_, _>, Error>>()?;
+
+        let cs = plonk_vk.cs();
+        let fb_labels = fixed_base_labels::<S>(
+            cs.num_fixed_columns() + cs.num_selectors(),
+            cs.permutation().columns.len(),
+        );
+        let carried_acc = std_lib.verifier().assign_collapsed_accumulator(
+            layouter,
+            &fb_labels,
+            Value::known(vk.accumulator.clone()),
+        )?;
+
+        Ok(IvcAssignedFinalVk {
+            vk: assigned_vk,
+            carried_acc,
+            fixed_bases,
+        })
     }
 
     fn prepare(
@@ -326,7 +364,7 @@ impl Decider for IvcFinalDecider {
             .expect("IvcDecider always yields an accumulator");
         let mut next_acc = Accumulator::accumulate(&[proof_acc, vk.accumulator.clone()]);
         next_acc.collapse();
-        next_acc.resolve_fixed_bases(&fixed_bases::<S>(&vk.vk.vk()));
+        next_acc.resolve_fixed_bases(&fixed_bases::<S>(vk.plonk_vk()));
         Ok(Some(next_acc))
     }
 
@@ -362,8 +400,11 @@ impl Decider for IvcFinalDecider {
         params: &midnight_proofs::poly::kzg::params::ParamsVerifierKZG<Bls12>,
         vk: &Self::Vk,
     ) -> Result<(), Error> {
-        
-        let fixed_bases = fixed_bases::<S>(vk.vk.vk());
-        if acc.check(params, &fixed_bases) {Ok(())} else {Err(Error::Opening)}
+        let fixed_bases = fixed_bases::<S>(vk.plonk_vk());
+        if acc.check(params, &fixed_bases) {
+            Ok(())
+        } else {
+            Err(Error::Opening)
+        }
     }
 }

--- a/aggregation/src/ivc/circuit.rs
+++ b/aggregation/src/ivc/circuit.rs
@@ -9,19 +9,26 @@
 //! there is no meaningful prior proof to verify, so the circuit substitutes a
 //! default accumulator that satisfies the verification invariant.
 
+use std::collections::BTreeMap;
+
+use group::Group;
 use midnight_circuits::{
-    instructions::{BinaryInstructions, PublicInputInstructions},
-    types::Instantiable,
+    instructions::{AssignmentInstructions, BinaryInstructions, PublicInputInstructions},
+    types::{AssignedNative, Instantiable},
     verifier::{
-        Accumulator, AssignedAccumulator, AssignedKZGMultiCommitment, AssignedVk, InCircuitKZG,
+        fixed_bases, Accumulator, AssignedAccumulator, AssignedKZGCommitment, AssignedVk,
+        SelfEmulation,
     },
 };
+use midnight_curves::Bls12;
 use midnight_proofs::{
-    circuit::{Layouter, Value},
-    plonk::ConstraintSystem,
-    poly::{EvaluationDomain, PolynomialLabel},
+    circuit::{Layouter, Value}, plonk::{ConstraintSystem, Error, VerifyingKey}, poly::{
+        EvaluationDomain, PolynomialLabel, kzg::{KZGCommitmentScheme, commitment::KZGCommitment},
+    }, utils::helpers::ProcessedSerdeObject,
 };
-use midnight_zk_stdlib::{Relation, ZkStdLib, ZkStdLibArch};
+use midnight_zk_stdlib::{
+    Relation, ZkStdLib, ZkStdLibArch, decidable::{Decider, DeciderKind, IvcDecider},
+};
 
 use super::{Ivc, IvcError, F, S};
 
@@ -47,6 +54,11 @@ impl<T: Ivc> IvcInstance<T> {
     /// Returns the current state.
     pub fn state(&self) -> &T::State {
         &self.state
+    }
+
+    /// Returns the accumulator carried by this instance.
+    pub fn acc(&self) -> &Accumulator<S> {
+        &self.acc
     }
 }
 
@@ -189,13 +201,15 @@ impl<T: Ivc> Relation for IvcCircuit<T> {
 
         // Verify a witnessed proof that ensures the validity of `prev_state`.
         // The proof is valid iff `prev_proof_acc` satisfies the invariant.
-        let mut prev_proof_acc = verifier_gadget.prepare(
+        let mut prev_proof_acc = IvcDecider::in_circuit_prepare(
+            std_lib,
             layouter,
             &assigned_self_vk,
             &[instance_com],
             &[&prev_proof_pi],
             witness.map(|w| w.prev_proof),
-        )?;
+        )?
+        .expect("IvcDecider always yields an accumulator");
 
         // If `prev_state` is genesis, the provided accumulator is discarded/multiplied
         // by 0 so that it trivially satisfies the invariant.

--- a/aggregation/src/ivc/circuit.rs
+++ b/aggregation/src/ivc/circuit.rs
@@ -27,7 +27,7 @@ use midnight_proofs::{
     }, utils::helpers::ProcessedSerdeObject,
 };
 use midnight_zk_stdlib::{
-    Relation, ZkStdLib, ZkStdLibArch, decidable::{Decider, DeciderKind, IvcDecider},
+    MidnightVK, Relation, ZkStdLib, ZkStdLibArch, decidable::{Decider, DeciderKind, IvcDecider},
 };
 
 use super::{Ivc, IvcError, F, S};
@@ -254,5 +254,112 @@ impl<T: Ivc> Relation for IvcCircuit<T> {
         let domain = EvaluationDomain::new(cs.degree() as u32, k);
 
         Ok(IvcCircuit { domain, cs, ctx })
+    }
+}
+
+/// Off-circuit verifying context for *finalizing* an IVC chain: the IVC PLONK
+/// verifying key plus the (structured) accumulator carried in the proof's
+/// public inputs.
+#[derive(Clone, Debug)]
+pub struct IvcFinalVk {
+    /// Circuit VK
+    pub vk: MidnightVK,
+    /// Accumulator from the IVC instance
+    pub accumulator: Accumulator<S>,
+}
+
+impl ProcessedSerdeObject for IvcFinalVk {
+    fn read<R: std::io::Read>(reader: &mut R, format: midnight_proofs::utils::SerdeFormat) -> std::io::Result<Self> {
+        todo!()
+    }
+
+    fn write<W: std::io::Write>(&self, writer: &mut W, format: midnight_proofs::utils::SerdeFormat) -> std::io::Result<()> {
+        todo!()
+    }
+
+    fn byte_length(&self, format: midnight_proofs::utils::SerdeFormat) -> usize {
+        todo!()
+    }
+}
+
+/// In-circuit analog of [`IvcFinalVk`].
+#[derive(Clone, Debug)]
+pub struct IvcAssignedFinalVk {
+    /// Assigned VK.
+    pub vk: AssignedVk<S>,
+    /// Assigned accumulator from the IVC instance.
+    pub carried_acc: AssignedAccumulator<S>,
+    /// Assigned fixed bases map.
+    pub fixed_bases: BTreeMap<PolynomialLabel, <S as SelfEmulation>::AssignedPoint>,
+}
+
+/// IVC final decider. Updates the state (as per the step function) once, and
+/// collapses the MSM (including the fixed bases) into a collapsed MSM.
+#[derive(Clone, Copy, Debug, Default)]
+pub struct IvcFinalDecider {}
+
+impl Decider for IvcFinalDecider {
+    type Vk = IvcFinalVk;
+    type AssignedVk = IvcAssignedFinalVk;
+    
+    const KIND: DeciderKind = DeciderKind::FinalIVC;
+    
+    fn assign_vk(
+        std_lib: &ZkStdLib,
+        layouter: &mut impl Layouter<F>,
+        vk: &Self::Vk,
+    ) -> Result<Self::AssignedVk, Error> {
+        todo!()
+    }
+
+    fn prepare(
+        vk: &Self::Vk,
+        committed_instance: &[KZGCommitment<midnight_curves::Bls12>],
+        instance: &[&[F]],
+        proof: &[u8],
+    ) -> Result<Option<Accumulator<S>>, Error> {
+        let proof_acc = IvcDecider::prepare(&vk.vk, committed_instance, instance, proof)?
+            .expect("IvcDecider always yields an accumulator");
+        let mut next_acc = Accumulator::accumulate(&[proof_acc, vk.accumulator.clone()]);
+        next_acc.collapse();
+        next_acc.resolve_fixed_bases(&fixed_bases::<S>(&vk.vk.vk()));
+        Ok(Some(next_acc))
+    }
+
+    fn in_circuit_prepare(
+        std_lib: &ZkStdLib,
+        layouter: &mut impl Layouter<F>,
+        vk: &Self::AssignedVk,
+        committed_instance: &[AssignedKZGCommitment<S>],
+        instance: &[&[AssignedNative<F>]],
+        proof: Value<Vec<u8>>,
+    ) -> Result<Option<AssignedAccumulator<S>>, Error> {
+        let bls = std_lib.bls12_381();
+
+        let proof_acc = IvcDecider::in_circuit_prepare(
+            std_lib,
+            layouter,
+            &vk.vk,
+            committed_instance,
+            instance,
+            proof,
+        )?
+        .expect("IvcDecider always yields an accumulator");
+        let mut next_acc =
+            std_lib.verifier().accumulate(layouter, &[proof_acc, vk.carried_acc.clone()])?;
+        next_acc.collapse(layouter, bls, bls.scalar_field_chip())?;
+        next_acc.resolve_fixed_bases(&vk.fixed_bases);
+
+        Ok(Some(next_acc))
+    }
+
+    fn decide(
+        acc: &Accumulator<S>,
+        params: &midnight_proofs::poly::kzg::params::ParamsVerifierKZG<Bls12>,
+        vk: &Self::Vk,
+    ) -> Result<(), Error> {
+        
+        let fixed_bases = fixed_bases::<S>(vk.vk.vk());
+        if acc.check(params, &fixed_bases) {Ok(())} else {Err(Error::Opening)}
     }
 }

--- a/aggregation/src/ivc/mod.rs
+++ b/aggregation/src/ivc/mod.rs
@@ -19,8 +19,9 @@
 //! the chain length is relevant, it can be tracked by including a counter in
 //! the state that the transition function increments at each step.
 
-pub use circuit::{IvcCircuit, IvcInstance, IvcWitness};
+pub use circuit::{IvcAssignedFinalVk, IvcCircuit, IvcFinalVk, IvcInstance, IvcWitness};
 pub use error::IvcError;
+pub use midnight_zk_stdlib::decidable::IvcDecider;
 use midnight_circuits::{
     instructions::{BinaryInstructions, EqualityInstructions},
     types::{AssignedBit, AssignedNative},

--- a/aggregation/src/ivc/mod.rs
+++ b/aggregation/src/ivc/mod.rs
@@ -21,7 +21,6 @@
 
 pub use circuit::{IvcAssignedFinalVk, IvcCircuit, IvcFinalVk, IvcInstance, IvcWitness};
 pub use error::IvcError;
-pub use midnight_zk_stdlib::decidable::IvcDecider;
 use midnight_circuits::{
     instructions::{BinaryInstructions, EqualityInstructions},
     types::{AssignedBit, AssignedNative},
@@ -31,6 +30,7 @@ use midnight_proofs::{
     circuit::{Layouter, Value},
     plonk::Error,
 };
+pub use midnight_zk_stdlib::decider::IvcDecider;
 use midnight_zk_stdlib::{ZkStdLib, ZkStdLibArch};
 pub use prover::IvcProver;
 pub use setup::setup;

--- a/aggregation/src/ivc/prover.rs
+++ b/aggregation/src/ivc/prover.rs
@@ -7,23 +7,23 @@
 //! accumulates the result, produces a new proof for the updated state, and
 //! stores everything internally so the next step can build on it.
 
+use group::Group;
 use midnight_circuits::{
     hash::poseidon::PoseidonState,
     types::Instantiable,
     verifier::{Accumulator, AssignedAccumulator, AssignedVk, InCircuitKZG},
 };
-use midnight_proofs::{
-    plonk::{self},
-    poly::{
-        kzg::{commitment::KZGMultiCommitment, params::ParamsKZG, KZGCommitmentScheme},
-        PolynomialLabel,
-    },
-    transcript::{CircuitTranscript, Transcript},
+use midnight_proofs::poly::{
+    kzg::{commitment::KZGCommitment, params::ParamsKZG},
+    PolynomialLabel,
 };
-use midnight_zk_stdlib::MidnightPK;
+use midnight_zk_stdlib::{
+    decider::{Decider, IvcDecider},
+    MidnightPK,
+};
 use rand::rngs::OsRng;
 
-use super::{Ivc, IvcCircuit, IvcError, IvcInstance, IvcWitness, E, F, S};
+use super::{Ivc, IvcCircuit, IvcError, IvcInstance, IvcWitness, C, E, F, S};
 
 /// Stateful IVC prover holding:
 /// - the SRS (params),
@@ -63,10 +63,10 @@ impl<T: Ivc> IvcProver<T> {
         let next_state =
             T::transition(self.relation.ctx(), &self.state, transition_witness.clone());
 
-        let vk = self.pk.pk().get_vk();
-        let vk_repr = vk.transcript_repr();
+        let vk = self.pk.vk();
+        let vk_repr = vk.vk().transcript_repr();
 
-        let fixed_bases = midnight_circuits::verifier::fixed_bases::<S>(vk);
+        let fixed_bases = midnight_circuits::verifier::fixed_bases::<S>(vk.vk());
 
         // Off-circuit verification of the previous proof.
         let proof_acc = if T::is_genesis(self.relation.ctx(), &self.state) {
@@ -88,29 +88,24 @@ impl<T: Ivc> IvcProver<T> {
         } else {
             // Construct the public inputs of the previous proof.
             let prev_pi = [
-                AssignedVk::<S, InCircuitKZG<S>>::as_public_input(vk),
+                AssignedVk::<S, InCircuitKZG<S>>::as_public_input(vk.vk()),
                 T::format_public_input(&self.state),
                 AssignedAccumulator::<S>::as_public_input(&self.acc),
             ]
             .concat();
 
-            let mut transcript =
-                CircuitTranscript::<PoseidonState<F>>::init_from_bytes(&self.proof);
-            let dual_msm =
-                plonk::prepare::<F, KZGCommitmentScheme<E>, CircuitTranscript<PoseidonState<F>>>(
-                    vk,
-                    &[KZGMultiCommitment::commitment_to_zero(
-                        PolynomialLabel::CommittedInstance(0),
-                    )],
-                    &[&prev_pi],
-                    &mut transcript,
-                )?;
-
-            if !dual_msm.clone().check(&self.params.verifier_params()) {
-                return Err(IvcError::InvalidProof);
-            }
-
-            Accumulator::from_dual_msm(dual_msm, &fixed_bases)
+            // Off-circuit partial verification of the previous proof, via the
+            // IVC circuit's decider (prepare-only, mirroring the in-circuit path).
+            IvcDecider::prepare(
+                &vk,
+                &[KZGCommitment::Simple(
+                    C::identity(),
+                    PolynomialLabel::CommittedInstance(0),
+                )],
+                &[&prev_pi],
+                &self.proof,
+            )?
+            .expect("IvcDecider always yields an accumulator")
         };
 
         // Accumulate the proof accumulator with the previous accumulator.

--- a/aggregation/src/ivc/verifier.rs
+++ b/aggregation/src/ivc/verifier.rs
@@ -14,7 +14,10 @@ use midnight_proofs::{
     },
     transcript::{CircuitTranscript, Transcript},
 };
-use midnight_zk_stdlib::{MidnightVK, Relation};
+use midnight_zk_stdlib::{
+    decider::{Decider, IvcDecider},
+    MidnightVK, Relation,
+};
 
 use super::{Ivc, IvcCircuit, IvcError, IvcInstance, E, F, S};
 
@@ -32,6 +35,16 @@ pub struct IvcVerifier<T: Ivc> {
 }
 
 impl<T: Ivc> IvcVerifier<T> {
+    /// The verifying key of the IVC circuit.
+    pub fn vk(&self) -> &MidnightVK {
+        &self.vk
+    }
+
+    /// The SRS verifier parameters.
+    pub fn params_verifier(&self) -> &ParamsVerifierKZG<E> {
+        &self.params_verifier
+    }
+
     /// Verifies an IVC proof against the given instance.
     ///
     /// Checks that the proof is valid with respect to the given instance by:
@@ -78,11 +91,12 @@ impl<T: Ivc> IvcVerifier<T> {
         let proof_acc = Accumulator::from_dual_msm(dual_msm, &fixed_bases);
 
         // Verify that both `proof_acc` and `instance.acc` satisfy the pairing
-        // invariant, with a single pairing, by accumulating them first.
+        // invariant, with a single pairing, by accumulating them first. The
+        // accumulator still carries fixed bases, so `finalise` folds them via an
+        // MSM before the pairing.
         let final_acc = Accumulator::<S>::accumulate(&[proof_acc, instance.acc.clone()]);
-        if !final_acc.check(&self.params_verifier, &fixed_bases) {
-            return Err(IvcError::InvalidProof);
-        };
+        IvcDecider::decide(&final_acc, &self.params_verifier, &self.vk)
+            .map_err(|_| IvcError::InvalidProof)?;
 
         Ok(())
     }

--- a/aggregation/src/multi_circuit_aggregator/circuit.rs
+++ b/aggregation/src/multi_circuit_aggregator/circuit.rs
@@ -16,27 +16,30 @@
 use std::collections::BTreeMap;
 
 use ff::Field;
+use group::Group;
 use midnight_circuits::{
-    hash::poseidon::{PoseidonChip, PoseidonState},
+    hash::poseidon::PoseidonChip,
     instructions::{hash::HashCPU, *},
     types::{AssignedNative, Instantiable},
-    verifier::{self, Accumulator, AssignedAccumulator, AssignedKZGMultiCommitment},
+    verifier::{Accumulator, AssignedAccumulator, AssignedKZGCommitment},
 };
 use midnight_proofs::{
     circuit::{Layouter, Value},
-    plonk::{self, ConstraintSystem, Error},
+    plonk::{ConstraintSystem, Error},
     poly::{
-        kzg::{commitment::KZGMultiCommitment, params::ParamsVerifierKZG, KZGCommitmentScheme},
+        kzg::{commitment::KZGCommitment, params::ParamsVerifierKZG},
         EvaluationDomain, PolynomialLabel,
     },
-    transcript::{CircuitTranscript, Transcript},
     utils::SerdeFormat,
 };
-use midnight_zk_stdlib::{ZkStdLib, ZkStdLibArch};
+use midnight_zk_stdlib::{
+    decider::{Decider, StandardAssignedVk, StandardDecider},
+    ZkStdLib, ZkStdLibArch,
+};
 
 use super::aggregator::AggregationWitness;
 use crate::{
-    ivc::{IvcContext, IvcIO, IvcState, IvcTransition, E, F, S},
+    ivc::{IvcContext, IvcIO, IvcState, IvcTransition, C, E, F, S},
     multi_circuit_aggregator::{
         utils::{assign_as_public_inputs_and_hash_vk, compute_vk_hash},
         Claim,
@@ -244,7 +247,7 @@ impl IvcTransition for ProofAggregation {
     }
 
     fn transition(
-        ctx: &InnerCircuitsContext,
+        _ctx: &InnerCircuitsContext,
         state: &Self::State,
         witness: Self::Witness,
     ) -> Self::State {
@@ -254,33 +257,19 @@ impl IvcTransition for ProofAggregation {
         // 2. Extract the statement.
         let statement = witness.claim.statement.format_instance();
 
-        // 3. Prepare inner proof into an accumulator, resolve fixed bases.
-        let inner_proof_acc = {
-            let mut transcript =
-                CircuitTranscript::<PoseidonState<F>>::init_from_bytes(&witness.inner_proof);
-            let dual_msm =
-                plonk::prepare::<F, KZGCommitmentScheme<E>, CircuitTranscript<PoseidonState<F>>>(
-                    witness.claim.vk.vk(),
-                    &[KZGMultiCommitment::commitment_to_zero(
-                        PolynomialLabel::CommittedInstance(0),
-                    )],
-                    &[&[statement]],
-                    &mut transcript,
-                )
-                .expect("off-circuit prepare should succeed");
-
-            // Sanity check (also validated in Aggregator::aggregate).
-            assert!(
-                dual_msm.clone().check(&ctx.params_verifier),
-                "invalid inner proof"
-            );
-
-            let vk_bases = verifier::fixed_bases::<S>(witness.claim.vk.vk());
-            let mut acc = Accumulator::from_dual_msm(dual_msm, &vk_bases);
-            acc.collapse();
-            acc.resolve_fixed_bases(&vk_bases);
-            acc
-        };
+        // 3. Verify the inner proof into a collapsed accumulator via the circuit's
+        //    decider.
+        let inner_proof_acc = StandardDecider::prepare(
+            &witness.claim.vk,
+            &[KZGCommitment::Simple(
+                C::identity(),
+                PolynomialLabel::CommittedInstance(0),
+            )],
+            &[&[statement]],
+            &witness.inner_proof,
+        )
+        .expect("Invalid inner proof.")
+        .expect("StandardDecider always yields an accumulator");
 
         // 4. Accumulate with the running accumulator and collapse.
         let inner_acc = {
@@ -325,32 +314,25 @@ impl IvcTransition for ProofAggregation {
             witness.as_ref().map(|w| w.claim.statement.format_instance()),
         )?;
 
-        // 3. Verify the inner proof in-circuit against the witnessed VK and statement.
-        let inner_proof_acc = {
-            let instance_com = AssignedKZGMultiCommitment::commitment_to_zero(
-                layouter,
-                self.std_lib.bls12_381(),
-                PolynomialLabel::CommittedInstance(0),
-            )?;
-            let mut acc = self.std_lib.verifier().prepare(
-                layouter,
-                &assigned_vk,
-                &[instance_com],
-                &[std::slice::from_ref(&statement)],
-                witness.map(|w| w.inner_proof.clone()),
-            )?;
-
-            // Collapse before resolving, mirroring the off-circuit `transition`
-            // exactly so both feed an identically-shaped accumulator into the
-            // accumulation step (otherwise the batching challenge diverges).
-            acc.collapse(
-                layouter,
-                self.std_lib.bls12_381(),
-                self.std_lib.bls12_381().scalar_field_chip(),
-            )?;
-            acc.resolve_fixed_bases(&fixed_bases_map);
-            acc
+        // 3. Verify the inner proof in-circuit against the witnessed VK and statement,
+        //    via the circuit's decider.
+        let instance_com = AssignedKZGCommitment::simple(
+            self.std_lib.bls12_381().assign_fixed(layouter, C::identity())?,
+            PolynomialLabel::CommittedInstance(0),
+        );
+        let std_vk = StandardAssignedVk {
+            vk: assigned_vk.clone(),
+            fixed_bases: fixed_bases_map,
         };
+        let inner_proof_acc = StandardDecider::in_circuit_prepare(
+            &self.std_lib,
+            layouter,
+            &std_vk,
+            &[instance_com],
+            &[std::slice::from_ref(&statement)],
+            witness.map(|w| w.inner_proof.clone()),
+        )?
+        .expect("StandardDecider always yields an accumulator");
 
         // 4. Accumulate with the running accumulator and collapse.
         let inner_acc = {

--- a/circuits/src/ecc/foreign/edwards_chip.rs
+++ b/circuits/src/ecc/foreign/edwards_chip.rs
@@ -364,7 +364,6 @@ where
         .concat()
     }
 
-    #[cfg(any(test, feature = "testing"))]
     fn from_public_input(fields: &[F]) -> Option<C::CryptographicGroup> {
         let nb_limbs_per_batch = (F::CAPACITY / B::LOG2_BASE) as usize;
         let nb_pi_per_coord = (B::NB_LIMBS as usize).div_ceil(nb_limbs_per_batch);

--- a/circuits/src/ecc/foreign/weierstrass_chip.rs
+++ b/circuits/src/ecc/foreign/weierstrass_chip.rs
@@ -246,7 +246,6 @@ where
         pis
     }
 
-    #[cfg(any(test, feature = "testing"))]
     fn from_public_input(fields: &[F]) -> Option<C::CryptographicGroup> {
         if *fields.last()? == F::ONE {
             return Some(C::CryptographicGroup::identity());

--- a/circuits/src/ecc/native/edwards_chip.rs
+++ b/circuits/src/ecc/native/edwards_chip.rs
@@ -96,7 +96,6 @@ impl<C: CircuitCurve> Instantiable<C::Base> for AssignedNativePoint<C> {
         vec![coordinates.0, coordinates.1]
     }
 
-    #[cfg(any(test, feature = "testing"))]
     fn from_public_input(fields: &[C::Base]) -> Option<C::CryptographicGroup> {
         if fields.len() != 2 {
             return None;
@@ -143,7 +142,6 @@ impl<C: EdwardsCurve> Instantiable<C::Base> for AssignedScalarOfNativeCurve<C> {
             .collect()
     }
 
-    #[cfg(any(test, feature = "testing"))]
     fn from_public_input(fields: &[C::Base]) -> Option<C::ScalarField> {
         // A scalar needs at most two elements to be represented.
         if fields.len() > 2 {

--- a/circuits/src/field/foreign/field_chip.rs
+++ b/circuits/src/field/foreign/field_chip.rs
@@ -138,7 +138,6 @@ where
             .collect()
     }
 
-    #[cfg(any(test, feature = "testing"))]
     fn from_public_input(fields: &[F]) -> Option<K> {
         let base = BI::from(2).pow(P::LOG2_BASE);
         let nb_limbs_per_batch = (F::CAPACITY / P::LOG2_BASE) as usize;

--- a/circuits/src/field/native/native_chip.rs
+++ b/circuits/src/field/native/native_chip.rs
@@ -1093,7 +1093,6 @@ impl<F: CircuitField> Instantiable<F> for AssignedBit<F> {
         vec![if *element { F::ONE } else { F::ZERO }]
     }
 
-    #[cfg(any(test, feature = "testing"))]
     fn from_public_input(fields: &[F]) -> Option<bool> {
         match fields {
             [f] if *f == F::ZERO => Some(false),

--- a/circuits/src/field/native/native_gadget.rs
+++ b/circuits/src/field/native/native_gadget.rs
@@ -105,7 +105,6 @@ impl<F: CircuitField> Instantiable<F> for AssignedByte<F> {
         vec![F::from(*element as u64)]
     }
 
-    #[cfg(any(test, feature = "testing"))]
     fn from_public_input(fields: &[F]) -> Option<u8> {
         let [f] = fields else { return None };
         u8::try_from(f.to_biguint()).ok()

--- a/circuits/src/utils/types.rs
+++ b/circuits/src/utils/types.rs
@@ -32,7 +32,6 @@ pub trait Instantiable<F: CircuitField>: InnerValue {
     /// Inverse of [Self::as_public_input]: reconstructs the element from
     /// its public input representation. Returns `None` if `fields` does not
     /// encode a valid element.
-    #[cfg(any(test, feature = "testing"))]
     fn from_public_input(fields: &[F]) -> Option<<Self as InnerValue>::Element>;
 }
 
@@ -72,7 +71,6 @@ impl<F: CircuitField> Instantiable<F> for AssignedNative<F> {
         vec![*element]
     }
 
-    #[cfg(any(test, feature = "testing"))]
     fn from_public_input(fields: &[F]) -> Option<F> {
         match fields {
             [f] => Some(*f),

--- a/circuits/src/verifier/accumulator.rs
+++ b/circuits/src/verifier/accumulator.rs
@@ -224,7 +224,7 @@ impl<S: SelfEmulation> Instantiable<S::F> for AssignedAccumulator<S> {
     }
 
     /// Reconstructs a **single-point-per-side** accumulator from its
-    /// public-input encoding — i.e. one produced by a fully-collapsed verifier. 
+    /// public-input encoding — i.e. one produced by a fully-collapsed verifier.
     /// The encoding is `lhs || rhs`, each side being one variable
     /// followed by its scalar.
     ///
@@ -237,12 +237,16 @@ impl<S: SelfEmulation> Instantiable<S::F> for AssignedAccumulator<S> {
         let reconstruct = |side: &[S::F]| -> Option<Msm<S>> {
             let (point_fields, scalar) = side.split_at(side.len() - 1);
             let base = <AssignedPoint<S> as Instantiable<S::F>>::from_public_input(point_fields)?;
-            Some(Msm::new(&[base], &[scalar[0]], &[PolynomialLabel::NoLabel]))
+            Some(Msm::new(
+                &[base],
+                &[scalar[0]],
+                &[PolynomialLabel::NoLabel],
+            ))
         };
 
         let lhs = reconstruct(&fields[..fields.len() / 2])?;
         let rhs = reconstruct(&fields[fields.len() / 2..])?;
-        
+
         Some(Accumulator { lhs, rhs })
     }
 }

--- a/circuits/src/verifier/accumulator.rs
+++ b/circuits/src/verifier/accumulator.rs
@@ -58,7 +58,7 @@ use crate::{
     instructions::{hash::HashCPU, HashInstructions, PublicInputInstructions},
     types::{AssignedBit, InnerValue, Instantiable},
     verifier::{
-        msm::{AssignedMsm, Msm, Point},
+        msm::{AssignedMsm, AssignedPoint, Msm, Point},
         utils::AssignedBoundedScalar,
         SelfEmulation,
     },
@@ -223,9 +223,27 @@ impl<S: SelfEmulation> Instantiable<S::F> for AssignedAccumulator<S> {
         .collect()
     }
 
-    #[cfg(any(test, feature = "testing"))]
-    fn from_public_input(_fields: &[S::F]) -> Option<Accumulator<S>> {
-        unimplemented!("Size of inner MSMs cannot be known from public input format.")
+    /// Reconstructs a **single-point-per-side** accumulator from its
+    /// public-input encoding — i.e. one produced by a fully-collapsed verifier. 
+    /// The encoding is `lhs || rhs`, each side being one variable
+    /// followed by its scalar.
+    ///
+    /// Returns `None` if `fields` does not have that shape.
+    fn from_public_input(fields: &[S::F]) -> Option<Accumulator<S>> {
+        if fields.len() % 2 != 0 || fields.len() < 4 {
+            return None;
+        }
+
+        let reconstruct = |side: &[S::F]| -> Option<Msm<S>> {
+            let (point_fields, scalar) = side.split_at(side.len() - 1);
+            let base = <AssignedPoint<S> as Instantiable<S::F>>::from_public_input(point_fields)?;
+            Some(Msm::new(&[base], &[scalar[0]], &[PolynomialLabel::Collapsed]))
+        };
+
+        let lhs = reconstruct(&fields[..fields.len() / 2])?;
+        let rhs = reconstruct(&fields[fields.len() / 2..])?;
+        
+        Some(Accumulator { lhs, rhs })
     }
 }
 

--- a/circuits/src/verifier/accumulator.rs
+++ b/circuits/src/verifier/accumulator.rs
@@ -434,4 +434,3 @@ where
         buf.len()
     }
 }
-

--- a/circuits/src/verifier/accumulator.rs
+++ b/circuits/src/verifier/accumulator.rs
@@ -237,7 +237,7 @@ impl<S: SelfEmulation> Instantiable<S::F> for AssignedAccumulator<S> {
         let reconstruct = |side: &[S::F]| -> Option<Msm<S>> {
             let (point_fields, scalar) = side.split_at(side.len() - 1);
             let base = <AssignedPoint<S> as Instantiable<S::F>>::from_public_input(point_fields)?;
-            Some(Msm::new(&[base], &[scalar[0]], &[PolynomialLabel::Collapsed]))
+            Some(Msm::new(&[base], &[scalar[0]], &[PolynomialLabel::NoLabel]))
         };
 
         let lhs = reconstruct(&fields[..fields.len() / 2])?;

--- a/circuits/src/verifier/accumulator.rs
+++ b/circuits/src/verifier/accumulator.rs
@@ -27,10 +27,14 @@
 //! Note that implication <= holds unconditionally, whereas implication => holds
 //! "computationally".
 
-use std::collections::{BTreeMap, HashSet};
+use std::{
+    collections::{BTreeMap, HashSet},
+    io,
+};
 
 use ff::Field;
 use group::Group;
+use midnight_curves::serde::SerdeObject;
 use midnight_proofs::{
     circuit::{Layouter, Value},
     plonk::Error,
@@ -41,6 +45,7 @@ use midnight_proofs::{
         },
         PolynomialLabel,
     },
+    utils::{helpers::ProcessedSerdeObject, SerdeFormat},
 };
 use num_bigint::BigUint;
 use num_traits::One;
@@ -385,3 +390,26 @@ impl<S: SelfEmulation> AssignedAccumulator<S> {
         Ok(acc)
     }
 }
+impl<S: SelfEmulation> ProcessedSerdeObject for Accumulator<S>
+where
+    S::F: SerdeObject,
+    S::C: ProcessedSerdeObject,
+{
+    fn read<R: io::Read>(reader: &mut R, format: SerdeFormat) -> io::Result<Self> {
+        let lhs = Msm::<S>::read(reader, format)?;
+        let rhs = Msm::<S>::read(reader, format)?;
+        Ok(Accumulator { lhs, rhs })
+    }
+
+    fn write<W: io::Write>(&self, writer: &mut W, format: SerdeFormat) -> io::Result<()> {
+        self.lhs.write(writer, format)?;
+        self.rhs.write(writer, format)
+    }
+
+    fn byte_length(&self, format: SerdeFormat) -> usize {
+        let mut buf = Vec::new();
+        self.write(&mut buf, format).expect("in-memory write cannot fail");
+        buf.len()
+    }
+}
+

--- a/circuits/src/verifier/mod.rs
+++ b/circuits/src/verifier/mod.rs
@@ -90,7 +90,6 @@ impl<S: SelfEmulation, PCS: InCircuitPCS<S>> Instantiable<S::F> for AssignedVk<S
         AssignedNative::<S::F>::as_public_input(&vk.transcript_repr())
     }
 
-    #[cfg(any(test, feature = "testing"))]
     fn from_public_input(_fields: &[S::F]) -> Option<VerifyingKey<S>> {
         unimplemented!("as_public_input encodes the VK as its transcript_repr() — not invertible")
     }

--- a/circuits/src/verifier/msm.rs
+++ b/circuits/src/verifier/msm.rs
@@ -107,7 +107,6 @@ impl<S: SelfEmulation> Instantiable<S::F> for AssignedPoint<S> {
         }
     }
 
-    #[cfg(any(test, feature = "testing"))]
     fn from_public_input(fields: &[S::F]) -> Option<Point<S>> {
         match fields {
             [] => Some(Point::Fixed),
@@ -366,7 +365,6 @@ impl<S: SelfEmulation> Instantiable<S::F> for AssignedMsm<S> {
         .collect::<Vec<_>>()
     }
 
-    #[cfg(any(test, feature = "testing"))]
     fn from_public_input(_fields: &[S::F]) -> Option<Msm<S>> {
         unimplemented!("not invertible: the flat encoding loses structural metadata.")
     }

--- a/circuits/src/verifier/msm.rs
+++ b/circuits/src/verifier/msm.rs
@@ -795,7 +795,9 @@ where
         let mut tag = [0u8; 1];
         reader.read_exact(&mut tag)?;
         match tag[0] {
-            0 => Ok(Point::Variable(<S::C as ProcessedSerdeObject>::read(reader, format)?)),
+            0 => Ok(Point::Variable(<S::C as ProcessedSerdeObject>::read(
+                reader, format,
+            )?)),
             1 => Ok(Point::Fixed),
             other => Err(io::Error::new(
                 io::ErrorKind::InvalidData,
@@ -837,7 +839,11 @@ where
             .collect::<io::Result<Vec<_>>>()?;
         let k = read_usize(reader)?;
         let labels = (0..k).map(|_| read_label(reader)).collect::<io::Result<Vec<_>>>()?;
-        Ok(Msm { scalars, bases, labels })
+        Ok(Msm {
+            scalars,
+            bases,
+            labels,
+        })
     }
 
     fn write<W: io::Write>(&self, writer: &mut W, format: SerdeFormat) -> io::Result<()> {

--- a/circuits/src/verifier/msm.rs
+++ b/circuits/src/verifier/msm.rs
@@ -16,14 +16,18 @@
 //! scalars only.
 //! (The bases are assumed to be fixed and globally known.)
 
-use std::collections::{btree_map::Entry, BTreeMap, HashSet};
+use std::{
+    collections::{btree_map::Entry, BTreeMap, HashSet},
+    io,
+};
 
 use ff::Field;
-use midnight_curves::msm::msm_best;
+use midnight_curves::{msm::msm_best, serde::SerdeObject};
 use midnight_proofs::{
     circuit::{Layouter, Value},
     plonk::Error,
     poly::PolynomialLabel,
+    utils::{helpers::ProcessedSerdeObject, SerdeFormat},
 };
 
 use crate::{
@@ -694,5 +698,169 @@ impl<S: SelfEmulation> AssignedMsm<S> {
         acc.add_msm(&other)?;
 
         Ok(acc)
+    }
+}
+
+// Helper functions
+
+fn write_usize<W: io::Write>(writer: &mut W, v: usize) -> io::Result<()> {
+    writer.write_all(&(v as u32).to_le_bytes())
+}
+
+fn read_usize<R: io::Read>(reader: &mut R) -> io::Result<usize> {
+    let mut b = [0u8; 4];
+    reader.read_exact(&mut b)?;
+    Ok(u32::from_le_bytes(b) as usize)
+}
+
+fn write_string<W: io::Write>(writer: &mut W, s: &str) -> io::Result<()> {
+    write_usize(writer, s.len())?;
+    writer.write_all(s.as_bytes())
+}
+
+fn read_string<R: io::Read>(reader: &mut R) -> io::Result<String> {
+    let len = read_usize(reader)?;
+    let mut buf = vec![0u8; len];
+    reader.read_exact(&mut buf)?;
+    String::from_utf8(buf).map_err(|e| io::Error::new(io::ErrorKind::InvalidData, e))
+}
+
+fn write_label<W: io::Write>(writer: &mut W, label: &PolynomialLabel) -> io::Result<()> {
+    match label {
+        PolynomialLabel::Fixed(i) => (writer.write_all(&[0])).and_then(|_| write_usize(writer, *i)),
+        PolynomialLabel::Advice(i) => (writer.write_all(&[1])).and_then(|_| write_usize(writer, *i)),
+        PolynomialLabel::CommittedInstance(i) => {
+            (writer.write_all(&[2])).and_then(|_| write_usize(writer, *i))
+        }
+        PolynomialLabel::PermutationFixed(i) => {
+            (writer.write_all(&[3])).and_then(|_| write_usize(writer, *i))
+        }
+        PolynomialLabel::PermutationAccumulator(i) => {
+            (writer.write_all(&[4])).and_then(|_| write_usize(writer, *i))
+        }
+        PolynomialLabel::LogupHelper(i, j) => (writer.write_all(&[5]))
+            .and_then(|_| write_usize(writer, *i))
+            .and_then(|_| write_usize(writer, *j)),
+        PolynomialLabel::LogupMultiplicities(i) => {
+            (writer.write_all(&[6])).and_then(|_| write_usize(writer, *i))
+        }
+        PolynomialLabel::LogupAggregator(i) => {
+            (writer.write_all(&[7])).and_then(|_| write_usize(writer, *i))
+        }
+        PolynomialLabel::Linearization => writer.write_all(&[8]),
+        PolynomialLabel::Quotient => writer.write_all(&[9]),
+        PolynomialLabel::QuotientPiece(i) => {
+            (writer.write_all(&[10])).and_then(|_| write_usize(writer, *i))
+        }
+        PolynomialLabel::Trash(i) => {
+            (writer.write_all(&[11])).and_then(|_| write_usize(writer, *i))
+        }
+        PolynomialLabel::Custom(s) => {
+            (writer.write_all(&[12])).and_then(|_| write_string(writer, s))
+        }
+        PolynomialLabel::NoLabel => writer.write_all(&[13]),
+    }
+}
+
+fn read_label<R: io::Read>(reader: &mut R) -> io::Result<PolynomialLabel> {
+    let mut tag = [0u8; 1];
+    reader.read_exact(&mut tag)?;
+    Ok(match tag[0] {
+        0 => PolynomialLabel::Fixed(read_usize(reader)?),
+        1 => PolynomialLabel::Advice(read_usize(reader)?),
+        2 => PolynomialLabel::CommittedInstance(read_usize(reader)?),
+        3 => PolynomialLabel::PermutationFixed(read_usize(reader)?),
+        4 => PolynomialLabel::PermutationAccumulator(read_usize(reader)?),
+        5 => PolynomialLabel::LogupHelper(read_usize(reader)?, read_usize(reader)?),
+        6 => PolynomialLabel::LogupMultiplicities(read_usize(reader)?),
+        7 => PolynomialLabel::LogupAggregator(read_usize(reader)?),
+        8 => PolynomialLabel::Linearization,
+        9 => PolynomialLabel::Quotient,
+        10 => PolynomialLabel::QuotientPiece(read_usize(reader)?),
+        11 => PolynomialLabel::Trash(read_usize(reader)?),
+        12 => PolynomialLabel::Custom(read_string(reader)?),
+        13 => PolynomialLabel::NoLabel,
+        other => {
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidData,
+                format!("unknown PolynomialLabel tag: {other}"),
+            ))
+        }
+    })
+}
+
+impl<S: SelfEmulation> ProcessedSerdeObject for Point<S>
+where
+    S::C: ProcessedSerdeObject,
+{
+    fn read<R: io::Read>(reader: &mut R, format: SerdeFormat) -> io::Result<Self> {
+        let mut tag = [0u8; 1];
+        reader.read_exact(&mut tag)?;
+        match tag[0] {
+            0 => Ok(Point::Variable(<S::C as ProcessedSerdeObject>::read(reader, format)?)),
+            1 => Ok(Point::Fixed),
+            other => Err(io::Error::new(
+                io::ErrorKind::InvalidData,
+                format!("unknown Point tag: {other}"),
+            )),
+        }
+    }
+
+    fn write<W: io::Write>(&self, writer: &mut W, format: SerdeFormat) -> io::Result<()> {
+        match self {
+            Point::Variable(p) => {
+                writer.write_all(&[0])?;
+                p.write(writer, format)
+            }
+            Point::Fixed => writer.write_all(&[1]),
+        }
+    }
+
+    fn byte_length(&self, format: SerdeFormat) -> usize {
+        let mut buf = Vec::new();
+        self.write(&mut buf, format).expect("in-memory write cannot fail");
+        buf.len()
+    }
+}
+
+impl<S: SelfEmulation> ProcessedSerdeObject for Msm<S>
+where
+    S::F: SerdeObject,
+    S::C: ProcessedSerdeObject,
+{
+    fn read<R: io::Read>(reader: &mut R, format: SerdeFormat) -> io::Result<Self> {
+        let n = read_usize(reader)?;
+        let scalars = (0..n)
+            .map(|_| <S::F as SerdeObject>::read_raw(reader))
+            .collect::<io::Result<Vec<_>>>()?;
+        let m = read_usize(reader)?;
+        let bases = (0..m)
+            .map(|_| Point::<S>::read(reader, format))
+            .collect::<io::Result<Vec<_>>>()?;
+        let k = read_usize(reader)?;
+        let labels = (0..k).map(|_| read_label(reader)).collect::<io::Result<Vec<_>>>()?;
+        Ok(Msm { scalars, bases, labels })
+    }
+
+    fn write<W: io::Write>(&self, writer: &mut W, format: SerdeFormat) -> io::Result<()> {
+        write_usize(writer, self.scalars.len())?;
+        for s in &self.scalars {
+            s.write_raw(writer)?;
+        }
+        write_usize(writer, self.bases.len())?;
+        for b in &self.bases {
+            b.write(writer, format)?;
+        }
+        write_usize(writer, self.labels.len())?;
+        for l in &self.labels {
+            write_label(writer, l)?;
+        }
+        Ok(())
+    }
+
+    fn byte_length(&self, format: SerdeFormat) -> usize {
+        let mut buf = Vec::new();
+        self.write(&mut buf, format).expect("in-memory write cannot fail");
+        buf.len()
     }
 }

--- a/zk_stdlib/src/decider.rs
+++ b/zk_stdlib/src/decider.rs
@@ -7,8 +7,12 @@ use std::{collections::BTreeMap, io};
 
 use group::Group;
 use midnight_circuits::{
-    hash::poseidon::PoseidonState, instructions::AssignmentInstructions, types::{AssignedNative, Instantiable}, verifier::{
-        Accumulator, AssignedAccumulator, AssignedKZGCommitment, AssignedKZGMultiCommitment, AssignedVk, BlstrsEmulation, InCircuitKZG, SelfEmulation, fixed_bases,
+    hash::poseidon::PoseidonState,
+    instructions::AssignmentInstructions,
+    types::{AssignedNative, Instantiable},
+    verifier::{
+        fixed_bases, Accumulator, AssignedAccumulator, AssignedKZGCommitment,
+        AssignedKZGMultiCommitment, AssignedVk, BlstrsEmulation, InCircuitKZG, SelfEmulation,
     },
 };
 use midnight_proofs::{
@@ -198,7 +202,11 @@ impl Decider for StandardDecider {
         vk: &MidnightVK,
     ) -> Result<(), Error> {
         let fixed_bases = fixed_bases::<S>(vk.vk());
-        if acc.check(params, &fixed_bases) {Ok(())} else {Err(Error::Opening)}
+        if acc.check(params, &fixed_bases) {
+            Ok(())
+        } else {
+            Err(Error::Opening)
+        }
     }
 }
 
@@ -274,7 +282,11 @@ impl Decider for IvcDecider {
         vk: &Self::Vk,
     ) -> Result<(), Error> {
         let fixed_bases = fixed_bases::<S>(vk.vk());
-        if acc.check(params, &fixed_bases) {Ok(())} else {Err(Error::Opening)}
+        if acc.check(params, &fixed_bases) {
+            Ok(())
+        } else {
+            Err(Error::Opening)
+        }
     }
 }
 
@@ -286,7 +298,7 @@ pub enum DeciderKind {
     Standard,
     /// The IVC per-step decider ([`IvcDecider`]).
     Ivc,
-    /// Final IVC decider (Verifies the previous IVC check, and collapses it in 
+    /// Final IVC decider (Verifies the previous IVC check, and collapses it in
     /// a single step).
     FinalIVC,
 }
@@ -321,12 +333,12 @@ impl DeciderKind {
     }
 }
 
-/////////////
-/// Wrappers and abstractions for midnight-ledger
-/////////////
+/*
+Wrappers and abstractions for midnight-ledger
+*/
 
-/// Off-circuit partial verification from a self-describing VK blob. This function resolves
-/// the kind of decider, and executes the decide function.
+/// Off-circuit partial verification from a self-describing VK blob. This
+/// function resolves the kind of decider, and executes the decide function.
 pub fn decide(vk_blob: &[u8], instance: &[&[F]], proof: &[u8]) -> Result<Accumulator<S>, Error> {
     let (kind, vk_bytes) = DeciderKind::split(vk_blob)?;
     let committed_instance = [KZGCommitment::Simple(

--- a/zk_stdlib/src/decider.rs
+++ b/zk_stdlib/src/decider.rs
@@ -306,7 +306,7 @@ pub fn decide(vk_blob: &[u8], instance: &[&[F]], proof: &[u8]) -> Result<Accumul
     let (kind, vk_bytes) = DeciderKind::split(vk_blob)?;
     let committed_instance = [KZGCommitment::Simple(
         C::identity(),
-        PolynomialLabel::Instance(0),
+        PolynomialLabel::CommittedInstance(0),
     )];
     match kind {
         DeciderKind::Standard => {

--- a/zk_stdlib/src/decider.rs
+++ b/zk_stdlib/src/decider.rs
@@ -8,15 +8,18 @@ use std::{collections::BTreeMap, io};
 use group::Group;
 use midnight_circuits::{
     hash::poseidon::PoseidonState, instructions::AssignmentInstructions, types::{AssignedNative, Instantiable}, verifier::{
-        Accumulator, AssignedAccumulator, AssignedKZGCommitment, AssignedVk, BlstrsEmulation, SelfEmulation, fixed_bases,
+        Accumulator, AssignedAccumulator, AssignedKZGCommitment, AssignedKZGMultiCommitment, AssignedVk, BlstrsEmulation, InCircuitKZG, SelfEmulation, fixed_bases,
     },
 };
-use midnight_curves::G1Projective;
 use midnight_proofs::{
     circuit::{Layouter, Value},
     plonk::{self, Error},
     poly::{
-        kzg::{commitment::KZGCommitment, params::ParamsVerifierKZG, KZGCommitmentScheme},
+        kzg::{
+            commitment::{KZGCommitment, KZGMultiCommitment},
+            params::ParamsVerifierKZG,
+            KZGCommitmentScheme,
+        },
         PolynomialLabel,
     },
     transcript::{CircuitTranscript, Transcript},
@@ -100,7 +103,7 @@ pub struct StandardDecider;
 #[derive(Clone, Debug)]
 pub struct StandardAssignedVk {
     /// The assigned verifying key.
-    pub vk: AssignedVk<S>,
+    pub vk: AssignedVk<S, InCircuitKZG<S>>,
     /// The assigned fixed-base points, keyed by label.
     pub fixed_bases: BTreeMap<PolynomialLabel, AssignedPoint>,
 }
@@ -141,12 +144,17 @@ impl Decider for StandardDecider {
     ) -> Result<Option<Accumulator<S>>, Error> {
         let vk = vk.vk();
         let bases = fixed_bases::<S>(vk);
+        let committed_instance: Vec<KZGMultiCommitment<Bls12>> = committed_instance
+            .iter()
+            .cloned()
+            .map(|c| KZGMultiCommitment(vec![c]))
+            .collect();
         let mut transcript = CircuitTranscript::<PoseidonState<F>>::init_from_bytes(proof);
         let dual_msm = plonk::prepare::<
             F,
             KZGCommitmentScheme<Bls12>,
             CircuitTranscript<PoseidonState<F>>,
-        >(vk, committed_instance, instance, &mut transcript)?;
+        >(vk, &committed_instance, instance, &mut transcript)?;
         let mut acc = Accumulator::from_dual_msm(dual_msm, &bases);
         acc.collapse();
         acc.resolve_fixed_bases(&bases);
@@ -166,10 +174,15 @@ impl Decider for StandardDecider {
         proof: Value<Vec<u8>>,
     ) -> Result<Option<AssignedAccumulator<S>>, Error> {
         let bls = std_lib.bls12_381();
+        let committed_instance: Vec<AssignedKZGMultiCommitment<S>> = committed_instance
+            .iter()
+            .cloned()
+            .map(|c| AssignedKZGMultiCommitment(vec![c]))
+            .collect();
         let mut acc =
             std_lib
                 .verifier()
-                .prepare(layouter, &vk.vk, committed_instance, instance, proof)?;
+                .prepare(layouter, &vk.vk, &committed_instance, instance, proof)?;
         acc.collapse(layouter, bls, bls.scalar_field_chip())?;
         acc.resolve_fixed_bases(&vk.fixed_bases);
 
@@ -197,7 +210,7 @@ pub struct IvcDecider;
 
 impl Decider for IvcDecider {
     type Vk = MidnightVK;
-    type AssignedVk = AssignedVk<S>;
+    type AssignedVk = AssignedVk<S, InCircuitKZG<S>>;
 
     const KIND: DeciderKind = DeciderKind::Ivc;
 
@@ -205,7 +218,7 @@ impl Decider for IvcDecider {
         std_lib: &ZkStdLib,
         layouter: &mut impl Layouter<F>,
         vk: &MidnightVK,
-    ) -> Result<AssignedVk<S>, Error> {
+    ) -> Result<AssignedVk<S, InCircuitKZG<S>>, Error> {
         let plonk_vk = vk.vk();
         std_lib.verifier().assign_fixed_vk(
             layouter,
@@ -222,12 +235,17 @@ impl Decider for IvcDecider {
         proof: &[u8],
     ) -> Result<Option<Accumulator<S>>, Error> {
         let bases = fixed_bases::<S>(vk.vk());
+        let committed_instance: Vec<KZGMultiCommitment<Bls12>> = committed_instance
+            .iter()
+            .cloned()
+            .map(|c| KZGMultiCommitment(vec![c]))
+            .collect();
         let mut transcript = CircuitTranscript::<PoseidonState<F>>::init_from_bytes(proof);
         let dual_msm = plonk::prepare::<
             F,
             KZGCommitmentScheme<Bls12>,
             CircuitTranscript<PoseidonState<F>>,
-        >(vk.vk(), committed_instance, instance, &mut transcript)?;
+        >(vk.vk(), &committed_instance, instance, &mut transcript)?;
         Ok(Some(Accumulator::from_dual_msm(dual_msm, &bases)))
     }
 
@@ -239,7 +257,14 @@ impl Decider for IvcDecider {
         instance: &[&[AssignedNative<F>]],
         proof: Value<Vec<u8>>,
     ) -> Result<Option<AssignedAccumulator<S>>, Error> {
-        let acc = std_lib.verifier().prepare(layouter, vk, committed_instance, instance, proof)?;
+        let committed_instance: Vec<AssignedKZGMultiCommitment<S>> = committed_instance
+            .iter()
+            .cloned()
+            .map(|c| AssignedKZGMultiCommitment(vec![c]))
+            .collect();
+        let acc = std_lib
+            .verifier()
+            .prepare(layouter, vk, &committed_instance, instance, proof)?;
         Ok(Some(acc))
     }
     

--- a/zk_stdlib/src/decider.rs
+++ b/zk_stdlib/src/decider.rs
@@ -1,0 +1,345 @@
+//! A `Decider` interface.
+//!
+//! A `Decider` circuit knows how to partially verify a proof
+//! into an accumulator whose decider is deferred to a final decider step.
+
+use std::{collections::BTreeMap, io};
+
+use group::Group;
+use midnight_circuits::{
+    hash::poseidon::PoseidonState, instructions::AssignmentInstructions, types::{AssignedNative, Instantiable}, verifier::{
+        Accumulator, AssignedAccumulator, AssignedKZGCommitment, AssignedVk, BlstrsEmulation, SelfEmulation, fixed_bases,
+    },
+};
+use midnight_curves::G1Projective;
+use midnight_proofs::{
+    circuit::{Layouter, Value},
+    plonk::{self, Error},
+    poly::{
+        kzg::{commitment::KZGCommitment, params::ParamsVerifierKZG, KZGCommitmentScheme},
+        PolynomialLabel,
+    },
+    transcript::{CircuitTranscript, Transcript},
+    utils::{helpers::ProcessedSerdeObject, SerdeFormat},
+};
+
+use crate::{MidnightVK, ZkStdLib, F};
+
+type S = BlstrsEmulation;
+type Bls12 = midnight_curves::Bls12;
+type C = <S as SelfEmulation>::C;
+type AssignedPoint = <S as SelfEmulation>::AssignedPoint;
+
+/// Interface for partially verifying a proof into a deferred accumulator and,
+/// finally, accepting or rejecting it.
+///
+/// Every decider is addressable *from data*: its verifying key is a
+/// self-describing [`ProcessedSerdeObject`] blob tagged by a [`DeciderKind`]
+/// discriminant, so [`encode_vk`] / [`decide`] /
+/// [`ZkStdLib::verify_proof`](crate::ZkStdLib::verify_proof) can serialize the
+/// key and dispatch to the right implementation. This is why `Vk` is bound to
+/// [`ProcessedSerdeObject`].
+pub trait Decider {
+    /// Off-circuit verifying-key. Must be serializable so the key can be
+    /// recovered from an opaque, self-describing blob.
+    type Vk: ProcessedSerdeObject;
+    /// In-circuit verifying-key.
+    type AssignedVk;
+
+    /// The discriminant identifying this decider.
+    const KIND: DeciderKind;
+
+    /// Serializes a decider's verifying key into a self-describing VK blob.
+    fn encode_vk(vk: &Self::Vk) -> io::Result<Vec<u8>> {
+        let mut blob = vec![Self::KIND.tag()];
+        vk.write(&mut blob, SerdeFormat::Processed)?;
+        Ok(blob)
+    }
+
+    /// Assigns the (fixed) verifying key in-circuit, producing
+    /// [`Self::AssignedVk`].
+    fn assign_vk(
+        std_lib: &ZkStdLib,
+        layouter: &mut impl Layouter<F>,
+        vk: &Self::Vk,
+    ) -> Result<Self::AssignedVk, Error>;
+
+    /// Off-circuit partial verification.
+    fn prepare(
+        vk: &Self::Vk,
+        committed_instance: &[KZGCommitment<Bls12>],
+        instance: &[&[F]],
+        proof: &[u8],
+    ) -> Result<Option<Accumulator<S>>, Error>;
+
+    /// In-circuit mirror of [`Self::prepare`].
+    fn in_circuit_prepare(
+        std_lib: &ZkStdLib,
+        layouter: &mut impl Layouter<F>,
+        vk: &Self::AssignedVk,
+        committed_instance: &[AssignedKZGCommitment<S>],
+        instance: &[&[AssignedNative<F>]],
+        proof: Value<Vec<u8>>,
+    ) -> Result<Option<AssignedAccumulator<S>>, Error>;
+
+    /// Final decider on a (deferred) accumulator.
+    fn decide(
+        acc: &Accumulator<S>,
+        params: &ParamsVerifierKZG<Bls12>,
+        vk: &Self::Vk,
+    ) -> Result<(), Error>;
+}
+
+/// The standard decider: verify a proof and collapse to a canonical
+/// (single-point-per-side, fixed bases resolved) accumulator.
+#[derive(Clone, Copy, Debug, Default)]
+pub struct StandardDecider;
+
+/// In-circuit verifying key for [`StandardDecider`]: the assigned vk together
+/// with its assigned fixed bases (needed to resolve after collapsing).
+#[derive(Clone, Debug)]
+pub struct StandardAssignedVk {
+    /// The assigned verifying key.
+    pub vk: AssignedVk<S>,
+    /// The assigned fixed-base points, keyed by label.
+    pub fixed_bases: BTreeMap<PolynomialLabel, AssignedPoint>,
+}
+
+impl Decider for StandardDecider {
+    type Vk = MidnightVK;
+    type AssignedVk = StandardAssignedVk;
+
+    const KIND: DeciderKind = DeciderKind::Standard;
+
+    fn assign_vk(
+        std_lib: &ZkStdLib,
+        layouter: &mut impl Layouter<F>,
+        vk: &MidnightVK,
+    ) -> Result<StandardAssignedVk, Error> {
+        let plonk_vk = vk.vk();
+        let assigned_vk = std_lib.verifier().assign_fixed_vk(
+            layouter,
+            plonk_vk.get_domain(),
+            plonk_vk.cs(),
+            plonk_vk.transcript_repr(),
+        )?;
+        let mut fixed_bases_map = BTreeMap::new();
+        for (label, base) in fixed_bases::<S>(plonk_vk) {
+            fixed_bases_map.insert(label, std_lib.bls12_381().assign_fixed(layouter, base)?);
+        }
+        Ok(StandardAssignedVk {
+            vk: assigned_vk,
+            fixed_bases: fixed_bases_map,
+        })
+    }
+
+    fn prepare(
+        vk: &MidnightVK,
+        committed_instance: &[KZGCommitment<Bls12>],
+        instance: &[&[F]],
+        proof: &[u8],
+    ) -> Result<Option<Accumulator<S>>, Error> {
+        let vk = vk.vk();
+        let bases = fixed_bases::<S>(vk);
+        let mut transcript = CircuitTranscript::<PoseidonState<F>>::init_from_bytes(proof);
+        let dual_msm = plonk::prepare::<
+            F,
+            KZGCommitmentScheme<Bls12>,
+            CircuitTranscript<PoseidonState<F>>,
+        >(vk, committed_instance, instance, &mut transcript)?;
+        let mut acc = Accumulator::from_dual_msm(dual_msm, &bases);
+        acc.collapse();
+        acc.resolve_fixed_bases(&bases);
+
+        // Collapse the fixed bases
+        // todo: better to resolve fixed bases first?
+        acc.collapse();
+        Ok(Some(acc))
+    }
+
+    fn in_circuit_prepare(
+        std_lib: &ZkStdLib,
+        layouter: &mut impl Layouter<F>,
+        vk: &StandardAssignedVk,
+        committed_instance: &[AssignedKZGCommitment<S>],
+        instance: &[&[AssignedNative<F>]],
+        proof: Value<Vec<u8>>,
+    ) -> Result<Option<AssignedAccumulator<S>>, Error> {
+        let bls = std_lib.bls12_381();
+        let mut acc =
+            std_lib
+                .verifier()
+                .prepare(layouter, &vk.vk, committed_instance, instance, proof)?;
+        acc.collapse(layouter, bls, bls.scalar_field_chip())?;
+        acc.resolve_fixed_bases(&vk.fixed_bases);
+
+        // Collapse the fixed bases
+        // todo: better to resolve fixed bases first?
+        acc.collapse(layouter, bls, bls.scalar_field_chip())?;
+        Ok(Some(acc))
+    }
+    
+    fn decide(
+        acc: &Accumulator<S>,
+        params: &ParamsVerifierKZG<Bls12>,
+        vk: &MidnightVK,
+    ) -> Result<(), Error> {
+        let fixed_bases = fixed_bases::<S>(vk.vk());
+        if acc.check(params, &fixed_bases) {Ok(())} else {Err(Error::Opening)}
+    }
+}
+
+/// The IVC per-step decider: **prepare-only** partial verification of a step's
+/// proof into a deferred accumulator. Unlike [`StandardDecider`], it does *not*
+/// resolve its fixed bases. Those are deferred to a final decider step.
+#[derive(Clone, Copy, Debug, Default)]
+pub struct IvcDecider;
+
+impl Decider for IvcDecider {
+    type Vk = MidnightVK;
+    type AssignedVk = AssignedVk<S>;
+
+    const KIND: DeciderKind = DeciderKind::Ivc;
+
+    fn assign_vk(
+        std_lib: &ZkStdLib,
+        layouter: &mut impl Layouter<F>,
+        vk: &MidnightVK,
+    ) -> Result<AssignedVk<S>, Error> {
+        let plonk_vk = vk.vk();
+        std_lib.verifier().assign_fixed_vk(
+            layouter,
+            plonk_vk.get_domain(),
+            plonk_vk.cs(),
+            plonk_vk.transcript_repr(),
+        )
+    }
+
+    fn prepare(
+        vk: &Self::Vk,
+        committed_instance: &[KZGCommitment<Bls12>],
+        instance: &[&[F]],
+        proof: &[u8],
+    ) -> Result<Option<Accumulator<S>>, Error> {
+        let bases = fixed_bases::<S>(vk.vk());
+        let mut transcript = CircuitTranscript::<PoseidonState<F>>::init_from_bytes(proof);
+        let dual_msm = plonk::prepare::<
+            F,
+            KZGCommitmentScheme<Bls12>,
+            CircuitTranscript<PoseidonState<F>>,
+        >(vk.vk(), committed_instance, instance, &mut transcript)?;
+        Ok(Some(Accumulator::from_dual_msm(dual_msm, &bases)))
+    }
+
+    fn in_circuit_prepare(
+        std_lib: &ZkStdLib,
+        layouter: &mut impl Layouter<F>,
+        vk: &Self::AssignedVk,
+        committed_instance: &[AssignedKZGCommitment<S>],
+        instance: &[&[AssignedNative<F>]],
+        proof: Value<Vec<u8>>,
+    ) -> Result<Option<AssignedAccumulator<S>>, Error> {
+        let acc = std_lib.verifier().prepare(layouter, vk, committed_instance, instance, proof)?;
+        Ok(Some(acc))
+    }
+    
+    fn decide(
+        acc: &Accumulator<S>,
+        params: &ParamsVerifierKZG<Bls12>,
+        vk: &Self::Vk,
+    ) -> Result<(), Error> {
+        let fixed_bases = fixed_bases::<S>(vk.vk());
+        if acc.check(params, &fixed_bases) {Ok(())} else {Err(Error::Opening)}
+    }
+}
+
+/// The curated set of deciders a caller may select from data, and the bridge
+/// from a serialized verifying key to a concrete [`Decider`] implementation.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum DeciderKind {
+    /// The standard, non-recursive decider ([`StandardDecider`]).
+    Standard,
+    /// The IVC per-step decider ([`IvcDecider`]).
+    Ivc,
+    /// Final IVC decider (Verifies the previous IVC check, and collapses it in 
+    /// a single step).
+    FinalIVC,
+}
+
+impl DeciderKind {
+    /// Tag of each decider kind.
+    pub fn tag(self) -> u8 {
+        match self {
+            DeciderKind::Standard => 0,
+            DeciderKind::Ivc => 1,
+            DeciderKind::FinalIVC => 2,
+        }
+    }
+
+    /// Splits a self-describing VK blob into its leading discriminant byte and
+    /// the remaining decider-specific verifying-key bytes.
+    pub fn split(vk_blob: &[u8]) -> Result<(DeciderKind, &[u8]), Error> {
+        let (tag, rest) = vk_blob
+            .split_first()
+            .ok_or_else(|| Error::Synthesis("empty verifying-key blob".into()))?;
+        let kind = match tag {
+            0 => DeciderKind::Standard,
+            1 => DeciderKind::Ivc,
+            2 => DeciderKind::FinalIVC,
+            other => {
+                return Err(Error::Synthesis(format!(
+                    "unknown decider discriminant: {other}"
+                )));
+            }
+        };
+        Ok((kind, rest))
+    }
+}
+
+/////////////
+/// Wrappers and abstractions for midnight-ledger
+/////////////
+
+/// Off-circuit partial verification from a self-describing VK blob. This function resolves
+/// the kind of decider, and executes the decide function.
+pub fn decide(vk_blob: &[u8], instance: &[&[F]], proof: &[u8]) -> Result<Accumulator<S>, Error> {
+    let (kind, vk_bytes) = DeciderKind::split(vk_blob)?;
+    let committed_instance = [KZGCommitment::Simple(
+        C::identity(),
+        PolynomialLabel::Instance(0),
+    )];
+    match kind {
+        DeciderKind::Standard => {
+            decide_with::<StandardDecider>(vk_bytes, &committed_instance, instance, proof)
+        }
+        DeciderKind::Ivc => {
+            decide_with::<IvcDecider>(vk_bytes, &committed_instance, instance, proof)
+        }
+        DeciderKind::FinalIVC => {
+            todo!()
+        }
+    }
+}
+
+fn decide_with<D: Decider>(
+    vk_bytes: &[u8],
+    committed_instance: &[KZGCommitment<Bls12>],
+    instance: &[&[F]],
+    proof: &[u8],
+) -> Result<Accumulator<S>, Error> {
+    let vk = <D::Vk as ProcessedSerdeObject>::read(&mut { vk_bytes }, SerdeFormat::Processed)
+        .map_err(|e| Error::Synthesis(format!("reading verifying key: {e}")))?;
+    D::prepare(&vk, committed_instance, instance, proof)?
+        .ok_or_else(|| Error::Synthesis("decider produced no accumulator".into()))
+}
+
+/// Field-element encoding of a (single-point) accumulator as public inputs.
+pub fn accumulator_as_public_input(acc: &Accumulator<S>) -> Vec<F> {
+    <AssignedAccumulator<S> as Instantiable<F>>::as_public_input(acc)
+}
+
+/// Number of public-input field elements a single-point-per-side accumulator
+/// occupies.
+pub fn accumulator_pi_len() -> usize {
+    accumulator_as_public_input(&Accumulator::<S>::trivial(&[])).len()
+}

--- a/zk_stdlib/src/interface.rs
+++ b/zk_stdlib/src/interface.rs
@@ -34,7 +34,7 @@ use midnight_proofs::{
         PolynomialLabel,
     },
     transcript::{CircuitTranscript, Hashable, Sampleable, Transcript, TranscriptHash},
-    utils::SerdeFormat,
+    utils::{helpers::ProcessedSerdeObject, SerdeFormat},
 };
 use rand::{CryptoRng, RngCore};
 
@@ -163,6 +163,23 @@ impl MidnightVK {
         &self,
     ) -> &VerifyingKey<midnight_curves::Fq, KZGCommitmentScheme<midnight_curves::Bls12>> {
         &self.vk
+    }
+}
+
+impl ProcessedSerdeObject for MidnightVK {
+    fn read<R: io::Read>(reader: &mut R, format: SerdeFormat) -> io::Result<Self> {
+        MidnightVK::read(reader, format)
+    }
+
+    fn write<W: io::Write>(&self, writer: &mut W, format: SerdeFormat) -> io::Result<()> {
+        MidnightVK::write(self, writer, format)
+    }
+
+    fn byte_length(&self, format: SerdeFormat) -> usize {
+        let mut buf = Vec::new();
+        self.write(&mut buf, format)
+            .expect("in-memory write cannot fail");
+        buf.len()
     }
 }
 

--- a/zk_stdlib/src/interface.rs
+++ b/zk_stdlib/src/interface.rs
@@ -317,7 +317,13 @@ impl<Rel: Relation> MidnightPK<Rel> {
             .params(),
         )?;
 
-        Ok(MidnightPK { k, nb_public_inputs, deferred_accumulators, relation, pk })
+        Ok(MidnightPK {
+            k,
+            nb_public_inputs,
+            deferred_accumulators,
+            relation,
+            pk,
+        })
     }
 
     /// The size of the domain associated to this proving key.
@@ -641,10 +647,11 @@ pub fn setup_pk<R: Relation>(relation: &R, vk: &MidnightVK) -> MidnightPK<R> {
     // During the call to [setup_vk] the circuit RefCell on public inputs has been
     // mutated with the correct value. The following [unwrap] is safe here.
     let nb_public_inputs = circuit.nb_public_inputs.clone().borrow().unwrap();
+    let deferred_accumulators = circuit.deferred_accumulators.clone().borrow().clone();
     MidnightPK {
         k: vk.k(),
         nb_public_inputs,
-        deferred_accumulators: vk.deferred_accumulators.clone(),
+        deferred_accumulators,
         relation: relation.clone(),
         pk,
     }

--- a/zk_stdlib/src/interface.rs
+++ b/zk_stdlib/src/interface.rs
@@ -16,7 +16,10 @@
 use std::{cell::RefCell, io, rc::Rc};
 
 use ff::Field;
-use midnight_circuits::types::ComposableChip;
+use midnight_circuits::{
+    types::{ComposableChip, Instantiable},
+    verifier::{AssignedAccumulator, BlstrsEmulation},
+};
 use midnight_curves::G1Projective;
 use midnight_proofs::{
     circuit::{Layouter, SimpleFloorPlanner, Value},
@@ -39,7 +42,7 @@ use midnight_proofs::{
 use rand::{CryptoRng, RngCore};
 
 use crate::{
-    utils::plonk_api::BlstPLONK, ZkStdLib, ZkStdLibArch, ZkStdLibConfig, F, NB_COMMITTED_INSTANCES,
+    F, IvcDecider, NB_COMMITTED_INSTANCES, ZkStdLib, ZkStdLibArch, ZkStdLibConfig, decider::{Decider, DeciderKind, StandardDecider, accumulator_pi_len}, utils::plonk_api::BlstPLONK,
 };
 
 /// Circuit structure which is used to create any circuit that can be compiled
@@ -51,6 +54,9 @@ pub struct MidnightCircuit<'a, R: Relation> {
     instance: Value<R::Instance>,
     witness: Value<R::Witness>,
     nb_public_inputs: Rc<RefCell<Option<usize>>>,
+    /// Deferred accumulators (as `(pi_offset, decider_kind)`) recorded during
+    /// synthesis, copied out of the `ZkStdLib` after `Relation::circuit` runs.
+    deferred_accumulators: Rc<RefCell<Vec<(usize, DeciderKind)>>>,
     circuit_error: Rc<RefCell<Option<R::Error>>>,
 }
 
@@ -78,6 +84,7 @@ impl<'a, R: Relation> MidnightCircuit<'a, R> {
             instance,
             witness,
             nb_public_inputs: Rc::new(RefCell::new(None)),
+            deferred_accumulators: Rc::new(RefCell::new(Vec::new())),
             circuit_error: Rc::new(RefCell::new(None)),
         }
     }
@@ -99,6 +106,11 @@ pub struct MidnightVK {
     architecture: ZkStdLibArch,
     k: u8,
     nb_public_inputs: usize,
+    /// Deferred accumulators (from proofs verified in-circuit) exposed in the
+    /// public inputs, as `(offset, decider_kind)` ranges. Each is a
+    /// single-point-per-side accumulator whose pairing check
+    /// is run transparently by [`verify`] after the Plonk check.
+    deferred_accumulators: Vec<(usize, DeciderKind)>,
     vk: VerifyingKey<midnight_curves::Fq, KZGCommitmentScheme<midnight_curves::Bls12>>,
 }
 
@@ -117,6 +129,12 @@ impl MidnightVK {
         writer.write_all(&[self.k])?;
 
         writer.write_all(&(self.nb_public_inputs as u32).to_le_bytes())?;
+
+        writer.write_all(&(self.deferred_accumulators.len() as u32).to_le_bytes())?;
+        for (offset, kind) in self.deferred_accumulators.iter() {
+            writer.write_all(&(*offset as u32).to_le_bytes())?;
+            writer.write_all(&[kind.tag()])?;
+        }
 
         self.vk.write(writer, format)
     }
@@ -140,6 +158,31 @@ impl MidnightVK {
         reader.read_exact(&mut bytes)?;
         let nb_public_inputs = u32::from_le_bytes(bytes) as usize;
 
+        let mut bytes = [0u8; 4];
+        reader.read_exact(&mut bytes)?;
+        let nb_accumulators = u32::from_le_bytes(bytes) as usize;
+        let mut deferred_accumulators = Vec::with_capacity(nb_accumulators);
+        for _ in 0..nb_accumulators {
+            let mut off = [0u8; 4];
+            reader.read_exact(&mut off)?;
+            let mut kind = [0u8; 1];
+            reader.read_exact(&mut kind)?;
+            let kind = match kind[0] {
+                0 => DeciderKind::Standard,
+                1 => DeciderKind::Ivc,
+                2 => DeciderKind::FinalIVC,
+                val => return Err(io::Error::new(
+                        io::ErrorKind::InvalidData,
+                        format!("unknown DeciderKind tag: {val}"),
+                    )),
+            };
+
+            deferred_accumulators.push((
+                u32::from_le_bytes(off) as usize,
+                kind,
+            ));
+        }
+
         let mut cs = ConstraintSystem::default();
         let _config = ZkStdLib::configure(&mut cs, (architecture, k - 1));
 
@@ -149,6 +192,7 @@ impl MidnightVK {
             architecture,
             k,
             nb_public_inputs,
+            deferred_accumulators,
             vk,
         })
     }
@@ -177,8 +221,7 @@ impl ProcessedSerdeObject for MidnightVK {
 
     fn byte_length(&self, format: SerdeFormat) -> usize {
         let mut buf = Vec::new();
-        self.write(&mut buf, format)
-            .expect("in-memory write cannot fail");
+        self.write(&mut buf, format).expect("in-memory write cannot fail");
         buf.len()
     }
 }
@@ -190,6 +233,7 @@ pub struct MidnightPK<R: Relation> {
     relation: R,
     // Needed to be able to build the VK from the PK
     nb_public_inputs: usize,
+    deferred_accumulators: Vec<(usize, DeciderKind)>,
     pk: ProvingKey<midnight_curves::Fq, KZGCommitmentScheme<midnight_curves::Bls12>>,
 }
 
@@ -205,6 +249,12 @@ impl<Rel: Relation> MidnightPK<Rel> {
     pub fn write<W: io::Write>(&self, writer: &mut W, format: SerdeFormat) -> io::Result<()> {
         writer.write_all(&[self.k])?;
         writer.write_all(&(self.nb_public_inputs as u32).to_le_bytes())?;
+
+        writer.write_all(&(self.deferred_accumulators.len() as u32).to_le_bytes())?;
+        for (offset, kind) in self.deferred_accumulators.iter() {
+            writer.write_all(&(*offset as u32).to_le_bytes())?;
+            writer.write_all(&[kind.tag()])?;
+        }
 
         Rel::write_relation(&self.relation, writer)?;
 
@@ -229,6 +279,30 @@ impl<Rel: Relation> MidnightPK<Rel> {
         reader.read_exact(&mut bytes)?;
         let nb_public_inputs = u32::from_le_bytes(bytes) as usize;
 
+        let mut bytes = [0u8; 4];
+        reader.read_exact(&mut bytes)?;
+        let nb_accumulators = u32::from_le_bytes(bytes) as usize;
+        let mut deferred_accumulators = Vec::with_capacity(nb_accumulators);
+        for _ in 0..nb_accumulators {
+            let mut off = [0u8; 4];
+            reader.read_exact(&mut off)?;
+            let mut kind = [0u8; 1];
+            reader.read_exact(&mut kind)?;
+            let kind = match kind[0] {
+                0 => DeciderKind::Standard,
+                1 => DeciderKind::Ivc,
+                2 => DeciderKind::FinalIVC,
+                val => return Err(io::Error::new(
+                        io::ErrorKind::InvalidData,
+                        format!("unknown DeciderKind tag: {val}"),
+                    )),
+            };
+            deferred_accumulators.push((
+                u32::from_le_bytes(off) as usize,
+                kind,
+            ));
+        }
+
         let relation = Rel::read_relation(reader)?;
 
         let pk = ProvingKey::read::<R, MidnightCircuit<Rel>>(
@@ -243,7 +317,7 @@ impl<Rel: Relation> MidnightPK<Rel> {
             .params(),
         )?;
 
-        Ok(MidnightPK { k, nb_public_inputs, relation, pk })
+        Ok(MidnightPK { k, nb_public_inputs, deferred_accumulators, relation, pk })
     }
 
     /// The size of the domain associated to this proving key.
@@ -260,11 +334,13 @@ impl<Rel: Relation> MidnightPK<Rel> {
 
     /// Return the associate [MidnightVk]
     pub fn vk(&self) -> MidnightVK {
-        MidnightVK { 
-            architecture: self.relation.used_chips(), 
-            k: self.k, 
-            nb_public_inputs: self.nb_public_inputs, 
-            vk: self.pk.get_vk().clone() }
+        MidnightVK {
+            architecture: self.relation.used_chips(),
+            k: self.k,
+            nb_public_inputs: self.nb_public_inputs,
+            deferred_accumulators: self.deferred_accumulators.clone(),
+            vk: self.pk.get_vk().clone(),
+        }
     }
 }
 
@@ -474,6 +550,12 @@ impl<R: Relation> Circuit<F> for MidnightCircuit<'_, R> {
         *self.nb_public_inputs.borrow_mut() =
             Some(zk_std_lib.native_gadget.native_chip.nb_public_inputs());
 
+        // Likewise, copy out the deferred accumulators recorded while the
+        // circuit exposed them as public inputs (see
+        // `ZkStdLib::constrain_accumulator_as_public_input`).
+        *self.deferred_accumulators.borrow_mut() =
+            zk_std_lib.deferred_accumulators.borrow().clone();
+
         // We load the tables at the end, once we have figured out what chips/gadgets
         // were actually used.
         zk_std_lib.core_decomposition_chip.load(&mut layouter)?;
@@ -535,11 +617,13 @@ pub fn setup_vk<R: Relation>(
     // During the call to [setup_vk] the circuit RefCell on public inputs has been
     // mutated with the correct value. The following [unwrap] is safe here.
     let nb_public_inputs = circuit.nb_public_inputs.clone().borrow().unwrap();
+    let deferred_accumulators = circuit.deferred_accumulators.borrow().clone();
 
     MidnightVK {
         architecture: relation.used_chips(),
         k: circuit.k as u8,
         nb_public_inputs,
+        deferred_accumulators,
         vk,
     }
 }
@@ -560,6 +644,7 @@ pub fn setup_pk<R: Relation>(relation: &R, vk: &MidnightVK) -> MidnightPK<R> {
     MidnightPK {
         k: vk.k(),
         nb_public_inputs,
+        deferred_accumulators: vk.deferred_accumulators.clone(),
         relation: relation.clone(),
         pk,
     }
@@ -618,13 +703,35 @@ where
     if pi.len() != vk.nb_public_inputs {
         return Err(Error::InvalidInstances.into());
     }
-    Ok(BlstPLONK::<MidnightCircuit<R>>::verify::<H>(
+    BlstPLONK::<MidnightCircuit<R>>::verify::<H>(
         params_verifier,
         &vk.vk,
         &[committed_pi],
         &[&pi],
         proof,
-    )?)
+    )?;
+
+    // Verify the deferred accumulators
+    // TODO: These could easily be batched.
+    // TODO: Handle batch_verify once the design is complete
+    for &(offset, kind) in vk.deferred_accumulators.iter() {
+        // The accumulator exposed in the public inputs is single-point (fixed
+        // bases already resolved).
+        let acc_len = accumulator_pi_len();
+        let fields = pi.get(offset..offset + acc_len).ok_or(Error::InvalidInstances)?;
+        let acc =
+            <AssignedAccumulator<BlstrsEmulation> as Instantiable<F>>::from_public_input(fields)
+                .ok_or(Error::InvalidInstances)?;
+        match kind{
+            DeciderKind::Standard => StandardDecider::decide(&acc, params_verifier, vk)
+            .map_err(|_| Error::InvalidInstances)?,
+            DeciderKind::Ivc => IvcDecider::decide(&acc, params_verifier, vk)
+            .map_err(|_| Error::InvalidInstances)?,
+            DeciderKind::FinalIVC => unimplemented!(),
+        }
+    }
+
+    Ok(())
 }
 
 /// Verifies a batch of proofs with respect to their corresponding vk.

--- a/zk_stdlib/src/interface.rs
+++ b/zk_stdlib/src/interface.rs
@@ -188,6 +188,8 @@ impl ProcessedSerdeObject for MidnightVK {
 pub struct MidnightPK<R: Relation> {
     k: u8,
     relation: R,
+    // Needed to be able to build the VK from the PK
+    nb_public_inputs: usize,
     pk: ProvingKey<midnight_curves::Fq, KZGCommitmentScheme<midnight_curves::Bls12>>,
 }
 
@@ -202,6 +204,7 @@ impl<Rel: Relation> MidnightPK<Rel> {
     /// but it is not recommended.
     pub fn write<W: io::Write>(&self, writer: &mut W, format: SerdeFormat) -> io::Result<()> {
         writer.write_all(&[self.k])?;
+        writer.write_all(&(self.nb_public_inputs as u32).to_le_bytes())?;
 
         Rel::write_relation(&self.relation, writer)?;
 
@@ -222,6 +225,10 @@ impl<Rel: Relation> MidnightPK<Rel> {
         reader.read_exact(&mut byte)?;
         let k = byte[0];
 
+        let mut bytes = [0u8; 4];
+        reader.read_exact(&mut bytes)?;
+        let nb_public_inputs = u32::from_le_bytes(bytes) as usize;
+
         let relation = Rel::read_relation(reader)?;
 
         let pk = ProvingKey::read::<R, MidnightCircuit<Rel>>(
@@ -236,7 +243,7 @@ impl<Rel: Relation> MidnightPK<Rel> {
             .params(),
         )?;
 
-        Ok(MidnightPK { k, relation, pk })
+        Ok(MidnightPK { k, nb_public_inputs, relation, pk })
     }
 
     /// The size of the domain associated to this proving key.
@@ -249,6 +256,15 @@ impl<Rel: Relation> MidnightPK<Rel> {
         &self,
     ) -> &ProvingKey<midnight_curves::Fq, KZGCommitmentScheme<midnight_curves::Bls12>> {
         &self.pk
+    }
+
+    /// Return the associate [MidnightVk]
+    pub fn vk(&self) -> MidnightVK {
+        MidnightVK { 
+            architecture: self.relation.used_chips(), 
+            k: self.k, 
+            nb_public_inputs: self.nb_public_inputs, 
+            vk: self.pk.get_vk().clone() }
     }
 }
 
@@ -537,8 +553,13 @@ pub fn setup_pk<R: Relation>(relation: &R, vk: &MidnightVK) -> MidnightPK<R> {
         Some(vk.k() as u32),
     );
     let pk = BlstPLONK::<MidnightCircuit<R>>::setup_pk(&circuit, &vk.vk);
+
+    // During the call to [setup_vk] the circuit RefCell on public inputs has been
+    // mutated with the correct value. The following [unwrap] is safe here.
+    let nb_public_inputs = circuit.nb_public_inputs.clone().borrow().unwrap();
     MidnightPK {
         k: vk.k(),
+        nb_public_inputs,
         relation: relation.clone(),
         pk,
     }

--- a/zk_stdlib/src/lib.rs
+++ b/zk_stdlib/src/lib.rs
@@ -13,6 +13,7 @@
 
 #![doc = include_str!("../README.md")]
 
+pub mod decider;
 mod external;
 mod instructions;
 pub mod interface;

--- a/zk_stdlib/src/lib.rs
+++ b/zk_stdlib/src/lib.rs
@@ -887,6 +887,14 @@ impl ZkStdLib {
         self.verifier().constrain_as_public_input(layouter, &acc)?;
         let len = self.native_gadget.native_chip.nb_public_inputs() - offset;
 
+        // Check that the accumulator is compressed.
+        assert_eq!(
+            len,
+            crate::decider::accumulator_pi_len(),
+            "decider exposed a non-single-point accumulator as public input; it \
+             must be collapsed with its fixed bases resolved"
+        );
+
         Ok(())
     }
 

--- a/zk_stdlib/src/lib.rs
+++ b/zk_stdlib/src/lib.rs
@@ -26,6 +26,7 @@ use blake2b::blake2b::{
     blake2b_chip::{Blake2bChip, Blake2bConfig},
     NB_BLAKE2B_ADVICE_COLS,
 };
+use group::Group;
 pub use interface::*;
 use keccak_sha3::packed_chip::{PackedChip, PackedConfig, PACKED_ADVICE_COLS, PACKED_FIXED_COLS};
 use midnight_circuits::{
@@ -73,7 +74,7 @@ use midnight_circuits::{
     },
     types::{AssignedBit, AssignedByte, AssignedNative, AssignedNativePoint, ComposableChip},
     vec::{vector_gadget::VectorGadget, AssignedVector},
-    verifier::{BlstrsEmulation, VerifierGadget},
+    verifier::{AssignedKZGCommitment, BlstrsEmulation, SelfEmulation, VerifierGadget},
 };
 use midnight_curves::{
     curve25519::{self as curve25519_mod, Curve25519},
@@ -82,11 +83,16 @@ use midnight_curves::{
     Fq,
 };
 use midnight_proofs::{
-    circuit::Layouter,
+    circuit::{Layouter, Value},
     plonk::{ConstraintSystem, Error},
+    poly::PolynomialLabel,
+    utils::{helpers::ProcessedSerdeObject, SerdeFormat},
 };
 
-use crate::external::{blake2b::Blake2bWrapper, keccak_sha3::KeccakSha3Wrapper};
+use crate::{
+    decider::{Decider, DeciderKind, IvcDecider, StandardDecider},
+    external::{blake2b::Blake2bWrapper, keccak_sha3::KeccakSha3Wrapper},
+};
 
 type C = midnight_curves::JubjubExtended;
 type F = midnight_curves::Fq;
@@ -347,6 +353,10 @@ pub struct ZkStdLib {
     used_scanner: Rc<RefCell<bool>>,
     used_keccak_or_sha3: Rc<RefCell<bool>>,
     used_blake2b: Rc<RefCell<bool>>,
+
+    // Deferred accumulators exposed as public inputs during synthesis, as
+    // `(pi_offset, pi_len)`.
+    deferred_accumulators: Rc<RefCell<Vec<(usize, DeciderKind)>>>,
 }
 
 impl ZkStdLib {
@@ -455,6 +465,7 @@ impl ZkStdLib {
             used_scanner: Rc::new(RefCell::new(false)),
             used_keccak_or_sha3: Rc::new(RefCell::new(false)),
             used_blake2b: Rc::new(RefCell::new(false)),
+            deferred_accumulators: Rc::new(RefCell::new(Vec::new())),
         }
     }
 
@@ -809,6 +820,74 @@ impl ZkStdLib {
         self.verifier_gadget
             .as_ref()
             .unwrap_or_else(|| panic!("ZkStdLibArch must enable bls12_381 & poseidon"))
+    }
+
+    /// Verifies an inner proof in-circuit from a self-describing, fixed,
+    /// verifying-key blob, and exposes the resulting single-point accumulator
+    /// as public inputs, **recording its `(offset, len)`** so that
+    /// [`verify`](crate::verify) executes deferred pairing check
+    /// automatically.
+    pub fn verify_proof(
+        &self,
+        layouter: &mut impl Layouter<F>,
+        vk_blob: &[u8],
+        instance: &[&[AssignedNative<F>]],
+        proof: Value<Vec<u8>>,
+    ) -> Result<(), Error> {
+        let (kind, vk_bytes) = DeciderKind::split(vk_blob)?;
+
+        // Push (offset, kind) to the deferred_accumulators.
+        self.deferred_accumulators.borrow_mut().push(
+            (self.native_gadget.native_chip.nb_public_inputs(), kind)
+        );
+
+        match kind {
+            DeciderKind::Standard => {
+                self.verify_proof_with::<StandardDecider>(layouter, vk_bytes, instance, proof)
+            }
+            DeciderKind::Ivc => {
+                self.verify_proof_with::<IvcDecider>(layouter, vk_bytes, instance, proof)
+            }
+            DeciderKind::FinalIVC => todo!(),
+        }
+    }
+
+    /// Body of [`verify_proof`](Self::verify_proof) parametrized for a
+    /// decider `D`: reads and assigns `D`'s verifying key, runs
+    /// [`Decider::in_circuit_decide`], then exposes and stores
+    /// the accumulator.
+    fn verify_proof_with<D: Decider>(
+        &self,
+        layouter: &mut impl Layouter<F>,
+        vk_bytes: &[u8],
+        instance: &[&[AssignedNative<F>]],
+        proof: Value<Vec<u8>>,
+    ) -> Result<(), Error> {
+        let vk = <D::Vk as ProcessedSerdeObject>::read(&mut { vk_bytes }, SerdeFormat::Processed)
+            .map_err(|e| Error::Synthesis(format!("reading verifying key: {e}")))?;
+        let assigned_vk = D::assign_vk(self, layouter, &vk)?;
+
+        let committed_instance = [AssignedKZGCommitment::simple(
+            self.bls12_381()
+                .assign_fixed(layouter, <BlstrsEmulation as SelfEmulation>::C::identity())?,
+            PolynomialLabel::CommittedInstance(0),
+        )];
+
+        let acc = D::in_circuit_prepare(
+            self,
+            layouter,
+            &assigned_vk,
+            &committed_instance,
+            instance,
+            proof,
+        )?
+        .ok_or_else(|| Error::Synthesis("decider produced no accumulator".into()))?;
+
+        let offset = self.native_gadget.native_chip.nb_public_inputs();
+        self.verifier().constrain_as_public_input(layouter, &acc)?;
+        let len = self.native_gadget.native_chip.nb_public_inputs() - offset;
+
+        Ok(())
     }
 
     /// Assert that a given assigned bit is true.


### PR DESCRIPTION
Include decider trait, and implement a few deciders (standard, IVC, final IVC). We also write an example of the 'final IVC' decider. 

We add a built-in function in zk-stdlib to verify a proof in circuit, using one of the decider strategies.

Work in progress. 