### PR TITLE
[Fflonk PR3] Batching `commit` calls

### DIFF
--- a/circuits/CHANGELOG.md
+++ b/circuits/CHANGELOG.md
@@ -17,6 +17,7 @@ We use [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 * Fix cost model to pass correct number of committed instances [#280](https://github.com/midnightntwrk/midnight-zk/pull/280)
 
 ### Changed
+* Adapt the in-circuit verifier gadget to the batched cross-argument commitment layout [#493](https://github.com/midnightntwrk/midnight-zk/pull/493)
 * Removes the Labelable trait [#491](https://github.com/midnightntwrk/midnight-zk/pull/491)
 * Migrate to Rust edition 2024; declare MSRV 1.90. Both are now inherited from the workspace [#508](https://github.com/midnightntwrk/midnight-zk/pull/508)
 * `circuit_modeling` derives the commitment byte length from `KZGCommitmentScheme` via `circuit_model_with` instead of hard-coded sizes [#440](https://github.com/midnightntwrk/midnight-zk/pull/440)

--- a/circuits/src/verifier/lookup.rs
+++ b/circuits/src/verifier/lookup.rs
@@ -75,36 +75,76 @@ pub(crate) fn read_multiplicities<S: SelfEmulation, PCS: InCircuitPCS<S>>(
         .collect())
 }
 
-impl<S: SelfEmulation, PCS: InCircuitPCS<S>> CommittedMultiplicities<S, PCS> {
-    pub(crate) fn read_commitment(
-        self,
-        argument_index: usize,
-        nb_flattened: usize,
-        layouter: &mut impl Layouter<S::F>,
-        transcript_gadget: &mut TranscriptGadget<S>,
-    ) -> Result<Committed<S, PCS>, Error> {
-        let helper_polys = (0..nb_flattened)
-            .map(|j| {
-                PCS::read_commitment(
-                    transcript_gadget,
-                    layouter,
-                    &[PolynomialLabel::LogupHelper(argument_index, j)],
-                )
-            })
-            .collect::<Result<Vec<_>, Error>>()?;
-        let accumulator = PCS::read_commitment(
-            transcript_gadget,
-            layouter,
-            &[PolynomialLabel::LogupAggregator(argument_index)],
-        )?;
+/// Partial state between the batched helper read and the batched aggregator
+/// read.
+#[derive(Clone, Debug)]
+pub(crate) struct Helpers<S: SelfEmulation, PCS: InCircuitPCS<S>> {
+    argument_index: usize,
+    multiplicities: PCS::AssignedCommitment,
+    helper_polys: Vec<PCS::AssignedCommitment>,
+}
 
-        Ok(Committed {
-            argument_index,
-            multiplicities: self.multiplicities,
-            helper_polys,
-            accumulator,
-        })
+/// Reads the batched helper commitments for all logup arguments.
+pub(crate) fn read_helpers<S: SelfEmulation, PCS: InCircuitPCS<S>>(
+    args_with_multiplicities: Vec<(usize, usize, CommittedMultiplicities<S, PCS>)>,
+    layouter: &mut impl Layouter<S::F>,
+    transcript_gadget: &mut TranscriptGadget<S>,
+) -> Result<Vec<Helpers<S, PCS>>, Error> {
+    // Build the full label set in (arg, chunk) order, matching the prover's
+    // flat iteration.
+    let mut labels: Vec<PolynomialLabel> = Vec::new();
+    for (arg, nb_chunks, _) in &args_with_multiplicities {
+        for chunk_idx in 0..*nb_chunks {
+            labels.push(PolynomialLabel::LogupHelper(*arg, chunk_idx));
+        }
     }
+    if labels.is_empty() {
+        // No helpers anywhere — the prover skipped the write.
+        return Ok(args_with_multiplicities
+            .into_iter()
+            .map(|(argument_index, _, m)| Helpers {
+                argument_index,
+                multiplicities: m.multiplicities,
+                helper_polys: Vec::new(),
+            })
+            .collect());
+    }
+    let shared = PCS::read_commitment(transcript_gadget, layouter, &labels)?;
+    Ok(args_with_multiplicities
+        .into_iter()
+        .map(|(argument_index, nb_chunks, m)| Helpers {
+            argument_index,
+            multiplicities: m.multiplicities,
+            helper_polys: vec![shared.clone(); nb_chunks],
+        })
+        .collect())
+}
+
+/// Reads the batched aggregator commitment for all logup arguments and
+/// assembles one [`Committed`] per arg. Mirrors the off-circuit
+/// `logup::verifier::read_aggregators`.
+pub(crate) fn read_aggregators<S: SelfEmulation, PCS: InCircuitPCS<S>>(
+    helpers: Vec<Helpers<S, PCS>>,
+    layouter: &mut impl Layouter<S::F>,
+    transcript_gadget: &mut TranscriptGadget<S>,
+) -> Result<Vec<Committed<S, PCS>>, Error> {
+    if helpers.is_empty() {
+        return Ok(Vec::new());
+    }
+    let labels: Vec<_> = helpers
+        .iter()
+        .map(|h| PolynomialLabel::LogupAggregator(h.argument_index))
+        .collect();
+    let shared_agg = PCS::read_commitment(transcript_gadget, layouter, &labels)?;
+    Ok(helpers
+        .into_iter()
+        .map(|h| Committed {
+            argument_index: h.argument_index,
+            multiplicities: h.multiplicities,
+            helper_polys: h.helper_polys,
+            accumulator: shared_agg.clone(),
+        })
+        .collect())
 }
 
 impl<S: SelfEmulation, PCS: InCircuitPCS<S>> Committed<S, PCS> {

--- a/circuits/src/verifier/lookup.rs
+++ b/circuits/src/verifier/lookup.rs
@@ -57,18 +57,22 @@ pub(crate) struct Evaluated<S: SelfEmulation, PCS: InCircuitPCS<S>> {
     pub(crate) evaluated: LookupEvaluated<S>,
 }
 
-/// Reads the prover's multiplicities commitment from the transcript.
+/// Reads the batched multiplicities commitment for all logup arguments.
 pub(crate) fn read_multiplicities<S: SelfEmulation, PCS: InCircuitPCS<S>>(
-    argument_index: usize,
+    num_args: usize,
     layouter: &mut impl Layouter<S::F>,
     transcript_gadget: &mut TranscriptGadget<S>,
-) -> Result<CommittedMultiplicities<S, PCS>, Error> {
-    let multiplicities = PCS::read_commitment(
-        transcript_gadget,
-        layouter,
-        &[PolynomialLabel::LogupMultiplicities(argument_index)],
-    )?;
-    Ok(CommittedMultiplicities { multiplicities })
+) -> Result<Vec<CommittedMultiplicities<S, PCS>>, Error> {
+    if num_args == 0 {
+        return Ok(Vec::new());
+    }
+    let labels: Vec<_> = (0..num_args).map(PolynomialLabel::LogupMultiplicities).collect();
+    let shared = PCS::read_commitment(transcript_gadget, layouter, &labels)?;
+    Ok((0..num_args)
+        .map(|_| CommittedMultiplicities {
+            multiplicities: shared.clone(),
+        })
+        .collect())
 }
 
 impl<S: SelfEmulation, PCS: InCircuitPCS<S>> CommittedMultiplicities<S, PCS> {

--- a/circuits/src/verifier/permutation.rs
+++ b/circuits/src/verifier/permutation.rs
@@ -60,18 +60,17 @@ pub(crate) fn read_product_commitments<S: SelfEmulation, PCS: InCircuitPCS<S>>(
     cs: &ConstraintSystem<S::F>,
 ) -> Result<Committed<S, PCS>, Error> {
     let chunk_len = cs.degree() - 2;
+    let num_chunks = cs.permutation().get_columns().len().div_ceil(chunk_len);
 
-    let nb_chunks = cs.permutation().get_columns().len().div_ceil(chunk_len);
-
-    let permutation_product_commitments = (0..nb_chunks)
-        .map(|i| {
-            PCS::read_commitment(
-                transcript_gadget,
-                layouter,
-                &[PolynomialLabel::PermutationAccumulator(i)],
-            )
-        })
-        .collect::<Result<Vec<_>, _>>()?;
+    // One batched read for all permutation-accumulator sets; each set's query
+    // routes to its own sub-bundle via `PermutationAccumulator(i)`.
+    let permutation_product_commitments = if num_chunks == 0 {
+        Vec::new()
+    } else {
+        let labels: Vec<_> = (0..num_chunks).map(PolynomialLabel::PermutationAccumulator).collect();
+        let shared = PCS::read_commitment(transcript_gadget, layouter, &labels)?;
+        vec![shared; num_chunks]
+    };
 
     Ok(Committed {
         permutation_product_commitments,

--- a/circuits/src/verifier/trash.rs
+++ b/circuits/src/verifier/trash.rs
@@ -44,21 +44,26 @@ pub(crate) struct Evaluated<S: SelfEmulation, PCS: InCircuitPCS<S>> {
     pub(crate) evaluated: TrashEvaluated<S>,
 }
 
-pub(crate) fn read_committed<S: SelfEmulation, PCS: InCircuitPCS<S>>(
-    argument_index: usize,
+/// Reads the batched commitment to all trash arguments in one transcript entry.
+/// Each argument holds a clone of the shared commitment and routes its query
+/// via its own label.
+pub(crate) fn read_trashcans<S: SelfEmulation, PCS: InCircuitPCS<S>>(
+    num_args: usize,
     layouter: &mut impl Layouter<S::F>,
     transcript_gadget: &mut TranscriptGadget<S>,
-) -> Result<Committed<S, PCS>, Error> {
-    let trash_commitment = PCS::read_commitment(
-        transcript_gadget,
-        layouter,
-        &[PolynomialLabel::Trash(argument_index)],
-    )?;
+) -> Result<Vec<Committed<S, PCS>>, Error> {
+    if num_args == 0 {
+        return Ok(Vec::new());
+    }
+    let labels: Vec<_> = (0..num_args).map(PolynomialLabel::Trash).collect();
+    let shared = PCS::read_commitment(transcript_gadget, layouter, &labels)?;
 
-    Ok(Committed {
-        argument_index,
-        trash_commitment,
-    })
+    Ok((0..num_args)
+        .map(|argument_index| Committed {
+            argument_index,
+            trash_commitment: shared.clone(),
+        })
+        .collect())
 }
 
 impl<S: SelfEmulation, PCS: InCircuitPCS<S>> Committed<S, PCS> {

--- a/circuits/src/verifier/verifier_gadget.rs
+++ b/circuits/src/verifier/verifier_gadget.rs
@@ -390,12 +390,10 @@ impl<S: SelfEmulation> VerifierGadget<S> {
 
         let trash_challenge = transcript.squeeze_challenge(layouter)?;
 
-        let trashcans_committed = cs
-            .trashcans()
-            .iter()
-            .enumerate()
-            .map(|(i, _argument)| trash::read_committed(i, layouter, &mut transcript))
-            .collect::<Result<Vec<_>, _>>()?;
+        // Read the batched trash commitment (one transcript entry for all trash
+        // arguments).
+        let trashcans_committed =
+            trash::read_trashcans(cs.trashcans().len(), layouter, &mut transcript)?;
 
         // Sample y challenge, which keeps the gates linearly independent
         let y = transcript.squeeze_challenge(layouter)?;

--- a/circuits/src/verifier/verifier_gadget.rs
+++ b/circuits/src/verifier/verifier_gadget.rs
@@ -39,7 +39,7 @@ use crate::{
             eval_expression, lookup::lookup_expressions, permutation::permutation_expressions,
             trash::trash_expressions,
         },
-        lookup,
+        lookup::{read_aggregators, read_helpers, read_multiplicities},
         pcs::{InCircuitHomomorphicCommitment, InCircuitPCS, VerifierQuery},
         permutation::{self, evaluate_permutation_common},
         traces::VerifierTrace,
@@ -377,7 +377,11 @@ impl<S: SelfEmulation> VerifierGadget<S> {
                 let nb_flat = batch.num_chunks(assigned_vk.cs_degree);
                 (i, nb_flat, m)
             })
-            .collect::<Result<Vec<_>, _>>()?;
+            .collect();
+        let helpers_only =
+            read_helpers::<S, PCS>(args_with_multiplicities, layouter, &mut transcript)?;
+        let lookups_committed =
+            read_aggregators::<S, PCS>(helpers_only, layouter, &mut transcript)?;
 
         let trash_challenge = transcript.squeeze_challenge(layouter)?;
 

--- a/circuits/src/verifier/verifier_gadget.rs
+++ b/circuits/src/verifier/verifier_gadget.rs
@@ -357,28 +357,25 @@ impl<S: SelfEmulation> VerifierGadget<S> {
         // Sample theta challenge for keeping lookup columns linearly independent
         let theta = transcript.squeeze_challenge(layouter)?;
 
-        let multiplicities_committed = cs
-            .lookups()
-            .iter()
-            .enumerate()
-            .map(|(i, _l)| lookup::read_multiplicities(i, layouter, &mut transcript))
-            .collect::<Result<Vec<_>, Error>>()?;
+        // Read the batched multiplicities commitment.
+        let multiplicities_committed =
+            read_multiplicities::<S, PCS>(cs.lookups().len(), layouter, &mut transcript)?;
 
         let beta = transcript.squeeze_challenge(layouter)?;
         let gamma = transcript.squeeze_challenge(layouter)?;
 
         let permutation_committed =
-            // Hash each permutation product commitment
             permutation::read_product_commitments(layouter, &mut transcript, cs)?;
 
-        let lookups_committed = multiplicities_committed
+        // Read one batched helper commitment for all (arg, chunk) helpers, then
+        // one batched aggregator commitment.
+        let args_with_multiplicities: Vec<_> = multiplicities_committed
             .into_iter()
             .zip(cs.lookups().iter())
             .enumerate()
             .map(|(i, (m, batch))| {
                 let nb_flat = batch.num_chunks(assigned_vk.cs_degree);
-                // Hash each lookup product commitment
-                m.read_commitment(i, nb_flat, layouter, &mut transcript)
+                (i, nb_flat, m)
             })
             .collect::<Result<Vec<_>, _>>()?;
 

--- a/circuits/src/verifier/verifier_gadget.rs
+++ b/circuits/src/verifier/verifier_gadget.rs
@@ -348,11 +348,16 @@ impl<S: SelfEmulation> VerifierGadget<S> {
             instance.iter().try_for_each(|pi| transcript.common_scalar(layouter, pi))?;
         }
 
-        // Hash the prover's advice commitments into the transcript and squeeze
-        // challenges
-        let advice_commitments = (0..cs.num_advice_columns())
-            .map(|i| PCS::read_commitment(&mut transcript, layouter, &[PolynomialLabel::Advice(i)]))
-            .collect::<Result<Vec<_>, Error>>()?;
+        // Read the batched advice commitment (one transcript entry for all advice
+        // columns).
+        let advice_commitments = if cs.num_advice_columns() == 0 {
+            Vec::new()
+        } else {
+            let labels: Vec<_> =
+                (0..cs.num_advice_columns()).map(PolynomialLabel::Advice).collect();
+            let shared = PCS::read_commitment(&mut transcript, layouter, &labels)?;
+            vec![shared; cs.num_advice_columns()]
+        };
 
         // Sample theta challenge for keeping lookup columns linearly independent
         let theta = transcript.squeeze_challenge(layouter)?;

--- a/proofs/CHANGELOG.md
+++ b/proofs/CHANGELOG.md
@@ -31,6 +31,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 * Migrate to Rust edition 2024; MSRV raised from 1.76 to 1.90. Both are now inherited from the workspace [#508](https://github.com/midnightntwrk/midnight-zk/pull/508)
+* Batch cross-argument commitments and add `write_commitment` method on the `PolynomialCommitmentScheme` trait [#493](https://github.com/midnightntwrk/midnight-zk/pull/493)
 * Extend `PolynomialCommitmentScheme` with `squeeze_evaluation_point` and `srs_monomial_blowup` and add a `k` argument to `multi_prepare`, as PCS-agnostic extension points for fflonk [#487](https://github.com/midnightntwrk/midnight-zk/pull/487)
 * `circuit_model` is now parameterized by a `PolynomialCommitmentScheme` (`circuit_model::<_, CS>`) instead of const `COMM`/`SCALAR` byte-size generics [#440](https://github.com/midnightntwrk/midnight-zk/pull/440)
 * Rename `PolynomialPointer` to `PolynomialReference` in `ProverQuery`; rename `poly` field to `poly_ref`; change `poly_inner_product` to accept `&[&Polynomial<F, Coeff>]` to avoid cloning [#411](https://github.com/midnightntwrk/midnight-zk/pull/411)

--- a/proofs/src/plonk/bench/prover.rs
+++ b/proofs/src/plonk/bench/prover.rs
@@ -5,9 +5,7 @@ use std::hash::Hash;
 use criterion::BenchmarkGroup;
 use ff::{FromUniformBytes, WithSmallOrderMulGroup};
 use rand_core::{CryptoRng, RngCore};
-use rayon::iter::{
-    IndexedParallelIterator, IntoParallelIterator, IntoParallelRefIterator, ParallelIterator,
-};
+use rayon::iter::{IndexedParallelIterator, IntoParallelIterator, ParallelIterator};
 
 use crate::{
     plonk::{
@@ -22,7 +20,7 @@ use crate::{
         traces::ProverTrace,
         trash,
     },
-    poly::{PolynomialLabel, commitment::PolynomialCommitmentScheme},
+    poly::commitment::PolynomialCommitmentScheme,
     transcript::{Hashable, Sampleable, Transcript},
     utils::arithmetic::eval_polynomial,
 };
@@ -226,10 +224,10 @@ where
         .map(|_| (0..blinding_factors).map(|_| F::random(&mut rng)).collect())
         .collect();
 
-    // Construct and commit to lookup product polynomials.
-    // `compute_logderivative` returns helper_polys_lagrange + aggregator
-    // commitment without transcript writes. Helper commitments must be taken
-    // and written here, and Lagrange polys converted to coefficient form.
+    // Construct and commit to lookup product polynomials. `compute_logderivative`
+    // returns helper_polys_lagrange + aggregator without transcript writes; the
+    // helper and aggregator commitments are batched and written per phase, and
+    // Lagrange polys are then converted to coefficient form.
     let lookups: Vec<logup::prover::Committed<F>> = {
         group.bench_function("Commit lookup products", |b| {
             b.iter_batched(
@@ -238,35 +236,10 @@ where
                     let computed: Vec<_> = lookups
                         .into_par_iter()
                         .zip(logup_blinds.into_par_iter())
-                        .map(|(lookup, blinds)| {
-                            lookup.compute_logderivative(pk, params, beta, blinds)
-                        })
+                        .map(|(lookup, blinds)| lookup.compute_logderivative(pk, beta, blinds))
                         .collect::<Result<Vec<_>, _>>()?;
-                    let all_helper_commitments: Vec<Vec<CS::Commitment>> = computed
-                        .par_iter()
-                        .map(|c| {
-                            c.helper_polys_lagrange
-                                .par_iter()
-                                .enumerate()
-                                .map(|(j, h)| {
-                                    let h_poly = domain.lagrange_from_vec(h.clone());
-                                    CS::commit(
-                                        params,
-                                        &h_poly,
-                                        PolynomialLabel::LogupHelper(c.argument_index, j),
-                                    )
-                                })
-                                .collect()
-                        })
-                        .collect();
-                    for (c, helper_commitments) in
-                        computed.iter().zip(all_helper_commitments.iter())
-                    {
-                        for h_commitment in helper_commitments {
-                            t.write(h_commitment)?;
-                        }
-                        t.write(&c.aggregator_commitment)?;
-                    }
+                    logup::prover::commit_helpers(params, pk, &computed, &mut t)?;
+                    logup::prover::commit_aggregators::<F, CS, T>(params, &computed, &mut t)?;
                     Ok(())
                 },
                 criterion::BatchSize::LargeInput,
@@ -275,31 +248,10 @@ where
         let computed: Vec<_> = lookups
             .into_par_iter()
             .zip(logup_blindings.into_par_iter())
-            .map(|(lookup, blinds)| lookup.compute_logderivative(pk, params, beta, blinds))
+            .map(|(lookup, blinds)| lookup.compute_logderivative(pk, beta, blinds))
             .collect::<Result<Vec<_>, _>>()?;
-        let all_helper_commitments: Vec<Vec<CS::Commitment>> = computed
-            .par_iter()
-            .map(|c| {
-                c.helper_polys_lagrange
-                    .par_iter()
-                    .enumerate()
-                    .map(|(j, h)| {
-                        let h_poly = domain.lagrange_from_vec(h.clone());
-                        CS::commit(
-                            params,
-                            &h_poly,
-                            PolynomialLabel::LogupHelper(c.argument_index, j),
-                        )
-                    })
-                    .collect()
-            })
-            .collect();
-        for (c, helper_commitments) in computed.iter().zip(all_helper_commitments.iter()) {
-            for h_commitment in helper_commitments {
-                transcript.write(h_commitment)?;
-            }
-            transcript.write(&c.aggregator_commitment)?;
-        }
+        logup::prover::commit_helpers(params, pk, &computed, transcript)?;
+        logup::prover::commit_aggregators::<F, CS, T>(params, &computed, transcript)?;
         computed
             .into_par_iter()
             .map(|c| {

--- a/proofs/src/plonk/bench/prover.rs
+++ b/proofs/src/plonk/bench/prover.rs
@@ -201,7 +201,7 @@ where
                         gamma,
                         perm_blinds,
                     );
-                    let _ = computed.write_and_convert(domain, &mut t)?;
+                    let _ = computed.write_and_convert::<_, CS>(domain, &mut t)?;
                     Ok(())
                 },
                 criterion::BatchSize::LargeInput,
@@ -218,7 +218,7 @@ where
             gamma,
             perm_blindings,
         );
-        computed.write_and_convert(domain, transcript)?
+        computed.write_and_convert::<_, CS>(domain, transcript)?
     };
 
     // Pre-generate logderivative blindings, one vector per lookup.

--- a/proofs/src/plonk/bench/prover.rs
+++ b/proofs/src/plonk/bench/prover.rs
@@ -18,7 +18,7 @@ use crate::{
             parse_advices, write_evals_to_transcript,
         },
         traces::ProverTrace,
-        trash,
+        trash::{self, prover::commit_trashcans},
     },
     poly::commitment::PolynomialCommitmentScheme,
     transcript::{Hashable, Sampleable, Transcript},
@@ -278,47 +278,30 @@ where
             b.iter_batched(
                 || (transcript.clone(), instance.clone(), advice.clone()),
                 |(mut t, inst, adv)| {
-                    let _: Result<Vec<_>, _> = pk
-                        .vk
-                        .cs
-                        .trashcans
-                        .iter()
-                        .enumerate()
-                        .map(|(i, trash)| {
-                            trash.commit::<CS, _>(
-                                i,
-                                params,
-                                domain,
-                                trash_challenge,
-                                &adv.advice_polys,
-                                &pk.fixed_values,
-                                &inst.instance_values,
-                                &mut t,
-                            )
-                        })
-                        .collect();
+                    let _ = commit_trashcans::<F, CS, T>(
+                        &pk.vk.cs.trashcans,
+                        params,
+                        domain,
+                        trash_challenge,
+                        &adv.advice_polys,
+                        &pk.fixed_values,
+                        &inst.instance_values,
+                        &mut t,
+                    );
                 },
                 criterion::BatchSize::LargeInput,
             )
         });
-        pk.vk
-            .cs
-            .trashcans
-            .iter()
-            .enumerate()
-            .map(|(i, trash)| {
-                trash.commit::<CS, _>(
-                    i,
-                    params,
-                    domain,
-                    trash_challenge,
-                    &advice.advice_polys,
-                    &pk.fixed_values,
-                    &instance.instance_values,
-                    transcript,
-                )
-            })
-            .collect::<Result<Vec<_>, _>>()?
+        commit_trashcans::<F, CS, T>(
+            &pk.vk.cs.trashcans,
+            params,
+            domain,
+            trash_challenge,
+            &advice.advice_polys,
+            &pk.fixed_values,
+            &instance.instance_values,
+            transcript,
+        )?
     };
 
     // Obtain challenge for keeping all separate gates linearly independent

--- a/proofs/src/plonk/bench/prover.rs
+++ b/proofs/src/plonk/bench/prover.rs
@@ -132,72 +132,34 @@ where
         .map(|_| (0..mult_blinding_count).map(|_| F::random(&mut rng)).collect())
         .collect();
 
-    // Commit to the multiplicities columns. Compute and transcript write are
-    // now separate API calls — measure them together to match the prior
-    // `commit_multiplicities` shape.
+    // Commit to the multiplicities columns.
     let lookups: Vec<logup::prover::ComputedMultiplicities<F>> = {
         group.bench_function("Commit lookup multiplicities", |b| {
             b.iter_batched(
                 || (transcript.clone(), mult_blindings.clone()),
-                |(mut t, mult_blinds)| -> Result<(), Error> {
-                    let logup_args: Vec<_> = pk
-                        .vk
-                        .cs
-                        .lookups
-                        .iter()
-                        .map(|l| l.chunk_by_degree(pk.vk.cs.degree()))
-                        .collect();
-                    let results: Vec<_> = logup_args
-                        .par_iter()
-                        .enumerate()
-                        .zip(mult_blinds.par_iter())
-                        .map(|((argument_index, logup), blinds)| {
-                            logup.compute_multiplicities_parallel(
-                                argument_index,
-                                pk,
-                                params,
-                                theta,
-                                &advice.advice_polys,
-                                &pk.fixed_values,
-                                &instance.instance_values,
-                                blinds,
-                            )
-                        })
-                        .collect::<Result<Vec<_>, Error>>()?;
-                    for (_, commitment) in &results {
-                        t.write(commitment)?;
-                    }
-                    Ok(())
+                |(mut t, mult_blinds)| {
+                    let _ = logup::prover::commit_multiplicities(
+                        params,
+                        pk,
+                        theta,
+                        &advice.advice_polys,
+                        &instance.instance_values,
+                        &mult_blinds,
+                        &mut t,
+                    );
                 },
                 criterion::BatchSize::LargeInput,
             )
         });
-        let logup_args: Vec<_> =
-            pk.vk.cs.lookups.iter().map(|l| l.chunk_by_degree(pk.vk.cs.degree())).collect();
-        let results: Vec<_> = logup_args
-            .par_iter()
-            .enumerate()
-            .zip(mult_blindings.par_iter())
-            .map(|((argument_index, logup), blinds)| {
-                logup.compute_multiplicities_parallel(
-                    argument_index,
-                    pk,
-                    params,
-                    theta,
-                    &advice.advice_polys,
-                    &pk.fixed_values,
-                    &instance.instance_values,
-                    blinds,
-                )
-            })
-            .collect::<Result<Vec<_>, Error>>()?;
-        results
-            .into_iter()
-            .map(|(c, commitment)| {
-                transcript.write(&commitment)?;
-                Ok::<_, Error>(c)
-            })
-            .collect::<Result<Vec<_>, _>>()?
+        logup::prover::commit_multiplicities(
+            params,
+            pk,
+            theta,
+            &advice.advice_polys,
+            &instance.instance_values,
+            &mult_blindings,
+            transcript,
+        )?
     };
 
     // Sample beta challenge

--- a/proofs/src/plonk/logup/prover.rs
+++ b/proofs/src/plonk/logup/prover.rs
@@ -20,7 +20,7 @@
 //!   iterates over columns
 //! - **Accumulator `Z(X)`**: Running sum of log-derivative differences
 
-use std::{hash::Hash, iter};
+use std::{collections::BTreeMap, hash::Hash, iter};
 
 use ff::{BatchInvert, FromUniformBytes, PrimeField, WithSmallOrderMulGroup};
 use rayon::iter::{IndexedParallelIterator, IntoParallelRefIterator, ParallelIterator};
@@ -404,14 +404,16 @@ where
     // equal-value runs, which collapse to zeros in the LagrangeDelta basis;
     // commit in that basis.
     if !computed.is_empty() {
-        let delta_polys =
-            computed.par_iter().map(|c| c.multiplicities.to_delta()).collect::<Vec<_>>();
-        let delta_refs = delta_polys.iter().collect::<Vec<_>>();
-        let labels: Vec<_> = computed
-            .iter()
-            .map(|c| PolynomialLabel::LogupMultiplicities(c.argument_index))
+        let delta_polys: BTreeMap<_, _> = computed
+            .par_iter()
+            .map(|c| {
+                (
+                    PolynomialLabel::LogupMultiplicities(c.argument_index),
+                    c.multiplicities.to_delta(),
+                )
+            })
             .collect();
-        let mult_com = CS::commit_many(params, &delta_refs, &labels);
+        let mult_com = CS::commit_many(params, &delta_polys);
         CS::write_commitment(transcript, &mult_com)?;
     }
 
@@ -435,12 +437,13 @@ where
     T: Transcript,
 {
     let domain = pk.vk.get_domain();
-    let mut helper_polys = Vec::new();
-    let mut labels = Vec::new();
+    let mut helper_polys = BTreeMap::new();
     for c in computed {
         for (chunk_idx, h) in c.helper_polys_lagrange.iter().enumerate() {
-            helper_polys.push(domain.lagrange_from_vec(h.clone()));
-            labels.push(PolynomialLabel::LogupHelper(c.argument_index, chunk_idx));
+            helper_polys.insert(
+                PolynomialLabel::LogupHelper(c.argument_index, chunk_idx),
+                domain.lagrange_from_vec(h.clone()),
+            );
         }
     }
 
@@ -448,8 +451,7 @@ where
         return Ok(());
     }
 
-    let helper_refs: Vec<_> = helper_polys.iter().collect();
-    let helpers_com = CS::commit_many(params, &helper_refs, &labels);
+    let helpers_com = CS::commit_many(params, &helper_polys);
     CS::write_commitment(transcript, &helpers_com)?;
 
     Ok(())
@@ -475,14 +477,16 @@ where
     // The aggregator is a running sum which is locally *linear* over the long
     // contiguous runs of multiplicities (highly contiguous, zero-padded
     // tables), so Δ² collapses those runs to zeros; commit in that basis.
-    let agg_delta_polys: Vec<_> =
-        computed.par_iter().map(|c| c.aggregator_poly.to_double_delta()).collect();
-    let agg_refs: Vec<_> = agg_delta_polys.iter().collect();
-    let agg_labels: Vec<_> = computed
-        .iter()
-        .map(|c| PolynomialLabel::LogupAggregator(c.argument_index))
+    let agg_delta_polys: BTreeMap<_, _> = computed
+        .par_iter()
+        .map(|c| {
+            (
+                PolynomialLabel::LogupAggregator(c.argument_index),
+                c.aggregator_poly.to_double_delta(),
+            )
+        })
         .collect();
-    let aggregators_com = CS::commit_many(params, &agg_refs, &agg_labels);
+    let aggregators_com = CS::commit_many(params, &agg_delta_polys);
     CS::write_commitment(transcript, &aggregators_com)?;
 
     Ok(())

--- a/proofs/src/plonk/logup/prover.rs
+++ b/proofs/src/plonk/logup/prover.rs
@@ -23,7 +23,7 @@
 use std::{hash::Hash, iter};
 
 use ff::{BatchInvert, FromUniformBytes, PrimeField, WithSmallOrderMulGroup};
-use rayon::iter::{IntoParallelRefIterator, ParallelIterator};
+use rayon::iter::{IndexedParallelIterator, IntoParallelRefIterator, ParallelIterator};
 
 use crate::{
     plonk::{
@@ -65,12 +65,11 @@ pub(crate) struct ComputedMultiplicities<F: PrimeField> {
 
 /// Intermediate result from logderivative computation, before transcript
 /// write and FFT conversion to coefficient form.
-pub(crate) struct ComputedLogderivative<F: PrimeField, C> {
+pub(crate) struct ComputedLogderivative<F: PrimeField> {
     pub(crate) argument_index: usize,
     pub(crate) multiplicities: Polynomial<F, LagrangeCoeff>,
     pub(crate) helper_polys_lagrange: Vec<Vec<F>>,
     pub(crate) aggregator_poly: Polynomial<F, LagrangeCoeff>,
-    pub(crate) aggregator_commitment: C,
 }
 
 /// Committed polynomials after evaluation at challenge point.
@@ -80,13 +79,9 @@ pub(crate) struct Evaluated<F: PrimeField> {
 }
 
 impl<F: WithSmallOrderMulGroup<3> + Hash> ChunkedArgument<F> {
-    /// Compresses input and table expressions, computes multiplicities, and
-    /// commits — but does NOT write to the transcript. The caller is
-    /// responsible for writing `commitment` in the correct order.
-    ///
-    /// Compresses input and table expressions, computes multiplicities, and
-    /// commits — but does NOT write to the transcript. The caller is
-    /// responsible for writing `commitment` in the correct order.
+    /// Compresses input and table expressions and computes the multiplicities
+    /// polynomial. **Does not commit** — the caller batches the commitments
+    /// across arguments and writes them to the transcript in order.
     ///
     /// `blinding_values` are pre-generated random field elements for the
     /// blinding rows, so this method does not need `&mut rng` and can be
@@ -96,13 +91,12 @@ impl<F: WithSmallOrderMulGroup<3> + Hash> ChunkedArgument<F> {
         &self,
         argument_index: usize,
         pk: &ProvingKey<F, CS>,
-        params: &CS::Parameters,
         theta: F,
         advice_values: &'a [Polynomial<F, LagrangeCoeff>],
         fixed_values: &'a [Polynomial<F, LagrangeCoeff>],
         instance_values: &'a [Polynomial<F, LagrangeCoeff>],
         blinding_values: &[F],
-    ) -> Result<(ComputedMultiplicities<F>, CS::Commitment), Error>
+    ) -> Result<ComputedMultiplicities<F>, Error>
     where
         F: WithSmallOrderMulGroup<3> + FromUniformBytes<64>,
     {
@@ -159,27 +153,13 @@ impl<F: WithSmallOrderMulGroup<3> + Hash> ChunkedArgument<F> {
 
         let multiplicities = pk.vk.domain.lagrange_from_vec(multiplicities);
 
-        // Multiplicities are produced by sorting/deduplicating into contiguous
-        // equal-value runs, which collapse to zeros in the LagrangeDelta basis.
-        // The Lagrange form is needed downstream for `eval_polynomial` and the
-        // openings, so we borrow into a transient delta buffer rather than
-        // transforming in place and prefix-summing back.
-        let commitment = CS::commit(
-            params,
-            &multiplicities.to_delta(),
-            PolynomialLabel::LogupMultiplicities(argument_index),
-        );
-
-        Ok((
-            ComputedMultiplicities {
-                argument_index,
-                selector,
-                multiplicities,
-                chunked_compressed_inputs,
-                compressed_table_expression,
-            },
-            commitment,
-        ))
+        Ok(ComputedMultiplicities {
+            argument_index,
+            selector,
+            multiplicities,
+            chunked_compressed_inputs,
+            compressed_table_expression,
+        })
     }
 }
 
@@ -194,10 +174,9 @@ impl<F: WithSmallOrderMulGroup<3> + Hash> ComputedMultiplicities<F> {
     pub(crate) fn compute_logderivative<CS: PolynomialCommitmentScheme<F>>(
         self,
         pk: &ProvingKey<F, CS>,
-        params: &CS::Parameters,
         beta: F,
         blinding_values: Vec<F>,
-    ) -> Result<ComputedLogderivative<F, CS::Commitment>, Error>
+    ) -> Result<ComputedLogderivative<F>, Error>
     where
         F: WithSmallOrderMulGroup<3> + FromUniformBytes<64>,
     {
@@ -290,23 +269,11 @@ impl<F: WithSmallOrderMulGroup<3> + Hash> ComputedMultiplicities<F> {
             assert_eq!(aggregator_poly[u], F::ZERO);
         }
 
-        // The aggregator is a running sum. When the per-row contribution
-        // (selector·h − m·(t+β)⁻¹) is locally constant (common, because
-        // multiplicities m are highly contiguous and tables are zero-padded)
-        // the aggregator is locally *linear*. Δ² converts them in zero runs,
-        // which will be filtered out.
-        let aggregator_commitment = CS::commit(
-            params,
-            &aggregator_poly.to_double_delta(),
-            PolynomialLabel::LogupAggregator(self.argument_index),
-        );
-
         Ok(ComputedLogderivative {
             argument_index: self.argument_index,
             multiplicities: self.multiplicities,
             helper_polys_lagrange,
             aggregator_poly,
-            aggregator_commitment,
         })
     }
 }
@@ -449,6 +416,76 @@ where
     }
 
     Ok(computed)
+}
+
+/// Writes one batched commitment to the helper polynomials of every logup
+/// argument, in flat `(argument, chunk)` order. Each helper carries the unique
+/// label `LogupHelper(arg, chunk)`, so per-argument queries route to the right
+/// sub-bundle. Mirrors the verifier's `read_helpers`.
+pub(in crate::plonk) fn commit_helpers<F, CS, T>(
+    params: &CS::Parameters,
+    pk: &ProvingKey<F, CS>,
+    computed: &[ComputedLogderivative<F>],
+    transcript: &mut T,
+) -> Result<(), Error>
+where
+    F: WithSmallOrderMulGroup<3>,
+    CS: PolynomialCommitmentScheme<F>,
+    CS::Commitment: Hashable<T::Hash>,
+    T: Transcript,
+{
+    let domain = pk.vk.get_domain();
+    let mut helper_polys = Vec::new();
+    let mut labels = Vec::new();
+    for c in computed {
+        for (chunk_idx, h) in c.helper_polys_lagrange.iter().enumerate() {
+            helper_polys.push(domain.lagrange_from_vec(h.clone()));
+            labels.push(PolynomialLabel::LogupHelper(c.argument_index, chunk_idx));
+        }
+    }
+
+    if helper_polys.is_empty() {
+        return Ok(());
+    }
+
+    let helper_refs: Vec<_> = helper_polys.iter().collect();
+    let helpers_com = CS::commit_many(params, &helper_refs, &labels);
+    CS::write_commitment(transcript, &helpers_com)?;
+
+    Ok(())
+}
+
+/// Writes one batched commitment to the aggregator polynomial of every logup
+/// argument. Mirrors the verifier's `read_aggregators`.
+pub(in crate::plonk) fn commit_aggregators<F, CS, T>(
+    params: &CS::Parameters,
+    computed: &[ComputedLogderivative<F>],
+    transcript: &mut T,
+) -> Result<(), Error>
+where
+    F: WithSmallOrderMulGroup<3>,
+    CS: PolynomialCommitmentScheme<F>,
+    CS::Commitment: Hashable<T::Hash>,
+    T: Transcript,
+{
+    if computed.is_empty() {
+        return Ok(());
+    }
+
+    // The aggregator is a running sum which is locally *linear* over the long
+    // contiguous runs of multiplicities (highly contiguous, zero-padded
+    // tables), so Δ² collapses those runs to zeros; commit in that basis.
+    let agg_delta_polys: Vec<_> =
+        computed.par_iter().map(|c| c.aggregator_poly.to_double_delta()).collect();
+    let agg_refs: Vec<_> = agg_delta_polys.iter().collect();
+    let agg_labels: Vec<_> = computed
+        .iter()
+        .map(|c| PolynomialLabel::LogupAggregator(c.argument_index))
+        .collect();
+    let aggregators_com = CS::commit_many(params, &agg_refs, &agg_labels);
+    CS::write_commitment(transcript, &aggregators_com)?;
+
+    Ok(())
 }
 
 /// Computes the multiplicity of each value in the polynomial.

--- a/proofs/src/plonk/logup/prover.rs
+++ b/proofs/src/plonk/logup/prover.rs
@@ -391,6 +391,66 @@ impl<F: WithSmallOrderMulGroup<3>> Evaluated<F> {
     }
 }
 
+/// Computes the multiplicities of every logup argument and writes one batched
+/// commitment to all of them. Mirrors the verifier's `read_multiplicities`.
+///
+/// `blindings` holds one pre-generated set of blinding values per argument, so
+/// this function needs no `&mut rng` and the per-argument computation runs in
+/// parallel.
+pub(in crate::plonk) fn commit_multiplicities<F, CS, T>(
+    params: &CS::Parameters,
+    pk: &ProvingKey<F, CS>,
+    theta: F,
+    advice_values: &[Polynomial<F, LagrangeCoeff>],
+    instance_values: &[Polynomial<F, LagrangeCoeff>],
+    blindings: &[Vec<F>],
+    transcript: &mut T,
+) -> Result<Vec<ComputedMultiplicities<F>>, Error>
+where
+    F: WithSmallOrderMulGroup<3> + Hash + FromUniformBytes<64>,
+    CS: PolynomialCommitmentScheme<F>,
+    CS::Commitment: Hashable<T::Hash>,
+    T: Transcript,
+{
+    let logup_args: Vec<_> =
+        pk.vk.cs.lookups.iter().map(|l| l.chunk_by_degree(pk.vk.cs.degree())).collect();
+
+    // Compute all lookups in parallel (no transcript access, no rng).
+    let computed: Vec<_> = logup_args
+        .par_iter()
+        .enumerate()
+        .zip(blindings.par_iter())
+        .map(|((argument_index, logup), blinds)| {
+            logup.compute_multiplicities_parallel(
+                argument_index,
+                pk,
+                theta,
+                advice_values,
+                &pk.fixed_values,
+                instance_values,
+                blinds,
+            )
+        })
+        .collect::<Result<Vec<_>, Error>>()?;
+
+    // Multiplicities are produced by sorting/deduplicating into contiguous
+    // equal-value runs, which collapse to zeros in the LagrangeDelta basis;
+    // commit in that basis.
+    if !computed.is_empty() {
+        let delta_polys =
+            computed.par_iter().map(|c| c.multiplicities.to_delta()).collect::<Vec<_>>();
+        let delta_refs = delta_polys.iter().collect::<Vec<_>>();
+        let labels: Vec<_> = computed
+            .iter()
+            .map(|c| PolynomialLabel::LogupMultiplicities(c.argument_index))
+            .collect();
+        let mult_com = CS::commit_many(params, &delta_refs, &labels);
+        CS::write_commitment(transcript, &mult_com)?;
+    }
+
+    Ok(computed)
+}
+
 /// Computes the multiplicity of each value in the polynomial.
 ///
 /// Returns a vector where `result[i]` is the number of times `table[i]` appears

--- a/proofs/src/plonk/logup/verifier.rs
+++ b/proofs/src/plonk/logup/verifier.rs
@@ -49,6 +49,21 @@ pub struct Evaluated<F: PrimeField, CS: PolynomialCommitmentScheme<F>> {
     pub(crate) evaluated: logup::Evaluated<F>,
 }
 
+/// Lightweight per-arg view passed into [`read_helpers`] — just the argument
+/// index and chunk count, both reconstructible from the verifying key.
+pub(in crate::plonk) struct ChunkedArgRef {
+    pub(in crate::plonk) argument_index: usize,
+    pub(in crate::plonk) num_chunks: usize,
+}
+
+/// Partial state between the batched helper read and the batched aggregator
+/// read.
+pub(in crate::plonk) struct HelpersOnly<F: PrimeField, CS: PolynomialCommitmentScheme<F>> {
+    argument_index: usize,
+    multiplicities: CS::Commitment,
+    helper_polys: Vec<CS::Commitment>,
+}
+
 /// Reads the batched multiplicities commitment for all logup arguments in one
 /// transcript entry (one point per argument) and hands each argument a clone of
 /// the shared commitment. The shared object carries the full label list (one
@@ -76,8 +91,82 @@ where
         })
         .collect())
 }
-        })
+
+/// Reads the batched helper commitments for all logup arguments in one
+/// transcript entry (one point per `(arg, chunk)`, in flat `(arg, chunk)`
+/// order). Each helper carries the unique label `LogupHelper(arg, chunk_idx)`;
+/// each per-arg view holds a clone of the shared commitment for each of its
+/// chunks and routes per-chunk queries via that label.
+pub(in crate::plonk) fn read_helpers<F, CS, T>(
+    args_with_multiplicities: Vec<(ChunkedArgRef, CommittedMultiplicities<F, CS>)>,
+    transcript: &mut T,
+) -> Result<Vec<HelpersOnly<F, CS>>, Error>
+where
+    F: WithSmallOrderMulGroup<3>,
+    CS: PolynomialCommitmentScheme<F>,
+    CS::Commitment: Hashable<T::Hash>,
+    T: Transcript,
+{
+    // Build the full label set in (arg, chunk) order, matching the prover's
+    // flat iteration.
+    let mut labels: Vec<PolynomialLabel> = Vec::new();
+    for (arg, _) in &args_with_multiplicities {
+        for chunk_idx in 0..arg.num_chunks {
+            labels.push(PolynomialLabel::LogupHelper(arg.argument_index, chunk_idx));
+        }
     }
+    if labels.is_empty() {
+        // No helpers across any arg — the prover skipped the write.
+        return Ok(args_with_multiplicities
+            .into_iter()
+            .map(|(arg, m)| HelpersOnly {
+                argument_index: arg.argument_index,
+                multiplicities: m.multiplicities,
+                helper_polys: Vec::new(),
+            })
+            .collect());
+    }
+    let shared = CS::read_commitment(transcript, &labels)?;
+    Ok(args_with_multiplicities
+        .into_iter()
+        .map(|(arg, m)| HelpersOnly {
+            argument_index: arg.argument_index,
+            multiplicities: m.multiplicities,
+            helper_polys: vec![shared.clone(); arg.num_chunks],
+        })
+        .collect())
+}
+
+/// Reads the batched aggregator commitment for all logup arguments (one point
+/// per argument) and assembles one [`Committed`] per arg, each holding a clone
+/// of the shared aggregator commitment.
+pub(in crate::plonk) fn read_aggregators<F, CS, T>(
+    helpers: Vec<HelpersOnly<F, CS>>,
+    transcript: &mut T,
+) -> Result<Vec<Committed<F, CS>>, Error>
+where
+    F: WithSmallOrderMulGroup<3>,
+    CS: PolynomialCommitmentScheme<F>,
+    CS::Commitment: Hashable<T::Hash>,
+    T: Transcript,
+{
+    if helpers.is_empty() {
+        return Ok(Vec::new());
+    }
+    let labels: Vec<_> = helpers
+        .iter()
+        .map(|h| PolynomialLabel::LogupAggregator(h.argument_index))
+        .collect();
+    let shared_agg = CS::read_commitment(transcript, &labels)?;
+    Ok(helpers
+        .into_iter()
+        .map(|h| Committed {
+            argument_index: h.argument_index,
+            multiplicities: h.multiplicities,
+            helper_polys: h.helper_polys,
+            accumulator: shared_agg.clone(),
+        })
+        .collect())
 }
 
 impl<F: PrimeField, CS: PolynomialCommitmentScheme<F>> Committed<F, CS> {

--- a/proofs/src/plonk/logup/verifier.rs
+++ b/proofs/src/plonk/logup/verifier.rs
@@ -65,10 +65,11 @@ pub(in crate::plonk) struct HelpersOnly<F: PrimeField, CS: PolynomialCommitmentS
 }
 
 /// Reads the batched multiplicities commitment for all logup arguments in one
-/// transcript entry (one point per argument) and hands each argument a clone of
-/// the shared commitment. The shared object carries the full label list (one
-/// `LogupMultiplicities(arg)` per arg); per-arg queries route to the correct
-/// sub-bundle via the query label. Mirrors the prover's batched `commit_many`.
+/// transcript entry (one commitment per argument) and hands each argument a
+/// clone of the shared commitment. The shared object carries the full label
+/// list (one `LogupMultiplicities(arg)` per arg); per-arg queries route to the
+/// correct sub-bundle via the query label. Mirrors the prover's batched
+/// `commit_many`.
 pub(in crate::plonk) fn read_multiplicities<F, CS, T>(
     args: &[ChunkedArgument<F>],
     transcript: &mut T,
@@ -137,9 +138,9 @@ where
         .collect())
 }
 
-/// Reads the batched aggregator commitment for all logup arguments (one point
-/// per argument) and assembles one [`Committed`] per arg, each holding a clone
-/// of the shared aggregator commitment.
+/// Reads the batched aggregator commitment for all logup arguments (one
+/// commitment per argument) and assembles one [`Committed`] per arg, each
+/// holding a clone of the shared aggregator commitment.
 pub(in crate::plonk) fn read_aggregators<F, CS, T>(
     helpers: Vec<HelpersOnly<F, CS>>,
     transcript: &mut T,

--- a/proofs/src/plonk/logup/verifier.rs
+++ b/proofs/src/plonk/logup/verifier.rs
@@ -49,56 +49,33 @@ pub struct Evaluated<F: PrimeField, CS: PolynomialCommitmentScheme<F>> {
     pub(crate) evaluated: logup::Evaluated<F>,
 }
 
-impl<F: WithSmallOrderMulGroup<3>> ChunkedArgument<F> {
-    /// Reads the multiplicities commitment from the transcript.
-    pub(in crate::plonk) fn read_multiplicities<T: Transcript, CS: PolynomialCommitmentScheme<F>>(
-        &self,
-        argument_index: usize,
-        transcript: &mut T,
-    ) -> Result<CommittedMultiplicities<F, CS>, Error>
-    where
-        CS::Commitment: Hashable<T::Hash>,
-    {
-        let multiplicities = CS::read_commitment(
-            transcript,
-            &[PolynomialLabel::LogupMultiplicities(argument_index)],
-        )?;
-        Ok(CommittedMultiplicities { multiplicities })
-    }
-}
-
-impl<F: WithSmallOrderMulGroup<3>, CS: PolynomialCommitmentScheme<F>>
-    CommittedMultiplicities<F, CS>
+/// Reads the batched multiplicities commitment for all logup arguments in one
+/// transcript entry (one point per argument) and hands each argument a clone of
+/// the shared commitment. The shared object carries the full label list (one
+/// `LogupMultiplicities(arg)` per arg); per-arg queries route to the correct
+/// sub-bundle via the query label. Mirrors the prover's batched `commit_many`.
+pub(in crate::plonk) fn read_multiplicities<F, CS, T>(
+    args: &[ChunkedArgument<F>],
+    transcript: &mut T,
+) -> Result<Vec<CommittedMultiplicities<F, CS>>, Error>
+where
+    F: WithSmallOrderMulGroup<3>,
+    CS: PolynomialCommitmentScheme<F>,
+    CS::Commitment: Hashable<T::Hash>,
+    T: Transcript,
 {
-    /// Reads `nb_chunks` helper commitments and one accumulator commitment
-    /// from the transcript.
-    pub(in crate::plonk) fn read_commitment<T: Transcript>(
-        self,
-        argument_index: usize,
-        nb_chunks: usize,
-        transcript: &mut T,
-    ) -> Result<Committed<F, CS>, Error>
-    where
-        CS::Commitment: Hashable<T::Hash>,
-    {
-        let helper_polys = (0..nb_chunks)
-            .map(|j| {
-                CS::read_commitment(
-                    transcript,
-                    &[PolynomialLabel::LogupHelper(argument_index, j)],
-                )
-            })
-            .collect::<Result<Vec<_>, _>>()?;
-        let accumulator = CS::read_commitment(
-            transcript,
-            &[PolynomialLabel::LogupAggregator(argument_index)],
-        )?;
-
-        Ok(Committed {
-            argument_index,
-            multiplicities: self.multiplicities,
-            helper_polys,
-            accumulator,
+    if args.is_empty() {
+        return Ok(Vec::new());
+    }
+    let labels: Vec<_> = (0..args.len()).map(PolynomialLabel::LogupMultiplicities).collect();
+    let shared = CS::read_commitment(transcript, &labels)?;
+    Ok(args
+        .iter()
+        .map(|_| CommittedMultiplicities {
+            multiplicities: shared.clone(),
+        })
+        .collect())
+}
         })
     }
 }

--- a/proofs/src/plonk/permutation/prover.rs
+++ b/proofs/src/plonk/permutation/prover.rs
@@ -1,4 +1,4 @@
-use std::iter;
+use std::{collections::BTreeMap, iter};
 
 use ff::{PrimeField, WithSmallOrderMulGroup};
 use group::ff::BatchInvert;
@@ -241,11 +241,12 @@ impl Argument {
         // borrow into a transient delta buffer rather than transforming in place
         // and prefix-summing back. All accumulators are batched into one
         // `commit_many` call.
-        let delta_polys: Vec<_> = z_polys.par_iter().map(|z| z.to_delta()).collect();
-        let delta_refs: Vec<_> = delta_polys.iter().collect();
-        let labels: Vec<_> =
-            (0..z_polys.len()).map(PolynomialLabel::PermutationAccumulator).collect();
-        let commitment = CS::commit_many(params, &delta_refs, &labels);
+        let delta_polys: BTreeMap<_, _> = z_polys
+            .par_iter()
+            .enumerate()
+            .map(|(i, z)| (PolynomialLabel::PermutationAccumulator(i), z.to_delta()))
+            .collect();
+        let commitment = CS::commit_many(params, &delta_polys);
 
         Computed {
             commitment,

--- a/proofs/src/plonk/permutation/prover.rs
+++ b/proofs/src/plonk/permutation/prover.rs
@@ -33,27 +33,28 @@ pub(crate) struct Committed<F: PrimeField> {
 }
 
 /// Intermediate result from the computation stage of the permutation argument.
-/// Holds commitments and Lagrange-form z polynomials, ready to be written to
-/// the transcript and converted to coefficient form.
+/// Holds the batched commitment to all z polynomials and their Lagrange-form
+/// values, ready to be written to the transcript and converted to coefficient
+/// form.
 pub(crate) struct Computed<F: PrimeField, C> {
-    pub(crate) commitments: Vec<C>,
+    pub(crate) commitment: C,
     z_polys: Vec<Polynomial<F, LagrangeCoeff>>,
 }
 
 impl<F: WithSmallOrderMulGroup<3>, C> Computed<F, C> {
-    /// Write commitments to the transcript in order, then convert z polynomials
-    /// to coefficient form.
-    pub(crate) fn write_and_convert<T: Transcript>(
+    /// Write the batched commitment to the transcript, then convert z
+    /// polynomials to coefficient form.
+    pub(crate) fn write_and_convert<T, CS>(
         self,
         domain: &EvaluationDomain<F>,
         transcript: &mut T,
     ) -> Result<Committed<F>, Error>
     where
+        T: Transcript,
+        CS: PolynomialCommitmentScheme<F, Commitment = C>,
         C: Hashable<T::Hash>,
     {
-        for commitment in &self.commitments {
-            transcript.write(commitment)?;
-        }
+        CS::write_commitment(transcript, &self.commitment)?;
 
         let sets: Vec<_> = self
             .z_polys
@@ -216,13 +217,11 @@ impl Argument {
             corrections.push(prev);
         }
 
-        // Step C: Apply corrections and commit.
-        //
-        let committed: Vec<(CS::Commitment, Polynomial<F, LagrangeCoeff>)> = z_and_uncorrected
+        // Step C: Apply corrections.
+        let z_polys: Vec<Polynomial<F, LagrangeCoeff>> = z_and_uncorrected
             .into_par_iter()
             .zip(corrections.par_iter())
-            .enumerate()
-            .map(|(i, ((mut z, _), &correction))| {
+            .map(|((mut z, _), &correction)| {
                 // Multiply every z value by the correction factor.
                 if correction != F::ONE {
                     parallelize(&mut z, |z, _| {
@@ -232,23 +231,24 @@ impl Argument {
                     });
                 }
 
-                // perm_z has long contiguous-constant runs (the identity-permutation
-                // tail and interior gaps), so we commit in the LagrangeDelta basis.
-                // The Lagrange form is needed downstream for the linearization step,
-                // so we borrow into a transient delta buffer rather than transforming
-                // in place and prefix-summing back.
-                let commitment = CS::commit(
-                    params,
-                    &z.to_delta(),
-                    PolynomialLabel::PermutationAccumulator(i),
-                );
-                (commitment, z)
+                z
             })
             .collect();
 
-        let (commitments, z_polys) = committed.into_iter().unzip();
+        // perm_z has long contiguous-constant runs (the identity-permutation
+        // tail and interior gaps), so we commit in the LagrangeDelta basis. The
+        // Lagrange form is needed downstream for the linearization step, so we
+        // borrow into a transient delta buffer rather than transforming in place
+        // and prefix-summing back. All accumulators are batched into one
+        // `commit_many` call.
+        let delta_polys: Vec<_> = z_polys.par_iter().map(|z| z.to_delta()).collect();
+        let delta_refs: Vec<_> = delta_polys.iter().collect();
+        let labels: Vec<_> =
+            (0..z_polys.len()).map(PolynomialLabel::PermutationAccumulator).collect();
+        let commitment = CS::commit_many(params, &delta_refs, &labels);
+
         Computed {
-            commitments,
+            commitment,
             z_polys,
         }
     }

--- a/proofs/src/plonk/permutation/verifier.rs
+++ b/proofs/src/plonk/permutation/verifier.rs
@@ -35,10 +35,18 @@ impl Argument {
         CS::Commitment: Hashable<T::Hash>,
     {
         let chunk_len = vk.cs_degree - 2;
+        let num_chunks = self.columns.len().div_ceil(chunk_len);
 
-        let permutation_product_commitments = (0..self.columns.len().div_ceil(chunk_len))
-            .map(|i| CS::read_commitment(transcript, &[PolynomialLabel::PermutationAccumulator(i)]))
-            .collect::<Result<Vec<_>, _>>()?;
+        // One batched read for all permutation-accumulator sets; each set's
+        // query routes to its own sub-bundle via `PermutationAccumulator(i)`.
+        let permutation_product_commitments = if num_chunks == 0 {
+            Vec::new()
+        } else {
+            let labels: Vec<_> =
+                (0..num_chunks).map(PolynomialLabel::PermutationAccumulator).collect();
+            let shared = CS::read_commitment(transcript, &labels)?;
+            vec![shared; num_chunks]
+        };
 
         Ok(Committed {
             permutation_product_commitments,

--- a/proofs/src/plonk/prover.rs
+++ b/proofs/src/plonk/prover.rs
@@ -581,14 +581,13 @@ where
         }
     }
 
-    let advice_commitments: Vec<_> = advice_values
-        .par_iter()
-        .enumerate()
-        .map(|(i, poly)| CS::commit(params, poly, PolynomialLabel::Advice(i)))
-        .collect();
-
-    for commitment in &advice_commitments {
-        transcript.write(commitment)?;
+    // Commit to all advice columns in a single batched call, so that schemes
+    // able to fold same-phase polynomials (e.g. fflonk) see the whole phase.
+    if !advice_values.is_empty() {
+        let advice_refs: Vec<_> = advice_values.iter().collect();
+        let labels: Vec<_> = (0..advice_values.len()).map(PolynomialLabel::Advice).collect();
+        let advice_com = CS::commit_many(params, &advice_refs, &labels);
+        CS::write_commitment(transcript, &advice_com)?;
     }
 
     advice.advice_polys = advice_values;

--- a/proofs/src/plonk/prover.rs
+++ b/proofs/src/plonk/prover.rs
@@ -195,7 +195,7 @@ where
     );
 
     // Write permutation commitments first.
-    let permutations = perm_computed.write_and_convert(domain, transcript)?;
+    let permutations = perm_computed.write_and_convert::<T, CS>(domain, transcript)?;
 
     // Then write logup commitments and convert to coefficient form.
     let (computed, all_helper_commitments) = logup_computed?;

--- a/proofs/src/plonk/prover.rs
+++ b/proofs/src/plonk/prover.rs
@@ -1,5 +1,5 @@
 use std::{
-    collections::HashSet,
+    collections::{BTreeMap, HashSet},
     hash::Hash,
     iter::{self},
     ops::RangeTo,
@@ -575,9 +575,12 @@ where
     // Commit to all advice columns in a single batched call, so that schemes
     // able to fold same-phase polynomials (e.g. fflonk) see the whole phase.
     if !advice_values.is_empty() {
-        let advice_refs: Vec<_> = advice_values.iter().collect();
-        let labels: Vec<_> = (0..advice_values.len()).map(PolynomialLabel::Advice).collect();
-        let advice_com = CS::commit_many(params, &advice_refs, &labels);
+        let advice_polys: BTreeMap<_, _> = advice_values
+            .iter()
+            .enumerate()
+            .map(|(i, p)| (PolynomialLabel::Advice(i), p))
+            .collect();
+        let advice_com = CS::commit_many(params, &advice_polys);
         CS::write_commitment(transcript, &advice_com)?;
     }
 

--- a/proofs/src/plonk/prover.rs
+++ b/proofs/src/plonk/prover.rs
@@ -19,13 +19,22 @@ use super::{
         Advice, Any, Assignment, Circuit, Column, ConstraintSystem, Fixed, FloorPlanner, Instance,
         Selector,
     },
-    logup, permutation,
+    permutation,
 };
 use crate::{
     circuit::Value,
     plonk::{
-        linearization::prover::compute_linearization_poly, partially_evaluate_identities,
-        traces::ProverTrace, trash,
+        linearization::prover::compute_linearization_poly,
+        logup::{
+            self,
+            prover::{
+                Committed, ComputedLogderivative, ComputedMultiplicities, commit_aggregators,
+                commit_helpers, commit_multiplicities,
+            },
+        },
+        partially_evaluate_identities,
+        traces::ProverTrace,
+        trash,
     },
     poly::{
         Coeff, EvaluationDomain, ExtendedLagrangeCoeff, LagrangeCoeff, Polynomial, PolynomialLabel,
@@ -147,10 +156,8 @@ where
     let perm_blindings: Vec<Vec<F>> = sample_blindings(num_perm_sets, blinding_factors);
     let logup_blindings: Vec<Vec<F>> = sample_blindings(lookups.len(), blinding_factors);
 
-    // Overlap permutation and logup computation.
-    // Both only need β (and γ for permutation). Neither touches the transcript.
-    // Transcript writes preserve the original ordering:
-    // permutation commitments first, then logup commitments.
+    // Overlap permutation and logup computation. Neither touches the transcript.
+    // Transcript-write order: permutation, then all helpers, then all aggregators.
     let (perm_computed, logup_computed) = rayon::join(
         || {
             pk.vk.cs.permutation.compute::<F, CS>(
@@ -165,47 +172,25 @@ where
                 perm_blindings,
             )
         },
-        || -> Result<_, Error> {
-            let computed: Vec<_> = lookups
+        || -> Result<Vec<ComputedLogderivative<F>>, Error> {
+            lookups
                 .into_par_iter()
                 .zip(logup_blindings.into_par_iter())
-                .map(|(lookup, blindings)| {
-                    lookup.compute_logderivative(pk, params, beta, blindings)
-                })
-                .collect::<Result<Vec<_>, _>>()?;
-            let all_helper_commitments: Vec<Vec<CS::Commitment>> = computed
-                .par_iter()
-                .map(|c| {
-                    c.helper_polys_lagrange
-                        .par_iter()
-                        .enumerate()
-                        .map(|(j, h)| {
-                            let h_poly = domain.lagrange_from_vec(h.clone());
-                            CS::commit(
-                                params,
-                                &h_poly,
-                                PolynomialLabel::LogupHelper(c.argument_index, j),
-                            )
-                        })
-                        .collect()
-                })
-                .collect();
-            Ok((computed, all_helper_commitments))
+                .map(|(lookup, blindings)| lookup.compute_logderivative(pk, beta, blindings))
+                .collect()
         },
     );
 
-    // Write permutation commitments first.
+    // Write the batched permutation commitment first.
     let permutations = perm_computed.write_and_convert::<T, CS>(domain, transcript)?;
 
-    // Then write logup commitments and convert to coefficient form.
-    let (computed, all_helper_commitments) = logup_computed?;
-    for (c, helper_commitments) in computed.iter().zip(all_helper_commitments.iter()) {
-        for h_commitment in helper_commitments {
-            transcript.write(h_commitment)?;
-        }
-        transcript.write(&c.aggregator_commitment)?;
-    }
-    let lookups: Vec<logup::prover::Committed<F>> = computed
+    let computed = logup_computed?;
+
+    commit_helpers(params, pk, &computed, transcript)?;
+    commit_aggregators::<F, CS, T>(params, &computed, transcript)?;
+
+    // Convert logup polynomials to coefficient form for the opening phase.
+    let lookups: Vec<Committed<F>> = computed
         .into_par_iter()
         .map(|c| {
             let helper_polys = c
@@ -213,7 +198,7 @@ where
                 .into_iter()
                 .map(|h| domain.lagrange_to_coeff(domain.lagrange_from_vec(h)))
                 .collect();
-            logup::prover::Committed {
+            Committed {
                 argument_index: c.argument_index,
                 multiplicities: domain.lagrange_to_coeff(c.multiplicities),
                 helper_polys,

--- a/proofs/src/plonk/prover.rs
+++ b/proofs/src/plonk/prover.rs
@@ -123,38 +123,17 @@ where
     let mult_blinding_count = pk.vk.cs.blinding_factors() + 1;
     let mult_blindings: Vec<Vec<F>> = sample_blindings(num_lookups, mult_blinding_count);
 
-    // Commit to the multiplicities columns.
-    // Computation in parallel, then sequential transcript writes.
-    let lookups: Vec<logup::prover::ComputedMultiplicities<F>> = {
-        let logup_args: Vec<_> =
-            pk.vk.cs.lookups.iter().map(|l| l.chunk_by_degree(pk.vk.cs.degree())).collect();
-        // Compute all lookups in parallel (no transcript access, no rng).
-        let results: Vec<_> = logup_args
-            .par_iter()
-            .enumerate()
-            .zip(mult_blindings.par_iter())
-            .map(|((argument_index, logup), blinds)| {
-                logup.compute_multiplicities_parallel(
-                    argument_index,
-                    pk,
-                    params,
-                    theta,
-                    &advice.advice_polys,
-                    &pk.fixed_values,
-                    &instance.instance_values,
-                    blinds,
-                )
-            })
-            .collect::<Result<Vec<_>, Error>>()?;
-        // Sequential transcript writes to preserve Fiat-Shamir ordering.
-        results
-            .into_iter()
-            .map(|(computed, commitment)| {
-                transcript.write(&commitment)?;
-                Ok(computed)
-            })
-            .collect::<Result<Vec<_>, Error>>()?
-    };
+    // Commit to the multiplicities columns. All logup arguments'
+    // multiplicities are batched into one `CS::commit_many` call.
+    let lookups: Vec<ComputedMultiplicities<F>> = commit_multiplicities(
+        params,
+        pk,
+        theta,
+        &advice.advice_polys,
+        &instance.instance_values,
+        &mult_blindings,
+        transcript,
+    )?;
 
     // Sample beta challenge
     let beta: F = transcript.squeeze_challenge();

--- a/proofs/src/plonk/prover.rs
+++ b/proofs/src/plonk/prover.rs
@@ -34,7 +34,7 @@ use crate::{
         },
         partially_evaluate_identities,
         traces::ProverTrace,
-        trash,
+        trash::{self, prover::commit_trashcans},
     },
     poly::{
         Coeff, EvaluationDomain, ExtendedLagrangeCoeff, LagrangeCoeff, Polynomial, PolynomialLabel,
@@ -210,25 +210,16 @@ where
     // Trash argument
     let trash_challenge: F = transcript.squeeze_challenge();
 
-    let trashcans: Vec<trash::prover::Committed<F>> = pk
-        .vk
-        .cs
-        .trashcans
-        .iter()
-        .enumerate()
-        .map(|(i, trash)| {
-            trash.commit::<CS, _>(
-                i,
-                params,
-                domain,
-                trash_challenge,
-                &advice.advice_polys,
-                &pk.fixed_values,
-                &instance.instance_values,
-                transcript,
-            )
-        })
-        .collect::<Result<Vec<_>, _>>()?;
+    let trashcans = commit_trashcans::<F, CS, T>(
+        &pk.vk.cs.trashcans,
+        params,
+        domain,
+        trash_challenge,
+        &advice.advice_polys,
+        &pk.fixed_values,
+        &instance.instance_values,
+        transcript,
+    )?;
 
     // Obtain challenge for keeping all separate gates linearly independent
     let y: F = transcript.squeeze_challenge();

--- a/proofs/src/plonk/trash/prover.rs
+++ b/proofs/src/plonk/trash/prover.rs
@@ -1,4 +1,7 @@
 use ff::{FromUniformBytes, PrimeField, WithSmallOrderMulGroup};
+use rayon::iter::{
+    IndexedParallelIterator, IntoParallelIterator, IntoParallelRefIterator, ParallelIterator,
+};
 
 use super::{super::Error, Argument};
 use crate::{
@@ -23,57 +26,65 @@ pub(crate) struct Evaluated<F: PrimeField> {
     pub(crate) evaluated: trash::Evaluated<F>,
 }
 
-impl<F: WithSmallOrderMulGroup<3> + Ord> Argument<F> {
-    #[allow(clippy::too_many_arguments)]
-    pub(crate) fn commit<'a, 'params: 'a, CS, T>(
-        &self,
-        argument_index: usize,
-        params: &'params CS::Parameters,
-        domain: &EvaluationDomain<F>,
-        trash_challenge: F,
-        advice_values: &'a [Polynomial<F, LagrangeCoeff>],
-        fixed_values: &'a [Polynomial<F, LagrangeCoeff>],
-        instance_values: &'a [Polynomial<F, LagrangeCoeff>],
-        transcript: &mut T,
-    ) -> Result<Committed<F>, Error>
-    where
-        F: FromUniformBytes<64>,
-        CS: PolynomialCommitmentScheme<F>,
-        CS::Commitment: Hashable<T::Hash>,
-        T: Transcript,
-    {
-        let compressed_expression = self
-            .constraint_expressions
-            .iter()
-            .map(|expression| {
-                domain.lagrange_from_vec(evaluate(
-                    expression,
-                    domain.n as usize,
-                    0,
-                    fixed_values,
-                    advice_values,
-                    instance_values,
-                ))
-            })
-            .fold(domain.empty_lagrange(), |acc, expression| {
-                acc * trash_challenge + &expression
-            });
-
-        let trash_commitment = CS::commit(
-            params,
-            &compressed_expression,
-            PolynomialLabel::Trash(argument_index),
-        );
-        let trash_poly = domain.lagrange_to_coeff(compressed_expression);
-
-        // Hash permuted input commitment
-        transcript.write(&trash_commitment)?;
-
-        Ok(Committed {
-            argument_index,
-            trash_poly,
-        })
+/// Compresses the constraints of every trash argument into one polynomial each,
+/// commits to all of them in a single batched call, and writes the result to
+/// the transcript. Mirrors the verifier's `read_trashcans`.
+#[allow(clippy::too_many_arguments)]
+pub(in crate::plonk) fn commit_trashcans<F, CS, T>(
+    arguments: &[Argument<F>],
+    params: &CS::Parameters,
+    domain: &EvaluationDomain<F>,
+    trash_challenge: F,
+    advice_values: &[Polynomial<F, LagrangeCoeff>],
+    fixed_values: &[Polynomial<F, LagrangeCoeff>],
+    instance_values: &[Polynomial<F, LagrangeCoeff>],
+    transcript: &mut T,
+) -> Result<Vec<Committed<F>>, Error>
+where
+    F: WithSmallOrderMulGroup<3> + Ord + FromUniformBytes<64>,
+    CS: PolynomialCommitmentScheme<F>,
+    CS::Commitment: Hashable<T::Hash>,
+    T: Transcript,
+{
+    if arguments.is_empty() {
+        return Ok(Vec::new());
     }
+
+    let compressed_expressions: Vec<Polynomial<F, LagrangeCoeff>> = arguments
+        .par_iter()
+        .map(|argument| {
+            argument
+                .constraint_expressions
+                .iter()
+                .map(|expression| {
+                    domain.lagrange_from_vec(evaluate(
+                        expression,
+                        domain.n as usize,
+                        0,
+                        fixed_values,
+                        advice_values,
+                        instance_values,
+                    ))
+                })
+                .fold(domain.empty_lagrange(), |acc, expression| {
+                    acc * trash_challenge + &expression
+                })
+        })
+        .collect();
+
+    let refs: Vec<_> = compressed_expressions.iter().collect();
+    let labels: Vec<_> = (0..arguments.len()).map(PolynomialLabel::Trash).collect();
+    let trash_com = CS::commit_many(params, &refs, &labels);
+    CS::write_commitment(transcript, &trash_com)?;
+
+    Ok(compressed_expressions
+        .into_par_iter()
+        .enumerate()
+        .map(|(argument_index, compressed_expression)| Committed {
+            argument_index,
+            trash_poly: domain.lagrange_to_coeff(compressed_expression),
+        })
+        .collect())
 }
 
 impl<F: WithSmallOrderMulGroup<3>> Committed<F> {

--- a/proofs/src/plonk/trash/prover.rs
+++ b/proofs/src/plonk/trash/prover.rs
@@ -1,3 +1,5 @@
+use std::collections::BTreeMap;
+
 use ff::{FromUniformBytes, PrimeField, WithSmallOrderMulGroup};
 use rayon::iter::{
     IndexedParallelIterator, IntoParallelIterator, IntoParallelRefIterator, ParallelIterator,
@@ -72,9 +74,12 @@ where
         })
         .collect();
 
-    let refs: Vec<_> = compressed_expressions.iter().collect();
-    let labels: Vec<_> = (0..arguments.len()).map(PolynomialLabel::Trash).collect();
-    let trash_com = CS::commit_many(params, &refs, &labels);
+    let trash_polys: BTreeMap<_, _> = compressed_expressions
+        .iter()
+        .enumerate()
+        .map(|(i, p)| (PolynomialLabel::Trash(i), p))
+        .collect();
+    let trash_com = CS::commit_many(params, &trash_polys);
     CS::write_commitment(transcript, &trash_com)?;
 
     Ok(compressed_expressions

--- a/proofs/src/plonk/trash/verifier.rs
+++ b/proofs/src/plonk/trash/verifier.rs
@@ -1,6 +1,5 @@
 use ff::{PrimeField, WithSmallOrderMulGroup};
 
-use super::Argument;
 use crate::{
     plonk::{Error, trash},
     poly::{PolynomialLabel, VerifierQuery, commitment::PolynomialCommitmentScheme},
@@ -19,22 +18,31 @@ pub struct Evaluated<F: PrimeField, CS: PolynomialCommitmentScheme<F>> {
     pub(crate) evaluated: trash::Evaluated<F>,
 }
 
-impl<F: PrimeField> Argument<F> {
-    pub(crate) fn read_committed<CS: PolynomialCommitmentScheme<F>, T: Transcript>(
-        &self,
-        argument_index: usize,
-        transcript: &mut T,
-    ) -> Result<Committed<F, CS>, Error>
-    where
-        CS::Commitment: Hashable<T::Hash>,
-    {
-        let trash_commitment =
-            CS::read_commitment(transcript, &[PolynomialLabel::Trash(argument_index)])?;
-        Ok(Committed {
-            argument_index,
-            trash_commitment,
-        })
+/// Reads the batched commitment to the compressed polynomial of every trash
+/// argument in one transcript entry. Each argument holds a clone of the shared
+/// commitment and routes its query via its own label. Mirrors the prover's
+/// `commit_trashcans`.
+pub(in crate::plonk) fn read_trashcans<F, CS, T>(
+    num_args: usize,
+    transcript: &mut T,
+) -> Result<Vec<Committed<F, CS>>, Error>
+where
+    F: PrimeField,
+    CS: PolynomialCommitmentScheme<F>,
+    CS::Commitment: Hashable<T::Hash>,
+    T: Transcript,
+{
+    if num_args == 0 {
+        return Ok(Vec::new());
     }
+    let labels: Vec<_> = (0..num_args).map(PolynomialLabel::Trash).collect();
+    let shared = CS::read_commitment(transcript, &labels)?;
+    Ok((0..num_args)
+        .map(|argument_index| Committed {
+            argument_index,
+            trash_commitment: shared.clone(),
+        })
+        .collect())
 }
 
 impl<F: PrimeField, CS: PolynomialCommitmentScheme<F>> Committed<F, CS> {

--- a/proofs/src/plonk/verifier.rs
+++ b/proofs/src/plonk/verifier.rs
@@ -71,14 +71,11 @@ where
     // Sample theta challenge for keeping lookup columns linearly independent
     let theta: F = transcript.squeeze_challenge();
 
-    // Read multiplicities
-    let lookup_multiplicities: Vec<_> = vk
-        .cs
-        .lookups
-        .iter()
-        .enumerate()
-        .map(|(i, l)| l.chunk_by_degree(vk.cs_degree).read_multiplicities::<_, CS>(i, transcript))
-        .collect::<Result<Vec<_>, _>>()?;
+    // Read the batched multiplicities commitment (one transcript entry for all
+    // logup arguments; mirrors the prover's batched `commit_many`).
+    let chunked_lookups: Vec<_> =
+        vk.cs.lookups.iter().map(|l| l.chunk_by_degree(vk.cs_degree)).collect();
+    let lookup_multiplicities = read_multiplicities::<_, CS, _>(&chunked_lookups, transcript)?;
 
     // Sample beta challenge
     let beta: F = transcript.squeeze_challenge();
@@ -88,12 +85,22 @@ where
 
     let permutations_committed = vk.cs.permutation.read_product_commitments(vk, transcript)?;
 
-    let lookups_committed: Vec<_> = lookup_multiplicities
-        .into_iter()
-        .zip(vk.cs.lookups.iter().map(|l| l.chunk_by_degree(vk.cs_degree)))
+    // Read one batched helper commitment for all args + chunks, then one
+    // batched aggregator commitment.
+    let args_with_multiplicities: Vec<_> = chunked_lookups
+        .iter()
+        .zip(lookup_multiplicities)
         .enumerate()
-        .map(|(i, (m, batch))| m.read_commitment(i, batch.num_chunks(), transcript))
-        .collect::<Result<Vec<_>, _>>()?;
+        .map(|(i, (batch, m))| {
+            (
+                ChunkedArgRef {
+                    argument_index: i,
+                    num_chunks: batch.num_chunks(),
+                },
+                m,
+            )
+        })
+        .collect();
 
     let trash_challenge: F = transcript.squeeze_challenge();
 

--- a/proofs/src/plonk/verifier.rs
+++ b/proofs/src/plonk/verifier.rs
@@ -12,6 +12,7 @@ use crate::{
         logup::verifier::{ChunkedArgRef, read_aggregators, read_helpers, read_multiplicities},
         partially_evaluate_identities,
         traces::VerifierTrace,
+        trash::verifier::read_trashcans,
     },
     poly::{PolynomialLabel, VerifierQuery, commitment::PolynomialCommitmentScheme},
     transcript::{Hashable, Sampleable, Transcript, read_n},
@@ -113,13 +114,9 @@ where
 
     let trash_challenge: F = transcript.squeeze_challenge();
 
-    let trashcans_committed: Vec<_> = vk
-        .cs
-        .trashcans
-        .iter()
-        .enumerate()
-        .map(|(i, argument)| argument.read_committed::<CS, _>(i, transcript))
-        .collect::<Result<Vec<_>, _>>()?;
+    // Read the batched trash commitment (one transcript entry for all trash
+    // arguments; mirrors the prover's batched `commit_many`).
+    let trashcans_committed = read_trashcans::<F, CS, _>(vk.cs.trashcans.len(), transcript)?;
 
     // Sample y challenge, which keeps the gates linearly independent.
     let y: F = transcript.squeeze_challenge();

--- a/proofs/src/plonk/verifier.rs
+++ b/proofs/src/plonk/verifier.rs
@@ -8,7 +8,9 @@ use ff::{FromUniformBytes, WithSmallOrderMulGroup};
 use super::{Error, VerifyingKey};
 use crate::{
     plonk::{
-        linearization::verifier::compute_linearization_commitment, partially_evaluate_identities,
+        linearization::verifier::compute_linearization_commitment,
+        logup::verifier::{ChunkedArgRef, read_aggregators, read_helpers, read_multiplicities},
+        partially_evaluate_identities,
         traces::VerifierTrace,
     },
     poly::{PolynomialLabel, VerifierQuery, commitment::PolynomialCommitmentScheme},
@@ -101,6 +103,8 @@ where
             )
         })
         .collect();
+    let helpers_only = read_helpers::<_, CS, _>(args_with_multiplicities, transcript)?;
+    let lookups_committed = read_aggregators::<_, CS, _>(helpers_only, transcript)?;
 
     let trash_challenge: F = transcript.squeeze_challenge();
 

--- a/proofs/src/plonk/verifier.rs
+++ b/proofs/src/plonk/verifier.rs
@@ -64,11 +64,16 @@ where
         }
     }
 
-    // Hash the prover's advice commitments into the transcript and squeeze
-    // challenges
-    let advice_commitments: Vec<_> = (0..vk.cs.num_advice_columns)
-        .map(|i| CS::read_commitment(transcript, &[PolynomialLabel::Advice(i)]))
-        .collect::<Result<_, _>>()?;
+    // Read the batched advice commitment (one transcript entry for all advice
+    // columns; mirrors the prover's batched `commit_many`). Every column holds a
+    // clone of the shared commitment and routes its queries via its own label.
+    let advice_commitments: Vec<CS::Commitment> = if vk.cs.num_advice_columns == 0 {
+        Vec::new()
+    } else {
+        let labels: Vec<_> = (0..vk.cs.num_advice_columns).map(PolynomialLabel::Advice).collect();
+        let shared = CS::read_commitment(transcript, &labels)?;
+        vec![shared; vk.cs.num_advice_columns]
+    };
 
     // Sample theta challenge for keeping lookup columns linearly independent
     let theta: F = transcript.squeeze_challenge();

--- a/proofs/src/poly/commitment.rs
+++ b/proofs/src/poly/commitment.rs
@@ -1,6 +1,8 @@
 //! Trait for a commitment scheme
 use core::ops::{Add, Mul};
 use std::{
+    borrow::Borrow,
+    collections::BTreeMap,
     fmt::Debug,
     hash::Hash,
     io::{self, Read},
@@ -47,17 +49,18 @@ pub trait PolynomialCommitmentScheme<F: PrimeField>: Clone + Debug {
     /// Extract the `VerifierParameters` from `Parameters`
     fn get_verifier_params(params: &Self::Parameters) -> Self::VerifierParameters;
 
-    /// Commit to one or more polynomials, tagging the result with the
-    /// corresponding labels for identification during multi-open accumulation.
+    /// Commit to one or more polynomials, tagging each with its label for
+    /// identification during multi-open accumulation.
+    ///
+    /// The polynomials are committed to in the labels' `Ord` order, which is
+    /// the order [`read_commitment`](Self::read_commitment) reads them back in.
     ///
     /// # Panics
     ///
-    /// Panics if `polynomials` and `labels` have different lengths, or if
-    /// either slice is empty.
-    fn commit_many<B: PolynomialRepresentation>(
+    /// Panics if `polynomials` is empty.
+    fn commit_many<B: PolynomialRepresentation, P: Borrow<Polynomial<F, B>> + Sync>(
         params: &Self::Parameters,
-        polynomials: &[&Polynomial<F, B>],
-        labels: &[PolynomialLabel],
+        polynomials: &BTreeMap<PolynomialLabel, P>,
     ) -> Self::Commitment;
 
     /// Commit to a single polynomial in coefficient form, tagging the result
@@ -68,7 +71,7 @@ pub trait PolynomialCommitmentScheme<F: PrimeField>: Clone + Debug {
         polynomial: &Polynomial<F, B>,
         label: PolynomialLabel,
     ) -> Self::Commitment {
-        Self::commit_many(params, &[polynomial], &[label])
+        Self::commit_many(params, &BTreeMap::from([(label, polynomial)]))
     }
 
     /// Read a commitment to `labels.len()` polynomials from the proof

--- a/proofs/src/poly/commitment.rs
+++ b/proofs/src/poly/commitment.rs
@@ -96,6 +96,15 @@ pub trait PolynomialCommitmentScheme<F: PrimeField>: Clone + Debug {
         labels: &[PolynomialLabel],
     ) -> io::Result<Self::Commitment>;
 
+    /// Write a batched `commitment` to the transcript and proof. Counterpart to
+    /// [`read_commitment`](Self::read_commitment).
+    fn write_commitment<T: Transcript>(
+        transcript: &mut T,
+        commitment: &Self::Commitment,
+    ) -> io::Result<()>
+    where
+        Self::Commitment: Hashable<T::Hash>;
+
     /// Squeeze the evaluation point used by the protocol to open committed
     /// polynomials. The default implementation simply squeezes a challenge,
     /// but specific PCS may require squeezing challenges satisfying certain

--- a/proofs/src/poly/kzg/mod.rs
+++ b/proofs/src/poly/kzg/mod.rs
@@ -161,6 +161,20 @@ where
         Ok(KZGMultiCommitment(inners))
     }
 
+    fn write_commitment<T: Transcript>(
+        transcript: &mut T,
+        commitment: &Self::Commitment,
+    ) -> io::Result<()>
+    where
+        Self::Commitment: Hashable<T::Hash>,
+    {
+        // KZG commits each polynomial independently.
+        for inner in &commitment.0 {
+            transcript.write(&KZGMultiCommitment(vec![inner.clone()]))?;
+        }
+        Ok(())
+    }
+
     fn multi_open<T: Transcript>(
         params: &Self::Parameters,
         queries: &[ProverQuery<E::Fr>],

--- a/proofs/src/poly/kzg/mod.rs
+++ b/proofs/src/poly/kzg/mod.rs
@@ -95,10 +95,11 @@ where
         );
         assert!(!polynomials.is_empty(), "cannot commit to zero polynomials");
         let bases = params.bases::<B>();
+        // One independent MSM per polynomial, run in parallel.
         KZGMultiCommitment(
             polynomials
-                .iter()
-                .zip(labels)
+                .par_iter()
+                .zip(labels.par_iter())
                 .map(|(polynomial, label)| {
                     let size = polynomial.values.len();
                     assert!(bases.len() >= size);

--- a/proofs/src/poly/kzg/mod.rs
+++ b/proofs/src/poly/kzg/mod.rs
@@ -8,7 +8,8 @@
 //! For a more detailed explanation, see the [Halo 2 Book](https://zcash.github.io/halo2/design/proving-system/multipoint-opening.html) on Multipoint Openings.
 
 use std::{
-    collections::HashMap,
+    borrow::Borrow,
+    collections::{BTreeMap, HashMap},
     io::{self, Read},
     marker::PhantomData,
 };
@@ -83,24 +84,21 @@ where
         params.verifier_params()
     }
 
-    fn commit_many<B: PolynomialRepresentation>(
+    fn commit_many<B: PolynomialRepresentation, P: Borrow<Polynomial<E::Fr, B>> + Sync>(
         params: &Self::Parameters,
-        polynomials: &[&Polynomial<E::Fr, B>],
-        labels: &[PolynomialLabel],
+        polynomials: &BTreeMap<PolynomialLabel, P>,
     ) -> Self::Commitment {
-        assert_eq!(
-            polynomials.len(),
-            labels.len(),
-            "polynomials and labels must have the same length"
-        );
         assert!(!polynomials.is_empty(), "cannot commit to zero polynomials");
         let bases = params.bases::<B>();
+        // The map fixes the order to the labels' `Ord` order, which is the
+        // order `read_commitment` tags the points it reads in.
+        let entries: Vec<(&PolynomialLabel, &Polynomial<E::Fr, B>)> =
+            polynomials.iter().map(|(label, poly)| (label, poly.borrow())).collect();
         // One independent MSM per polynomial, run in parallel.
         KZGMultiCommitment(
-            polynomials
-                .par_iter()
-                .zip(labels.par_iter())
-                .map(|(polynomial, label)| {
+            entries
+                .into_par_iter()
+                .map(|(label, polynomial)| {
                     let size = polynomial.values.len();
                     assert!(bases.len() >= size);
                     KZGCommitment::Simple(


### PR DESCRIPTION
Prepares for fflonk implementation by changing how the calls to `commit`/`commit_many` are done. Right now they're called individually whenever a commit has to be made. Now a single `commit_many` call is performed at the end of the corresponding phase.

The PR commit history is basically 1 commit for each protocol phase (no pun intended).

NB: it was a bit confusing why, in commit 4, I reordered some commitments as said in the commit message, but that you cannot observe a change of goldenfiles. I think the reason is that for the proof bytes to change, we would need examples with ≥2 logup arguments (none for now it seems).