### PR TITLE
[Fflonk PR1] Refining protocol and PCS primitives to prepare for fflonk

### DIFF
--- a/proofs/CHANGELOG.md
+++ b/proofs/CHANGELOG.md
@@ -30,6 +30,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * Fix cost-model [#435](https://github.com/midnightntwrk/midnight-zk/pull/435)
 
 ### Changed
+* Extend `PolynomialCommitmentScheme` with `squeeze_evaluation_point` and `srs_monomial_blowup` and add a `k` argument to `multi_prepare`, as PCS-agnostic extension points for fflonk [#487](https://github.com/midnightntwrk/midnight-zk/pull/487)
 * `circuit_model` is now parameterized by a `PolynomialCommitmentScheme` (`circuit_model::<_, CS>`) instead of const `COMM`/`SCALAR` byte-size generics [#440](https://github.com/midnightntwrk/midnight-zk/pull/440)
 * Rename `PolynomialPointer` to `PolynomialReference` in `ProverQuery`; rename `poly` field to `poly_ref`; change `poly_inner_product` to accept `&[&Polynomial<F, Coeff>]` to avoid cloning [#411](https://github.com/midnightntwrk/midnight-zk/pull/411)
 * Rename `CommitmentLabel` to `PolynomialLabel`; add `NoLabel` variant for freshly deserialized commitments; introduce `Labelable` trait so every call site attaches the correct label after deserialization [#392](https://github.com/midnightntwrk/midnight-zk/pull/392)

--- a/proofs/src/plonk/bench/prover.rs
+++ b/proofs/src/plonk/bench/prover.rs
@@ -504,7 +504,8 @@ where
         ..
     } = trace;
 
-    let x: F = transcript.squeeze_challenge();
+    // PCS-aware squeeze (see plonk/prover.rs).
+    let x: F = CS::squeeze_evaluation_point(transcript);
 
     group.bench_function("Write evals to transcript", |b| {
         b.iter_batched(

--- a/proofs/src/plonk/prover.rs
+++ b/proofs/src/plonk/prover.rs
@@ -342,7 +342,7 @@ where
         ..
     } = trace;
 
-    let x: F = transcript.squeeze_challenge();
+    let x: F = CS::squeeze_evaluation_point(transcript);
 
     let Evals {
         fixed_evals,

--- a/proofs/src/plonk/verifier.rs
+++ b/proofs/src/plonk/verifier.rs
@@ -197,7 +197,7 @@ where
 
     // Sample x challenge, which is used to ensure the circuit is
     // satisfied with high probability.
-    let x: F = transcript.squeeze_challenge();
+    let x: F = CS::squeeze_evaluation_point(transcript);
 
     let splitting_factor = x.pow_vartime([vk.n() - 1]);
     let xn = splitting_factor * x;
@@ -360,7 +360,7 @@ where
     // We are now convinced the circuit is satisfied so long as the
     // polynomial commitments open to the correct values, which is true as long
     // as the following accumulator passes the invariant.
-    CS::multi_prepare(&queries, transcript).map_err(|_| Error::Opening)
+    CS::multi_prepare(&queries, vk.domain.k(), transcript).map_err(|_| Error::Opening)
 }
 
 /// Prepares a plonk proof into a PCS instance that can be finalized or

--- a/proofs/src/poly/commitment.rs
+++ b/proofs/src/poly/commitment.rs
@@ -68,6 +68,33 @@ pub trait PolynomialCommitmentScheme<F: PrimeField>: Clone + Debug {
         Self::commit_many(params, &[polynomial], &[label])
     }
 
+    /// Squeeze the evaluation point used by the protocol to open committed
+    /// polynomials. The default implementation simply squeezes a challenge,
+    /// but specific PCS may require squeezing over sets of challenges
+    /// verifying certain properties, for example fflonk requires the
+    /// evaluation point to be a `t`-th power in the field.
+    ///
+    /// The protocol must squeeze evaluation points through this method.
+    fn squeeze_evaluation_point<T: Transcript>(transcript: &mut T) -> F
+    where
+        F: Sampleable<T::Hash>,
+    {
+        transcript.squeeze_challenge()
+    }
+
+    /// Multiplicative blow-up factor by which `params.g_monomial_size()` must
+    /// exceed `2^k` (the circuit's Lagrange-domain size) for this PCS to
+    /// commit every polynomial it produces at the requested circuit size.
+    /// Returns `1` when no extension is needed.
+    ///
+    /// `cs_degree` is the constraint system's `cs.degree()`. Schemes that
+    /// commit to a single combined polynomial (e.g. `single-h-commitment`,
+    /// fflonk's bundles) factor that into their requested blow-up.
+    fn srs_monomial_blowup(cs_degree: usize) -> usize {
+        let _ = cs_degree; // Just to avoid a clippy warning.
+        1
+    }
+
     /// Create a multi-opening proof at a set of [ProverQuery]'s.
     fn multi_open<T: Transcript>(
         params: &Self::Parameters,
@@ -89,8 +116,15 @@ pub trait PolynomialCommitmentScheme<F: PrimeField>: Clone + Debug {
 
     /// Verify an multi-opening proof for a given set of [VerifierQuery]'s.
     /// The function fails if the transcript has trailing bytes.
+    ///
+    /// `k` is the log2 of the circuit's (Lagrange) domain size. Schemes whose
+    /// opening structure depends on the domain relative to the SRS capacity
+    /// (e.g. fflonk's SRS-aware bundling) need it to reconstruct and
+    /// sanity-check the prover's choices; schemes that don't (e.g. plain KZG)
+    /// ignore it.
     fn multi_prepare<'com, T: Transcript>(
         verifier_query: &[VerifierQuery<'com, F, Self>],
+        k: u32,
         transcript: &mut T,
     ) -> Result<Self::VerificationGuard, Error>
     where

--- a/proofs/src/poly/commitment.rs
+++ b/proofs/src/poly/commitment.rs
@@ -70,9 +70,9 @@ pub trait PolynomialCommitmentScheme<F: PrimeField>: Clone + Debug {
 
     /// Squeeze the evaluation point used by the protocol to open committed
     /// polynomials. The default implementation simply squeezes a challenge,
-    /// but specific PCS may require squeezing over sets of challenges
-    /// verifying certain properties, for example fflonk requires the
-    /// evaluation point to be a `t`-th power in the field.
+    /// but specific PCS may require squeezing challenges satisfying certain
+    /// properties, for example fflonk requires the evaluation point to be a
+    /// `t`-th power in the field.
     ///
     /// The protocol must squeeze evaluation points through this method.
     fn squeeze_evaluation_point<T: Transcript>(transcript: &mut T) -> F

--- a/proofs/src/poly/kzg/mod.rs
+++ b/proofs/src/poly/kzg/mod.rs
@@ -107,6 +107,18 @@ where
         )
     }
 
+    /// With `single-h-commitment` the quotient is committed as one polynomial
+    /// of degree up to `(cs_degree - 1) * n`, so the monomial basis must be
+    /// blown up to the next power of two of `cs_degree - 1`. Otherwise KZG
+    /// commits each polynomial at the Lagrange size and needs no extension.
+    fn srs_monomial_blowup(cs_degree: usize) -> usize {
+        if cfg!(feature = "single-h-commitment") {
+            (cs_degree - 1).next_power_of_two()
+        } else {
+            1
+        }
+    }
+
     fn multi_open<T: Transcript>(
         params: &Self::Parameters,
         queries: &[ProverQuery<E::Fr>],
@@ -290,6 +302,7 @@ where
 
     fn multi_prepare<'com, T: Transcript>(
         queries: &[VerifierQuery<'com, E::Fr, KZGCommitmentScheme<E>>],
+        _k: u32,
         transcript: &mut T,
     ) -> Result<DualMSM<E>, Error>
     where
@@ -609,7 +622,7 @@ mod tests {
         };
 
         let result =
-            KZGCommitmentScheme::multi_prepare(&queries.collect::<Vec<_>>(), &mut transcript)
+            KZGCommitmentScheme::multi_prepare(&queries.collect::<Vec<_>>(), 4, &mut transcript)
                 .unwrap();
 
         if should_fail {

--- a/proofs/src/poly/kzg/mod.rs
+++ b/proofs/src/poly/kzg/mod.rs
@@ -539,12 +539,12 @@ mod tests {
         let proof = create_proof::<_, CircuitTranscript<Blake2bState>>(&params);
 
         let verifier_params = params.verifier_params();
-        verify::<Bls12, CircuitTranscript<Blake2bState>>(&verifier_params, &proof[..], false);
+        verify::<Bls12, CircuitTranscript<Blake2bState>>(&verifier_params, &proof[..], K, false);
 
-        verify::<Bls12, CircuitTranscript<Blake2bState>>(&verifier_params, &proof[..], true);
+        verify::<Bls12, CircuitTranscript<Blake2bState>>(&verifier_params, &proof[..], K, true);
     }
 
-    fn verify<E, T>(verifier_params: &ParamsVerifierKZG<E>, proof: &[u8], should_fail: bool)
+    fn verify<E, T>(verifier_params: &ParamsVerifierKZG<E>, proof: &[u8], k: u32, should_fail: bool)
     where
         E: MultiMillerLoop,
         T: Transcript,
@@ -622,7 +622,7 @@ mod tests {
         };
 
         let result =
-            KZGCommitmentScheme::multi_prepare(&queries.collect::<Vec<_>>(), 4, &mut transcript)
+            KZGCommitmentScheme::multi_prepare(&queries.collect::<Vec<_>>(), k, &mut transcript)
                 .unwrap();
 
         if should_fail {

--- a/proofs/src/poly/kzg/params.rs
+++ b/proofs/src/poly/kzg/params.rs
@@ -128,7 +128,7 @@ where
     }
 
     /// Combine the monomial basis from `extended` with the Lagrange basis from
-    /// `self`, consuming both. This avoids the FFT that [`downsize_lagrange`]
+    /// `self`, consuming both. This avoids the FFT that `downsize_lagrange`
     /// would otherwise require.
     ///
     /// # Panics

--- a/proofs/src/poly/kzg/params.rs
+++ b/proofs/src/poly/kzg/params.rs
@@ -115,7 +115,6 @@ where
     /// `downsize_lagrange(k)` so that `max_k()` equals the circuit domain size
     /// `k` while `g` retains its original length for the H-polynomial
     /// commitment.
-    #[cfg(feature = "single-h-commitment")]
     pub fn downsize_lagrange(&mut self, new_k: u32) {
         let n = 1usize << new_k;
         assert!(
@@ -135,7 +134,6 @@ where
     ///
     /// If `extended.g` is not strictly larger than `self.g`, or if the shared
     /// prefix of the monomial bases does not match.
-    #[cfg(feature = "single-h-commitment")]
     pub fn with_extended_monomial(mut self, extended: Self) -> Self {
         assert!(
             extended.g.len() > self.g.len(),

--- a/zk_stdlib/CHANGELOG.md
+++ b/zk_stdlib/CHANGELOG.md
@@ -20,6 +20,7 @@ We use [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 * Fix cost model proof size check to account for committed instance columns [#280](https://github.com/midnightntwrk/midnight-zk/pull/280)
 
 ### Changed
+* `load_srs` sizes the monomial basis via `PolynomialCommitmentScheme::srs_monomial_blowup` instead of a `single-h-commitment` `cfg` branch [#487](https://github.com/midnightntwrk/midnight-zk/pull/487)
 * `cost_model` passes `KZGCommitmentScheme<Bls12>` to `circuit_model`, removing the `COMMITMENT_BYTE_SIZE`/`SCALAR_BYTE_SIZE` constants [#440](https://github.com/midnightntwrk/midnight-zk/pull/440)
 * `verify` now takes `committed_instance: Option<KZGMultiCommitment<Bls12>>` instead of `Option<G1Affine>`, avoiding a commitment→point→commitment round-trip at call sites [#450](https://github.com/midnightntwrk/midnight-zk/pull/450)
 * Adapt to new `KZGCommitment` API [#381](https://github.com/midnightntwrk/midnight-zk/pull/381)

--- a/zk_stdlib/src/utils/plonk_api.rs
+++ b/zk_stdlib/src/utils/plonk_api.rs
@@ -29,7 +29,7 @@ use midnight_proofs::{
         create_proof, keygen_pk, keygen_vk, prepare, Circuit, Error, ProvingKey, VerifyingKey,
     },
     poly::{
-        commitment::Guard,
+        commitment::{Guard, PolynomialCommitmentScheme},
         kzg::{
             commitment::KZGMultiCommitment,
             params::{ParamsKZG, ParamsVerifierKZG},
@@ -261,28 +261,26 @@ pub enum SrsSource {
 /// Loads an SRS (over BLS12-381) for the given circuit size `k` and
 /// constraint-system degree `cs_degree`.
 ///
-/// Without the `single-h-commitment` feature, the monomial and Lagrange bases
-/// have the same size `2^k`. With the feature enabled the monomial basis is
-/// extended to `k + ceil(log2(cs_degree - 1))` so that it can hold the full
-/// quotient polynomial, while the Lagrange basis is kept at size `2^k`.
+/// The monomial basis is sized via the active PCS's
+/// [`PolynomialCommitmentScheme::srs_monomial_blowup`]: a blow-up factor of
+/// `1` keeps the monomial basis at the Lagrange size `2^k`; a blow-up of `B`
+/// extends it to `2^k · B`. The Lagrange basis stays at size `2^k`.
 pub fn load_srs(source: SrsSource, k: u32, cs_degree: usize) -> ParamsKZG<Bls12> {
     let fetch = |k| match source {
         SrsSource::Filecoin => filecoin_srs(k),
         SrsSource::Midnight => midnight_srs(k),
     };
 
-    #[cfg(not(feature = "single-h-commitment"))]
-    {
-        let _ = cs_degree;
-        fetch(k)
+    let blowup = <KZGCommitmentScheme<Bls12> as PolynomialCommitmentScheme<
+        midnight_curves::Fq,
+    >>::srs_monomial_blowup(cs_degree);
+    let base = fetch(k);
+    if blowup <= 1 {
+        return base;
     }
-    #[cfg(feature = "single-h-commitment")]
-    {
-        let extended_k = k + ((cs_degree - 1) as f64).log2().ceil() as u32;
-        let base = fetch(k);
-        let extended = fetch(extended_k);
-        base.with_extended_monomial(extended)
-    }
+    let extended_k = k + (blowup as f64).log2().ceil() as u32;
+    let extended = fetch(extended_k);
+    base.with_extended_monomial(extended)
 }
 
 /// Loads Filecoin's production SRS (over BLS12-381) for the given relation.

--- a/zk_stdlib/src/utils/plonk_api.rs
+++ b/zk_stdlib/src/utils/plonk_api.rs
@@ -271,16 +271,16 @@ pub fn load_srs(source: SrsSource, k: u32, cs_degree: usize) -> ParamsKZG<Bls12>
         SrsSource::Midnight => midnight_srs(k),
     };
 
-    let blowup = <KZGCommitmentScheme<Bls12> as PolynomialCommitmentScheme<
-        midnight_curves::Fq,
-    >>::srs_monomial_blowup(cs_degree);
+    let blowup = <KZGCommitmentScheme<Bls12>>::srs_monomial_blowup(cs_degree);
+    assert_ne!(blowup, 0, "srs blowup should be >= 1");
     let base = fetch(k);
-    if blowup <= 1 {
-        return base;
+    if blowup == 1 {
+        base
+    } else {
+        let extended_k = k + (blowup as f64).log2().ceil() as u32;
+        let extended = fetch(extended_k);
+        base.with_extended_monomial(extended)
     }
-    let extended_k = k + (blowup as f64).log2().ceil() as u32;
-    let extended = fetch(extended_k);
-    base.with_extended_monomial(extended)
 }
 
 /// Loads Filecoin's production SRS (over BLS12-381) for the given relation.


### PR DESCRIPTION
Adds 3 functions to the `PolynomialCommitmentScheme` trait to prepare for fflonk, and call them in the protocol. These functions behave slightly differently for fflonk and kzg, hence the need to account for this at the trait level, so that the protocol can remain identical for the two implementations.