### PR TITLE
[Fflonk PR5] [REFACTOR] Last refactor before Fflonk trait implementation

### DIFF
--- a/aggregation/examples/single_circuit_aggregation.rs
+++ b/aggregation/examples/single_circuit_aggregation.rs
@@ -32,11 +32,9 @@ use midnight_circuits::{
     },
 };
 use midnight_proofs::{
+    MidnightPCS,
     circuit::{Layouter, Value},
-    pcs::{
-        kzg::{KZGCommitmentScheme, commitment::KZGMultiCommitment},
-        params::ParamsVerifierKZG,
-    },
+    pcs::{kzg::commitment::KZGMultiCommitment, params::ParamsVerifierKZG},
     plonk::{self, ConstraintSystem, Error},
     poly::{EvaluationDomain, PolynomialLabel},
     transcript::{CircuitTranscript, Transcript},
@@ -237,7 +235,7 @@ impl IvcTransition for ProofAggregation {
             let mut transcript =
                 CircuitTranscript::<PoseidonState<F>>::init_from_bytes(&witness.inner_proof);
             let dual_msm =
-                plonk::prepare::<F, KZGCommitmentScheme<E>, CircuitTranscript<PoseidonState<F>>>(
+                plonk::prepare::<F, MidnightPCS<E>, CircuitTranscript<PoseidonState<F>>>(
                     ctx.vk.vk(),
                     &[KZGMultiCommitment::commitment_to_zero(
                         PolynomialLabel::CommittedInstance(0),

--- a/aggregation/src/ivc/prover.rs
+++ b/aggregation/src/ivc/prover.rs
@@ -13,10 +13,8 @@ use midnight_circuits::{
     verifier::{Accumulator, AssignedAccumulator, AssignedVk, InCircuitKZG},
 };
 use midnight_proofs::{
-    pcs::{
-        kzg::{KZGCommitmentScheme, commitment::KZGMultiCommitment},
-        params::ParamsKZG,
-    },
+    MidnightPCS,
+    pcs::{kzg::commitment::KZGMultiCommitment, params::ParamsKZG},
     plonk::{self},
     poly::PolynomialLabel,
     transcript::{CircuitTranscript, Transcript},
@@ -97,15 +95,14 @@ impl<T: Ivc> IvcProver<T> {
 
             let mut transcript =
                 CircuitTranscript::<PoseidonState<F>>::init_from_bytes(&self.proof);
-            let dual_msm =
-                plonk::prepare::<F, KZGCommitmentScheme<E>, CircuitTranscript<PoseidonState<F>>>(
-                    vk,
-                    &[KZGMultiCommitment::commitment_to_zero(
-                        PolynomialLabel::CommittedInstance(0),
-                    )],
-                    &[&prev_pi],
-                    &mut transcript,
-                )?;
+            let dual_msm = plonk::prepare::<F, MidnightPCS<E>, CircuitTranscript<PoseidonState<F>>>(
+                vk,
+                &[KZGMultiCommitment::commitment_to_zero(
+                    PolynomialLabel::CommittedInstance(0),
+                )],
+                &[&prev_pi],
+                &mut transcript,
+            )?;
 
             if !dual_msm.clone().check(&self.params.verifier_params()) {
                 return Err(IvcError::InvalidProof);

--- a/aggregation/src/ivc/verifier.rs
+++ b/aggregation/src/ivc/verifier.rs
@@ -7,10 +7,8 @@
 
 use midnight_circuits::{hash::poseidon::PoseidonState, verifier::Accumulator};
 use midnight_proofs::{
-    pcs::{
-        kzg::{KZGCommitmentScheme, commitment::KZGMultiCommitment},
-        params::ParamsVerifierKZG,
-    },
+    MidnightPCS,
+    pcs::{kzg::commitment::KZGMultiCommitment, params::ParamsVerifierKZG},
     plonk::{self},
     poly::PolynomialLabel,
     transcript::{CircuitTranscript, Transcript},
@@ -63,16 +61,15 @@ impl<T: Ivc> IvcVerifier<T> {
             IvcCircuit::<T>::format_instance(instance).map_err(|_| IvcError::InvalidInstance)?;
 
         let mut transcript = CircuitTranscript::<PoseidonState<F>>::init_from_bytes(proof);
-        let dual_msm =
-            plonk::prepare::<F, KZGCommitmentScheme<E>, CircuitTranscript<PoseidonState<F>>>(
-                self.vk.vk(),
-                &[KZGMultiCommitment::commitment_to_zero(
-                    PolynomialLabel::CommittedInstance(0),
-                )],
-                &[&pi],
-                &mut transcript,
-            )
-            .map_err(|_| IvcError::InvalidProof)?;
+        let dual_msm = plonk::prepare::<F, MidnightPCS<E>, CircuitTranscript<PoseidonState<F>>>(
+            self.vk.vk(),
+            &[KZGMultiCommitment::commitment_to_zero(
+                PolynomialLabel::CommittedInstance(0),
+            )],
+            &[&pi],
+            &mut transcript,
+        )
+        .map_err(|_| IvcError::InvalidProof)?;
 
         transcript.assert_empty().map_err(|_| IvcError::TranscriptNotEmpty)?;
 

--- a/aggregation/src/multi_circuit_aggregator/circuit.rs
+++ b/aggregation/src/multi_circuit_aggregator/circuit.rs
@@ -23,11 +23,9 @@ use midnight_circuits::{
     verifier::{self, Accumulator, AssignedAccumulator, AssignedKZGMultiCommitment},
 };
 use midnight_proofs::{
+    MidnightPCS,
     circuit::{Layouter, Value},
-    pcs::{
-        kzg::{KZGCommitmentScheme, commitment::KZGMultiCommitment},
-        params::ParamsVerifierKZG,
-    },
+    pcs::{kzg::commitment::KZGMultiCommitment, params::ParamsVerifierKZG},
     plonk::{self, ConstraintSystem, Error},
     poly::{EvaluationDomain, PolynomialLabel},
     transcript::{CircuitTranscript, Transcript},
@@ -260,7 +258,7 @@ impl IvcTransition for ProofAggregation {
             let mut transcript =
                 CircuitTranscript::<PoseidonState<F>>::init_from_bytes(&witness.inner_proof);
             let dual_msm =
-                plonk::prepare::<F, KZGCommitmentScheme<E>, CircuitTranscript<PoseidonState<F>>>(
+                plonk::prepare::<F, MidnightPCS<E>, CircuitTranscript<PoseidonState<F>>>(
                     witness.claim.vk.vk(),
                     &[KZGMultiCommitment::commitment_to_zero(
                         PolynomialLabel::CommittedInstance(0),

--- a/circuits/src/utils/circuit_modeling.rs
+++ b/circuits/src/utils/circuit_modeling.rs
@@ -22,9 +22,10 @@ use ff::{Field, FromUniformBytes, PrimeField};
 use goldenfile::Mint;
 use midnight_curves::{Bls12, Fq};
 use midnight_proofs::{
+    MidnightPCS,
     circuit::Layouter,
     dev::cost_model::{COST_MEASURE_END, COST_MEASURE_START, CircuitModel, circuit_model_with},
-    pcs::{PolynomialCommitmentScheme, kzg::KZGCommitmentScheme},
+    pcs::PolynomialCommitmentScheme,
     plonk::Circuit,
 };
 use serde_json::{Map, Value, json};
@@ -83,7 +84,7 @@ where
         let model = circuit_model_with::<F>(
             &circuit,
             0,
-            <KZGCommitmentScheme<Bls12> as PolynomialCommitmentScheme<Fq>>::commitment_byte_length,
+            <MidnightPCS<Bls12> as PolynomialCommitmentScheme<Fq>>::commitment_byte_length,
         );
         update_json(chip_name, op_name, model).expect("csv generation failed");
     }

--- a/circuits/src/verifier/mod.rs
+++ b/circuits/src/verifier/mod.rs
@@ -17,8 +17,8 @@ use std::collections::BTreeMap;
 
 use group::Group;
 use midnight_proofs::{
+    MidnightPCS,
     circuit::Value,
-    pcs::kzg::KZGCommitmentScheme,
     plonk,
     plonk::ConstraintSystem,
     poly::{EvaluationDomain, PolynomialLabel},
@@ -53,7 +53,7 @@ pub use types::{BlstrsEmulation, SelfEmulation};
 pub use verifier_gadget::VerifierGadget;
 
 type VerifyingKey<S> =
-    plonk::VerifyingKey<<S as SelfEmulation>::F, KZGCommitmentScheme<<S as SelfEmulation>::Engine>>;
+    plonk::VerifyingKey<<S as SelfEmulation>::F, MidnightPCS<<S as SelfEmulation>::Engine>>;
 
 /// Type for in-circuit verifying keys.
 ///

--- a/circuits/src/verifier/verifier_gadget.rs
+++ b/circuits/src/verifier/verifier_gadget.rs
@@ -897,12 +897,10 @@ pub(crate) mod tests {
 
     use group::Group;
     use midnight_proofs::{
+        MidnightPCS,
         circuit::SimpleFloorPlanner,
         dev::MockProver,
-        pcs::{
-            kzg::{KZGCommitmentScheme, commitment::KZGMultiCommitment},
-            params::ParamsKZG,
-        },
+        pcs::{kzg::commitment::KZGMultiCommitment, params::ParamsKZG},
         plonk::{Circuit, Error, create_proof, keygen_pk, keygen_vk_with_k, prepare},
         poly::PolynomialLabel,
         transcript::{CircuitTranscript, Transcript},
@@ -1167,12 +1165,7 @@ pub(crate) mod tests {
 
         let inner_proof = {
             let mut transcript = CircuitTranscript::<PoseidonState<F>>::init();
-            create_proof::<
-                F,
-                KZGCommitmentScheme<E>,
-                CircuitTranscript<PoseidonState<F>>,
-                InnerCircuit,
-            >(
+            create_proof::<F, MidnightPCS<E>, CircuitTranscript<PoseidonState<F>>, InnerCircuit>(
                 &inner_params,
                 &inner_pk,
                 &InnerCircuit::from_witness(preimage),
@@ -1188,7 +1181,7 @@ pub(crate) mod tests {
         let inner_dual_msm = {
             let mut transcript =
                 CircuitTranscript::<PoseidonState<F>>::init_from_bytes(&inner_proof);
-            prepare::<F, KZGCommitmentScheme<E>, CircuitTranscript<PoseidonState<F>>>(
+            prepare::<F, MidnightPCS<E>, CircuitTranscript<PoseidonState<F>>>(
                 &inner_vk,
                 &[KZGMultiCommitment::commitment_to_zero(
                     PolynomialLabel::CommittedInstance(0),

--- a/proofs/examples/proof-size.rs
+++ b/proofs/examples/proof-size.rs
@@ -1,8 +1,8 @@
 use midnight_curves::{Bls12, Fq as Scalar};
 use midnight_proofs::{
+    MidnightPCS,
     circuit::{Layouter, SimpleFloorPlanner, Value},
     dev::cost_model::circuit_model,
-    pcs::kzg::KZGCommitmentScheme,
     plonk::{Advice, Circuit, Column, ConstraintSystem, Error, Expression, Selector, TableColumn},
     poly::Rotation,
 };
@@ -88,7 +88,7 @@ impl Circuit<Scalar> for TestCircuit {
 fn main() {
     let circuit = TestCircuit {};
 
-    let model = circuit_model::<_, KZGCommitmentScheme<Bls12>>(&circuit, 0);
+    let model = circuit_model::<_, MidnightPCS<Bls12>>(&circuit, 0);
     println!(
         "Cost of circuit with 8 bit lookup table: \n{}",
         serde_json::to_string_pretty(&model).unwrap()

--- a/proofs/src/dev/cost_model.rs
+++ b/proofs/src/dev/cost_model.rs
@@ -668,8 +668,9 @@ mod tests {
 
     use super::*;
     use crate::{
+        MidnightPCS,
         circuit::{Layouter, SimpleFloorPlanner},
-        pcs::{kzg::KZGCommitmentScheme, params::ParamsKZG},
+        pcs::params::ParamsKZG,
         plonk::{
             Constraints, Expression, Fixed, TableColumn, create_proof, keygen_pk, keygen_vk_with_k,
         },
@@ -833,14 +834,14 @@ mod tests {
         let circuit = StandardPlonk::<1>(Fq::from(random_byte[0] as u64));
 
         let params = ParamsKZG::<Bls12>::unsafe_setup(k, OsRng);
-        let vk = keygen_vk_with_k::<_, KZGCommitmentScheme<Bls12>, _>(&params, &circuit, k)
+        let vk = keygen_vk_with_k::<_, MidnightPCS<Bls12>, _>(&params, &circuit, k)
             .expect("vk should not fail");
         let pk = keygen_pk(vk, &circuit).expect("pk should not fail");
 
         let instances: &[&[Fq]] = &[&[circuit.0]];
         let mut transcript = CircuitTranscript::<State>::init();
 
-        create_proof::<Fq, KZGCommitmentScheme<Bls12>, _, _>(
+        create_proof::<Fq, MidnightPCS<Bls12>, _, _>(
             &params,
             &pk,
             &circuit,
@@ -855,7 +856,7 @@ mod tests {
         let proof = transcript.finalize();
 
         assert_eq!(
-            circuit_model::<_, KZGCommitmentScheme<Bls12>>(&circuit, 0).size,
+            circuit_model::<_, MidnightPCS<Bls12>>(&circuit, 0).size,
             proof.len()
         );
     }
@@ -869,14 +870,14 @@ mod tests {
         let circuit = StandardPlonk::<1>(Fq::from(random_byte[0] as u64));
 
         let params = ParamsKZG::<Bls12>::unsafe_setup(k, OsRng);
-        let vk = keygen_vk_with_k::<_, KZGCommitmentScheme<Bls12>, _>(&params, &circuit, k)
+        let vk = keygen_vk_with_k::<_, MidnightPCS<Bls12>, _>(&params, &circuit, k)
             .expect("vk should not fail");
         let pk = keygen_pk(vk, &circuit).expect("pk should not fail");
 
         let instances: &[&[Fq]] = &[&[circuit.0]];
         let mut transcript = CircuitTranscript::<State>::init();
 
-        create_proof::<Fq, KZGCommitmentScheme<Bls12>, _, _>(
+        create_proof::<Fq, MidnightPCS<Bls12>, _, _>(
             &params,
             &pk,
             &circuit,
@@ -890,7 +891,7 @@ mod tests {
         let proof = transcript.finalize();
 
         assert_eq!(
-            circuit_model::<_, KZGCommitmentScheme<Bls12>>(&circuit, 1).size,
+            circuit_model::<_, MidnightPCS<Bls12>>(&circuit, 1).size,
             proof.len()
         );
     }

--- a/proofs/src/lib.rs
+++ b/proofs/src/lib.rs
@@ -16,3 +16,10 @@ pub mod transcript;
 
 pub mod dev;
 pub mod utils;
+
+/// The polynomial commitment scheme Midnight's keys and proofs are built with,
+/// over the pairing engine `E`. Everything that means "the scheme this library
+/// ships" goes through this alias, so switching schemes is a single edit; code
+/// that means KZG specifically keeps naming
+/// [`KZGCommitmentScheme`](pcs::kzg::KZGCommitmentScheme).
+pub type MidnightPCS<E> = pcs::kzg::KZGCommitmentScheme<E>;

--- a/proofs/src/pcs/kzg/mod.rs
+++ b/proofs/src/pcs/kzg/mod.rs
@@ -15,9 +15,7 @@ use std::{
 };
 
 use midnight_curves::pairing::Engine;
-use rayon::iter::{
-    IndexedParallelIterator, IntoParallelIterator, IntoParallelRefIterator, ParallelIterator,
-};
+use rayon::iter::{IntoParallelIterator, ParallelIterator};
 
 /// KZG commitment type
 pub mod commitment;
@@ -25,32 +23,25 @@ pub mod commitment;
 use std::{fmt::Debug, hash::Hash};
 
 use commitment::{KZGCommitment, KZGMultiCommitment};
-use ff::Field;
-use group::Group;
 use midnight_curves::pairing::MultiMillerLoop;
 use rand_core::OsRng;
 
 #[cfg(feature = "fewer-point-sets")]
-use crate::pcs::compute_dummy_queries;
-#[cfg(feature = "truncated-challenges")]
-use crate::utils::arithmetic::{truncate, truncated_powers};
+use crate::{pcs::compute_dummy_queries, utils::arithmetic::eval_polynomial};
 use crate::{
     pcs::{
         PolynomialCommitmentScheme,
-        msm::{DualMSM, MSMKZG, msm_specific},
+        msm::{DualMSM, msm_specific},
+        multi_open::{multi_open_core, multi_prepare_core},
         params::{ParamsKZG, ParamsVerifierKZG},
-        utils::construct_intermediate_sets,
     },
     poly::{
-        Coeff, Error, Polynomial, PolynomialRepresentation, ProverQuery,
+        Error, Polynomial, PolynomialRepresentation, ProverQuery,
         query::{PolynomialLabel, VerifierQuery},
     },
     transcript::{Hashable, Sampleable, Transcript},
     utils::{
-        arithmetic::{
-            CurveAffine, CurveExt, MSM, eval_polynomial, evals_inner_product, inner_product,
-            kate_division, lagrange_interpolate, parallelize, powers,
-        },
+        arithmetic::{CurveAffine, CurveExt},
         helpers::{ProcessedSerdeObject, SerdeFormat},
     },
 };
@@ -166,36 +157,6 @@ where
         E::Fr: Sampleable<T::Hash> + Hash + Ord + Hashable<T::Hash>,
         KZGMultiCommitment<E>: Hashable<T::Hash>,
     {
-        /// Like [`inner_product`] but for coefficient-form polynomials that may
-        /// have different lengths (zero-extending the shorter operands).
-        ///
-        /// Fused parallel implementation: a single pass accumulates all
-        /// scaled contributions directly into the output buffer, avoiding
-        /// M intermediate allocations and the sequential reduce chain.
-        fn poly_inner_product<F: ff::PrimeField>(
-            polys: &[&Polynomial<F, Coeff>],
-            scalars: impl IntoIterator<Item = F>,
-        ) -> Polynomial<F, Coeff> {
-            let scalars: Vec<F> = scalars.into_iter().take(polys.len()).collect();
-            let max_len = polys.iter().map(|p| p.len()).max().unwrap_or(0);
-            let mut values = vec![F::ZERO; max_len];
-            parallelize(&mut values, |chunk, start| {
-                for (poly, scalar) in polys.iter().zip(scalars.iter()) {
-                    let pv: &[F] = poly;
-                    let end = (start + chunk.len()).min(pv.len());
-                    if start < pv.len() {
-                        for (out, coeff) in chunk[..end - start].iter_mut().zip(&pv[start..end]) {
-                            *out += *coeff * scalar;
-                        }
-                    }
-                }
-            });
-            Polynomial {
-                values,
-                _marker: PhantomData,
-            }
-        }
-
         // Add dummy queries to reduce the number of distinct multi-open point sets.
         #[cfg(feature = "fewer-point-sets")]
         let queries = &{
@@ -216,126 +177,7 @@ where
             queries
         };
 
-        // Refer to the halo2 book for docs:
-        // https://zcash.github.io/halo2/design/proving-system/multipoint-opening.html
-        let x1: E::Fr = transcript.squeeze_challenge();
-        let x2: E::Fr = transcript.squeeze_challenge();
-
-        // Map each label to the polynomial it identifies, so the per-set
-        // grouping (keyed by label) can recover the actual polynomials.
-        let label_to_poly: HashMap<PolynomialLabel, &Polynomial<E::Fr, Coeff>> =
-            queries.iter().map(|q| (q.label.clone(), q.poly)).collect();
-
-        let kzg_queries = queries
-            .iter()
-            .map(|query| {
-                (
-                    query.label.clone(),
-                    query.point,
-                    eval_polynomial(&query.poly[..], query.point),
-                )
-            })
-            .collect::<Vec<_>>();
-        let (poly_map, point_sets) = construct_intermediate_sets(&kzg_queries)?;
-
-        let mut q_polys = vec![vec![]; point_sets.len()];
-
-        for com_data in poly_map.iter() {
-            q_polys[com_data.set_index].push(label_to_poly[&com_data.label]);
-        }
-
-        let q_polys: Vec<_> = q_polys
-            .par_iter()
-            .map(|polys| {
-                #[cfg(feature = "truncated-challenges")]
-                let x1 = truncated_powers(x1);
-
-                #[cfg(not(feature = "truncated-challenges"))]
-                let x1 = powers(x1);
-
-                poly_inner_product(polys, x1)
-            })
-            .collect();
-
-        // Sort point sets by ascending cardinality to ensure the first set is the one
-        // that contains fixed commitments (which are evaluated at x only). This
-        // property is not necessary for the actual proving system, but it is important
-        // for in-circuit verification of proofs. (It enables an optimization based on
-        // an internal collapse.)
-        //
-        // The (len, i) key provides a deterministic total order even when two sets
-        // share the same cardinality.
-        let (q_polys, point_sets) = {
-            let mut order: Vec<usize> = (0..point_sets.len()).collect();
-            order.sort_by_key(|&i| (point_sets[i].len(), i));
-            let q_polys: Vec<_> = order.iter().map(|&i| &q_polys[i]).collect();
-            let point_sets: Vec<_> = order.iter().map(|&i| point_sets[i].clone()).collect();
-            (q_polys, point_sets)
-        };
-
-        let f_poly = {
-            let f_polys: Vec<_> = point_sets
-                .into_par_iter()
-                .zip(q_polys.clone().into_par_iter())
-                .map(|(points, q_poly)| {
-                    let poly = points.iter().fold(q_poly.values.clone(), |poly, point| {
-                        kate_division(&poly, *point)
-                    });
-                    Polynomial {
-                        values: poly,
-                        _marker: PhantomData,
-                    }
-                })
-                .collect();
-            poly_inner_product(&f_polys.iter().collect::<Vec<_>>(), powers(x2))
-        };
-
-        let f_com = Self::commit(
-            params,
-            &f_poly,
-            PolynomialLabel::Custom("multi_open_batch".into()),
-        );
-        transcript.write(&f_com).map_err(|_| Error::OpeningError)?;
-
-        let x3: E::Fr = transcript.squeeze_challenge();
-        #[cfg(feature = "truncated-challenges")]
-        let x3 = truncate(x3);
-
-        // Evaluate all q_polys at x3 in parallel, then write sequentially.
-        let q_evals: Vec<E::Fr> =
-            q_polys.par_iter().map(|q_poly| eval_polynomial(&q_poly.values, x3)).collect();
-        for eval in &q_evals {
-            transcript.write(eval).map_err(|_| Error::OpeningError)?;
-        }
-
-        let x4: E::Fr = transcript.squeeze_challenge();
-
-        let final_poly = {
-            let mut polys = q_polys;
-            polys.push(&f_poly);
-            #[cfg(feature = "truncated-challenges")]
-            let powers = truncated_powers(x4);
-
-            #[cfg(not(feature = "truncated-challenges"))]
-            let powers = powers(x4);
-
-            poly_inner_product(&polys, powers)
-        };
-        let v = eval_polynomial(&final_poly, x3);
-
-        let pi = {
-            let pi_poly = Polynomial::<_, Coeff> {
-                values: kate_division(&(&final_poly - v).values, x3),
-                _marker: PhantomData,
-            };
-            Self::commit(
-                params,
-                &pi_poly,
-                PolynomialLabel::Custom("kzg_proof".into()),
-            )
-        };
-
-        transcript.write(&pi).map_err(|_| Error::OpeningError)
+        multi_open_core::<E::Fr, Self, T>(params, queries, transcript)
     }
 
     fn multi_prepare<'com, T: Transcript>(
@@ -366,20 +208,14 @@ where
             queries
         };
 
-        // Refer to the halo2 book for docs:
-        // https://zcash.github.io/halo2/design/proving-system/multipoint-opening.html
-        let x1: E::Fr = transcript.squeeze_challenge();
-        let x2: E::Fr = transcript.squeeze_challenge();
-
         // Peel each query's multi-commitment down to the single inner
-        // `KZGCommitment` it targets, keyed by the query label. The rest of the
-        // routine then operates on individual `KZGCommitment`s as before.
+        // `KZGCommitment` it targets, keyed by the query label.
         //
         // A length-1 commitment (the common case, including the `Linear`
         // linearization commitment) peels to its sole inner. A batched
         // commitment holds several `Simple`s, so we pick the one whose own label
         // matches the query.
-        let label_to_commitment: HashMap<PolynomialLabel, &KZGCommitment<E>> = queries
+        let label_to_commitment: HashMap<PolynomialLabel, KZGCommitment<E>> = queries
             .iter()
             .map(|q| {
                 let inners = &q.commitment.0;
@@ -391,154 +227,27 @@ where
                         .find(|c| matches!(c, KZGCommitment::Simple(_, label) if *label == q.label))
                         .expect("batched commitment has no polynomial matching the query label")
                 };
-                (q.label.clone(), inner)
+                (q.label.clone(), inner.clone())
             })
             .collect();
 
-        let kzg_queries = queries
+        let triples = queries
             .iter()
             .map(|query| (query.label.clone(), query.point, query.eval))
             .collect::<Vec<_>>();
-        let (commitment_map, point_sets) = construct_intermediate_sets(&kzg_queries)?;
 
-        let mut q_coms: Vec<_> = vec![vec![]; point_sets.len()];
-        let mut q_eval_sets = vec![vec![]; point_sets.len()];
-
-        for com_data in commitment_map.into_iter() {
-            q_coms[com_data.set_index].push(label_to_commitment[&com_data.label].clone());
-            q_eval_sets[com_data.set_index].push(com_data.evals);
-        }
-
-        let nb_x1_powers = q_coms.iter().map(Vec::len).max().unwrap_or(0);
-        assert!(nb_x1_powers >= q_eval_sets.iter().map(Vec::len).max().unwrap_or(0));
-
-        #[cfg(feature = "truncated-challenges")]
-        let powers_x1 = truncated_powers(x1).take(nb_x1_powers).collect::<Vec<_>>();
-
-        #[cfg(not(feature = "truncated-challenges"))]
-        let powers_x1 = powers(x1).take(nb_x1_powers).collect::<Vec<_>>();
-
-        let q_coms = q_coms
-            .into_iter()
-            .map(|coms| inner_product(&coms, powers_x1.clone().into_iter()))
-            .collect::<Vec<_>>();
-
-        let q_eval_sets = q_eval_sets
-            .iter()
-            .map(|evals| evals_inner_product(evals, &powers_x1))
-            .collect::<Vec<_>>();
-
-        // Sort point sets by ascending cardinality to ensure the first set is the one
-        // that contains fixed commitments (which are evaluated at x only). This
-        // property is not necessary for the actual proving system, but it is important
-        // for in-circuit verification of proofs. (It enables an optimization based on
-        // an internal collapse.)
-        //
-        // The (len, i) key provides a deterministic total order even when two sets
-        // share the same cardinality.
-        let (q_coms, q_eval_sets, point_sets) = {
-            let mut order: Vec<usize> = (0..point_sets.len()).collect();
-            order.sort_by_key(|&i| (point_sets[i].len(), i));
-            let q_coms: Vec<_> = order.iter().map(|&i| q_coms[i].clone()).collect();
-            let q_eval_sets: Vec<_> = order.iter().map(|&i| q_eval_sets[i].clone()).collect();
-            let point_sets: Vec<_> = order.iter().map(|&i| point_sets[i].clone()).collect();
-            (q_coms, q_eval_sets, point_sets)
-        };
-
-        let f_point: E::G1 = transcript
-            .read::<KZGMultiCommitment<E>>()
-            .map_err(|_| Error::SamplingError)?
-            .into_single()
-            .into_point();
-        let f_com = KZGCommitment::Simple(f_point, PolynomialLabel::Custom("kzg_batch".into()));
-
-        // Sample a challenge x_3 for checking that f(X) was committed to
-        // correctly.
-        let x3: E::Fr = transcript.squeeze_challenge();
-        #[cfg(feature = "truncated-challenges")]
-        let x3 = truncate(x3);
-
-        let mut q_evals_on_x3 = Vec::<E::Fr>::with_capacity(q_eval_sets.len());
-        for _ in 0..q_eval_sets.len() {
-            q_evals_on_x3.push(transcript.read().map_err(|_| Error::SamplingError)?);
-        }
-
-        // We can compute the expected msm_eval at x_3 using the u provided
-        // by the prover and from x_2
-        let f_eval =
-            point_sets.iter().zip(q_eval_sets.iter()).zip(q_evals_on_x3.iter()).rev().fold(
-                E::Fr::ZERO,
-                |acc_eval, ((points, evals), proof_eval)| {
-                    let r_poly = lagrange_interpolate(points, evals);
-                    let r_eval = eval_polynomial(&r_poly, x3);
-                    // eval = (proof_eval - r_eval) / prod_i (x3 - point_i)
-                    let den = points.iter().fold(E::Fr::ONE, |acc, point| acc * &(x3 - point));
-                    let eval = (*proof_eval - &r_eval) * den.invert().unwrap();
-                    acc_eval * &(x2) + &eval
-                },
-            );
-
-        let x4: E::Fr = transcript.squeeze_challenge();
-
-        let final_com = {
-            let size = q_coms.len() + 1;
-            let mut coms = q_coms;
-
-            // Collapse all MSMs before combining with x4 powers, to match the
-            // in-circuit verifier. Skip the first one since its x4 power is 1.
-            #[cfg(feature = "truncated-challenges")]
-            coms.iter_mut().skip(1).for_each(|c| c.collapse(PolynomialLabel::NoLabel));
-            coms.push(f_com);
-
-            #[cfg(feature = "truncated-challenges")]
-            let powers = truncated_powers(x4);
-
-            #[cfg(not(feature = "truncated-challenges"))]
-            let powers = powers(x4);
-
-            inner_product(&coms, powers.take(size))
-        };
-
-        let v = {
-            let mut evals = q_evals_on_x3;
-            evals.push(f_eval);
-
-            #[cfg(feature = "truncated-challenges")]
-            let powers = truncated_powers(x4);
-
-            #[cfg(not(feature = "truncated-challenges"))]
-            let powers = powers(x4);
-
-            inner_product(&evals, powers)
-        };
-
-        let pi: E::G1 = transcript
-            .read::<KZGMultiCommitment<E>>()
-            .map_err(|_| Error::SamplingError)?
-            .into_single()
-            .into_point();
-
-        let mut pi_msm = MSMKZG::<E>::init();
-        pi_msm.append_term(E::Fr::ONE, pi, PolynomialLabel::Custom("π".into()));
-
-        // - vG + zπ
-        let extra_rhs = MSMKZG::new(
-            &[v, x3],
-            &[-E::G1::generator(), pi],
-            &[
-                PolynomialLabel::Custom("-G".into()),
-                PolynomialLabel::Custom("π".into()),
-            ],
-        );
-
-        // (π, C − vG + zπ)
-        let mut msm_accumulator = DualMSM {
-            left: pi_msm,
-            right: final_com.into(),
-        };
-        msm_accumulator.right.add_msm(&extra_rhs);
-
-        Ok(msm_accumulator)
+        multi_prepare_core::<E, KZGCommitment<E>, T>(
+            &triples,
+            &label_to_commitment,
+            transcript,
+            |transcript| {
+                Ok(transcript
+                    .read::<KZGMultiCommitment<E>>()
+                    .map_err(|_| Error::SamplingError)?
+                    .into_single()
+                    .into_point())
+            },
+        )
     }
 }
 

--- a/proofs/src/pcs/kzg/mod.rs
+++ b/proofs/src/pcs/kzg/mod.rs
@@ -105,18 +105,6 @@ where
         )
     }
 
-    /// With `single-h-commitment` the quotient is committed as one polynomial
-    /// of degree up to `(cs_degree - 1) * n`, so the monomial basis must be
-    /// blown up to the next power of two of `cs_degree - 1`. Otherwise KZG
-    /// commits each polynomial at the Lagrange size and needs no extension.
-    fn srs_monomial_blowup(cs_degree: usize) -> usize {
-        if cfg!(feature = "single-h-commitment") {
-            (cs_degree - 1).next_power_of_two()
-        } else {
-            1
-        }
-    }
-
     fn read_commitment<T: Transcript>(
         transcript: &mut T,
         labels: &[PolynomialLabel],

--- a/proofs/src/pcs/mod.rs
+++ b/proofs/src/pcs/mod.rs
@@ -16,6 +16,7 @@ pub mod params;
 /// `Guard`).
 pub mod scheme;
 
+pub(crate) mod multi_open;
 pub(crate) mod utils;
 
 pub use scheme::{Guard, Params, PolynomialCommitmentScheme};

--- a/proofs/src/pcs/multi_open.rs
+++ b/proofs/src/pcs/multi_open.rs
@@ -1,0 +1,432 @@
+//! The multi-point opening argument, shared by every scheme built on a
+//! KZG-style SRS.
+//!
+//! Refer to the [Halo 2 Book](https://zcash.github.io/halo2/design/proving-system/multipoint-opening.html)
+//! for the argument itself.
+//!
+//! A scheme's `multi_open` / `multi_prepare` is its own query expansion
+//! followed by a call into this module: KZG opens the queries it is given,
+//! while fflonk first replaces bundled queries with synthetic ones on the
+//! bundle's combined polynomial. Everything from the first squeezed challenge
+//! onwards is identical, and lives here.
+
+use std::{collections::HashMap, fmt::Debug, hash::Hash, marker::PhantomData};
+
+use ff::{Field, PrimeField};
+use group::Group;
+use midnight_curves::pairing::MultiMillerLoop;
+use rayon::iter::{
+    IndexedParallelIterator, IntoParallelIterator, IntoParallelRefIterator, ParallelIterator,
+};
+
+#[cfg(feature = "truncated-challenges")]
+use crate::utils::arithmetic::{truncate, truncated_powers};
+use crate::{
+    pcs::{
+        PolynomialCommitmentScheme,
+        kzg::commitment::KZGCommitment,
+        msm::{DualMSM, MSMKZG},
+        utils::construct_intermediate_sets,
+    },
+    poly::{Coeff, Error, Polynomial, ProverQuery, query::PolynomialLabel},
+    transcript::{Hashable, Sampleable, Transcript},
+    utils::arithmetic::{
+        CurveAffine, CurveExt, MSM, eval_polynomial, evals_inner_product, inner_product,
+        kate_division, lagrange_interpolate, parallelize, powers,
+    },
+};
+
+/// Label carried by the batch commitment `f`. Never serialized, so its value
+/// is cosmetic.
+const BATCH_LABEL: &str = "multi_open_batch";
+
+/// Label carried by the opening proof `π`. Never serialized, so its value is
+/// cosmetic.
+const PROOF_LABEL: &str = "multi_open_proof";
+
+/// Like [`inner_product`] but for coefficient-form polynomials that may
+/// have different lengths (zero-extending the shorter operands).
+///
+/// Fused parallel implementation: a single pass accumulates all
+/// scaled contributions directly into the output buffer, avoiding
+/// M intermediate allocations and the sequential reduce chain.
+fn poly_inner_product<F: PrimeField>(
+    polys: &[&Polynomial<F, Coeff>],
+    scalars: impl IntoIterator<Item = F>,
+) -> Polynomial<F, Coeff> {
+    let scalars: Vec<F> = scalars.into_iter().take(polys.len()).collect();
+    let max_len = polys.iter().map(|p| p.len()).max().unwrap_or(0);
+    let mut values = vec![F::ZERO; max_len];
+    parallelize(&mut values, |chunk, start| {
+        for (poly, scalar) in polys.iter().zip(scalars.iter()) {
+            let pv: &[F] = poly;
+            let end = (start + chunk.len()).min(pv.len());
+            if start < pv.len() {
+                for (out, coeff) in chunk[..end - start].iter_mut().zip(&pv[start..end]) {
+                    *out += *coeff * scalar;
+                }
+            }
+        }
+    });
+    Polynomial {
+        values,
+        _marker: PhantomData,
+    }
+}
+
+/// Sort point sets by ascending cardinality, so the first set is the one
+/// holding commitments evaluated at a single point (the fixed ones). Not
+/// needed by the proving system itself, but the in-circuit verifier relies on
+/// it for a collapse optimization.
+///
+/// The `(len, i)` key gives a deterministic total order when two sets share a
+/// cardinality.
+fn point_set_order<F>(point_sets: &[Vec<F>]) -> Vec<usize> {
+    let mut order: Vec<usize> = (0..point_sets.len()).collect();
+    order.sort_by_key(|&i| (point_sets[i].len(), i));
+    order
+}
+
+/// Prove that the polynomials behind `queries` take the claimed values at the
+/// claimed points, writing the argument to `transcript`.
+///
+/// Callers are responsible for any scheme-specific expansion of `queries`
+/// (fflonk's bundle expansion, the `fewer-point-sets` dummy queries) before
+/// handing them over.
+pub(crate) fn multi_open_core<F, CS, T>(
+    params: &CS::Parameters,
+    queries: &[ProverQuery<F>],
+    transcript: &mut T,
+) -> Result<(), Error>
+where
+    F: PrimeField + Hash + Ord + Sampleable<T::Hash> + Hashable<T::Hash>,
+    CS: PolynomialCommitmentScheme<F>,
+    CS::Commitment: Hashable<T::Hash>,
+    T: Transcript,
+{
+    let x1: F = transcript.squeeze_challenge();
+    let x2: F = transcript.squeeze_challenge();
+
+    // Map each label to the polynomial it identifies, so the per-set
+    // grouping (keyed by label) can recover the actual polynomials.
+    let label_to_poly: HashMap<PolynomialLabel, &Polynomial<F, Coeff>> =
+        queries.iter().map(|q| (q.label.clone(), q.poly)).collect();
+
+    let triples = queries
+        .iter()
+        .map(|query| {
+            (
+                query.label.clone(),
+                query.point,
+                eval_polynomial(&query.poly[..], query.point),
+            )
+        })
+        .collect::<Vec<_>>();
+    let (poly_map, point_sets) = construct_intermediate_sets(&triples)?;
+
+    let mut q_polys = vec![vec![]; point_sets.len()];
+
+    for com_data in poly_map.iter() {
+        q_polys[com_data.set_index].push(label_to_poly[&com_data.label]);
+    }
+
+    let q_polys: Vec<_> = q_polys
+        .par_iter()
+        .map(|polys| {
+            #[cfg(feature = "truncated-challenges")]
+            let x1 = truncated_powers(x1);
+
+            #[cfg(not(feature = "truncated-challenges"))]
+            let x1 = powers(x1);
+
+            poly_inner_product(polys, x1)
+        })
+        .collect();
+
+    let (q_polys, point_sets) = {
+        let order = point_set_order(&point_sets);
+        let q_polys: Vec<_> = order.iter().map(|&i| &q_polys[i]).collect();
+        let point_sets: Vec<_> = order.iter().map(|&i| point_sets[i].clone()).collect();
+        (q_polys, point_sets)
+    };
+
+    let f_poly = {
+        let f_polys: Vec<_> = point_sets
+            .into_par_iter()
+            .zip(q_polys.clone().into_par_iter())
+            .map(|(points, q_poly)| {
+                let poly = points.iter().fold(q_poly.values.clone(), |poly, point| {
+                    kate_division(&poly, *point)
+                });
+                Polynomial {
+                    values: poly,
+                    _marker: PhantomData,
+                }
+            })
+            .collect();
+        poly_inner_product(&f_polys.iter().collect::<Vec<_>>(), powers(x2))
+    };
+
+    let f_com = CS::commit(params, &f_poly, PolynomialLabel::Custom(BATCH_LABEL.into()));
+    transcript.write(&f_com).map_err(|_| Error::OpeningError)?;
+
+    let x3: F = transcript.squeeze_challenge();
+    #[cfg(feature = "truncated-challenges")]
+    let x3 = truncate(x3);
+
+    // Evaluate all q_polys at x3 in parallel, then write sequentially.
+    let q_evals: Vec<F> =
+        q_polys.par_iter().map(|q_poly| eval_polynomial(&q_poly.values, x3)).collect();
+    for eval in &q_evals {
+        transcript.write(eval).map_err(|_| Error::OpeningError)?;
+    }
+
+    let x4: F = transcript.squeeze_challenge();
+
+    let final_poly = {
+        let mut polys = q_polys;
+        polys.push(&f_poly);
+        #[cfg(feature = "truncated-challenges")]
+        let powers = truncated_powers(x4);
+
+        #[cfg(not(feature = "truncated-challenges"))]
+        let powers = powers(x4);
+
+        poly_inner_product(&polys, powers)
+    };
+    let v = eval_polynomial(&final_poly, x3);
+
+    let pi = {
+        let pi_poly = Polynomial::<_, Coeff> {
+            values: kate_division(&(&final_poly - v).values, x3),
+            _marker: PhantomData,
+        };
+        CS::commit(
+            params,
+            &pi_poly,
+            PolynomialLabel::Custom(PROOF_LABEL.into()),
+        )
+    };
+
+    transcript.write(&pi).map_err(|_| Error::OpeningError)
+}
+
+/// How a scheme accumulates commitments while batching the opening argument.
+///
+/// The argument only ever scales commitments and adds them together, then
+/// hands the result to the pairing check as an MSM. Expressed as methods
+/// rather than operators so that both a lazy commitment and an MSM can play
+/// the role.
+pub(crate) trait BatchAccumulator<E: MultiMillerLoop + Debug>: Clone {
+    /// Wrap a single group element, as read off the transcript.
+    fn from_point(point: E::G1, label: PolynomialLabel) -> Self;
+
+    /// Scale the accumulated linear combination by `factor`.
+    fn scale(&mut self, factor: E::Fr);
+
+    /// Add `other` into this linear combination.
+    fn add(&mut self, other: &Self);
+
+    /// Reduce the accumulated linear combination to a single term.
+    #[cfg(feature = "truncated-challenges")]
+    fn collapse(&mut self, label: PolynomialLabel);
+
+    /// Convert into the MSM the pairing check consumes.
+    fn into_msm(self) -> MSMKZG<E>;
+}
+
+impl<E: MultiMillerLoop + Debug> BatchAccumulator<E> for KZGCommitment<E>
+where
+    E::G1Affine: CurveAffine<ScalarExt = E::Fr, CurveExt = E::G1>,
+{
+    fn from_point(point: E::G1, label: PolynomialLabel) -> Self {
+        KZGCommitment::Simple(point, label)
+    }
+
+    fn scale(&mut self, factor: E::Fr) {
+        *self = self.clone() * factor;
+    }
+
+    fn add(&mut self, other: &Self) {
+        *self = self.clone() + other.clone();
+    }
+
+    #[cfg(feature = "truncated-challenges")]
+    fn collapse(&mut self, label: PolynomialLabel) {
+        KZGCommitment::collapse(self, label)
+    }
+
+    fn into_msm(self) -> MSMKZG<E> {
+        self.into()
+    }
+}
+
+/// `sum_i coms[i] * scalars[i]`, in the accumulator's own representation.
+fn com_inner_product<E: MultiMillerLoop + Debug, C: BatchAccumulator<E>>(
+    coms: &[C],
+    scalars: impl IntoIterator<Item = E::Fr>,
+) -> C {
+    let mut terms = coms.iter().zip(scalars).map(|(com, scalar)| {
+        let mut com = com.clone();
+        com.scale(scalar);
+        com
+    });
+    let mut acc = terms.next().expect("empty inner product");
+    for term in terms {
+        acc.add(&term);
+    }
+    acc
+}
+
+/// Check the multi-point opening argument written by [`multi_open_core`],
+/// returning the pairing accumulator to be verified.
+///
+/// `triples` are the `(label, point, eval)` claims after any scheme-specific
+/// expansion, and `label_to_com` resolves each label to the commitment it
+/// refers to. `read_point` reads one of the argument's two group elements off
+/// the transcript; it is a parameter because each scheme serializes its
+/// commitments differently, and both reads have to land at these exact points
+/// of the transcript.
+pub(crate) fn multi_prepare_core<E, C, T>(
+    triples: &[(PolynomialLabel, E::Fr, E::Fr)],
+    label_to_com: &HashMap<PolynomialLabel, C>,
+    transcript: &mut T,
+    read_point: impl Fn(&mut T) -> Result<E::G1, Error>,
+) -> Result<DualMSM<E>, Error>
+where
+    E: MultiMillerLoop + Debug,
+    E::Fr: PrimeField + Hash + Ord + Sampleable<T::Hash> + Hashable<T::Hash>,
+    E::G1: CurveExt<ScalarExt = E::Fr>,
+    E::G1Affine: CurveAffine<ScalarExt = E::Fr, CurveExt = E::G1>,
+    C: BatchAccumulator<E>,
+    T: Transcript,
+{
+    let x1: E::Fr = transcript.squeeze_challenge();
+    let x2: E::Fr = transcript.squeeze_challenge();
+
+    let (commitment_map, point_sets) = construct_intermediate_sets(triples)?;
+
+    let mut q_coms: Vec<Vec<C>> = vec![vec![]; point_sets.len()];
+    let mut q_eval_sets = vec![vec![]; point_sets.len()];
+
+    for com_data in commitment_map.into_iter() {
+        let com = label_to_com
+            .get(&com_data.label)
+            .cloned()
+            .expect("multi_prepare: no commitment registered for label");
+        q_coms[com_data.set_index].push(com);
+        q_eval_sets[com_data.set_index].push(com_data.evals);
+    }
+
+    let nb_x1_powers = q_coms.iter().map(Vec::len).max().unwrap_or(0);
+    assert!(nb_x1_powers >= q_eval_sets.iter().map(Vec::len).max().unwrap_or(0));
+
+    #[cfg(feature = "truncated-challenges")]
+    let powers_x1 = truncated_powers(x1).take(nb_x1_powers).collect::<Vec<_>>();
+
+    #[cfg(not(feature = "truncated-challenges"))]
+    let powers_x1 = powers(x1).take(nb_x1_powers).collect::<Vec<_>>();
+
+    let q_coms = q_coms
+        .into_iter()
+        .map(|coms| com_inner_product::<E, C>(&coms, powers_x1.clone()))
+        .collect::<Vec<_>>();
+
+    let q_eval_sets = q_eval_sets
+        .iter()
+        .map(|evals| evals_inner_product(evals, &powers_x1))
+        .collect::<Vec<_>>();
+
+    let (q_coms, q_eval_sets, point_sets) = {
+        let order = point_set_order(&point_sets);
+        let q_coms: Vec<_> = order.iter().map(|&i| q_coms[i].clone()).collect();
+        let q_eval_sets: Vec<_> = order.iter().map(|&i| q_eval_sets[i].clone()).collect();
+        let point_sets: Vec<_> = order.iter().map(|&i| point_sets[i].clone()).collect();
+        (q_coms, q_eval_sets, point_sets)
+    };
+
+    let f_point = read_point(transcript)?;
+    let f_com = C::from_point(f_point, PolynomialLabel::Custom(BATCH_LABEL.into()));
+
+    // Sample a challenge x_3 for checking that f(X) was committed to correctly.
+    let x3: E::Fr = transcript.squeeze_challenge();
+    #[cfg(feature = "truncated-challenges")]
+    let x3 = truncate(x3);
+
+    let mut q_evals_on_x3 = Vec::<E::Fr>::with_capacity(q_eval_sets.len());
+    for _ in 0..q_eval_sets.len() {
+        q_evals_on_x3.push(transcript.read().map_err(|_| Error::SamplingError)?);
+    }
+
+    // We can compute the expected msm_eval at x_3 using the u provided
+    // by the prover and from x_2
+    let f_eval = point_sets.iter().zip(q_eval_sets.iter()).zip(q_evals_on_x3.iter()).rev().fold(
+        E::Fr::ZERO,
+        |acc_eval, ((points, evals), proof_eval)| {
+            let r_poly = lagrange_interpolate(points, evals);
+            let r_eval = eval_polynomial(&r_poly, x3);
+            // eval = (proof_eval - r_eval) / prod_i (x3 - point_i)
+            let den = points.iter().fold(E::Fr::ONE, |acc, point| acc * &(x3 - point));
+            let eval = (*proof_eval - &r_eval) * den.invert().unwrap();
+            acc_eval * &(x2) + &eval
+        },
+    );
+
+    let x4: E::Fr = transcript.squeeze_challenge();
+
+    let final_com = {
+        let size = q_coms.len() + 1;
+        let mut coms = q_coms;
+
+        // Collapse all MSMs before combining with x4 powers, to match the
+        // in-circuit verifier. Skip the first one since its x4 power is 1.
+        #[cfg(feature = "truncated-challenges")]
+        coms.iter_mut().skip(1).for_each(|c| c.collapse(PolynomialLabel::NoLabel));
+        coms.push(f_com);
+
+        #[cfg(feature = "truncated-challenges")]
+        let powers = truncated_powers(x4);
+
+        #[cfg(not(feature = "truncated-challenges"))]
+        let powers = powers(x4);
+
+        com_inner_product::<E, C>(&coms, powers.take(size))
+    };
+
+    let v = {
+        let mut evals = q_evals_on_x3;
+        evals.push(f_eval);
+
+        #[cfg(feature = "truncated-challenges")]
+        let powers = truncated_powers(x4);
+
+        #[cfg(not(feature = "truncated-challenges"))]
+        let powers = powers(x4);
+
+        inner_product(&evals, powers)
+    };
+
+    let pi: E::G1 = read_point(transcript)?;
+
+    let mut pi_msm = MSMKZG::<E>::init();
+    pi_msm.append_term(E::Fr::ONE, pi, PolynomialLabel::Custom("π".into()));
+
+    // - vG + zπ
+    let extra_rhs = MSMKZG::new(
+        &[v, x3],
+        &[-E::G1::generator(), pi],
+        &[
+            PolynomialLabel::Custom("-G".into()),
+            PolynomialLabel::Custom("π".into()),
+        ],
+    );
+
+    // (π, C − vG + zπ)
+    let mut msm_accumulator = DualMSM {
+        left: pi_msm,
+        right: final_com.into_msm(),
+    };
+    msm_accumulator.right.add_msm(&extra_rhs);
+
+    Ok(msm_accumulator)
+}

--- a/proofs/src/pcs/scheme.rs
+++ b/proofs/src/pcs/scheme.rs
@@ -122,17 +122,19 @@ pub trait PolynomialCommitmentScheme<F: PrimeField>: Clone + Debug {
         transcript.squeeze_challenge()
     }
 
-    /// Multiplicative blow-up factor by which `params.g_monomial_size()` must
-    /// exceed `2^k` (the circuit's Lagrange-domain size) for this PCS to
-    /// commit every polynomial it produces at the requested circuit size.
-    /// Returns `1` when no extension is needed.
+    /// Largest polynomial degree this scheme commits to internally, when asked
+    /// to commit polynomials of degree at most `max_poly_degree`, those on the
+    /// circuit domain (of degree below `2^k`) possibly several at a time.
     ///
-    /// `cs_degree` is the constraint system's `cs.degree()`. Schemes that
-    /// commit to a single combined polynomial (e.g. `single-h-commitment`,
-    /// fflonk's bundles) factor that into their requested blow-up.
-    fn srs_monomial_blowup(cs_degree: usize) -> usize {
-        let _ = cs_degree; // Just to avoid a clippy warning.
-        1
+    /// Schemes that commit every polynomial as given (e.g. KZG) return
+    /// `max_poly_degree`. Schemes that fold several circuit-domain polynomials
+    /// into a single commitment (e.g. fflonk) return a larger degree.
+    ///
+    /// Used to size the parameters, see
+    /// [`max_committed_degree`](crate::plonk::max_committed_degree).
+    fn internal_degree(k: u32, max_poly_degree: usize) -> usize {
+        let _ = k; // Just to avoid a clippy warning.
+        max_poly_degree
     }
 
     /// Create a multi-opening proof at a set of [ProverQuery]'s.

--- a/proofs/src/plonk/prover.rs
+++ b/proofs/src/plonk/prover.rs
@@ -640,6 +640,29 @@ pub(super) fn compute_nu_poly<F: WithSmallOrderMulGroup<3>, CS: PolynomialCommit
     )
 }
 
+/// Degree of the largest polynomial the protocol commits when proving a
+/// circuit of size `2^k` whose constraint system has degree `cs_degree`.
+///
+/// Used to size the parameters: feed the result to
+/// [`PolynomialCommitmentScheme::internal_degree`] to obtain the degree the
+/// commitment scheme itself needs to support.
+pub fn max_committed_degree(k: u32, cs_degree: usize) -> usize {
+    let n = 1usize << k;
+
+    // Polynomials on the circuit domain (advice, fixed, permutation, lookups)
+    // have degree at most `n - 1`.
+    let domain_degree = n - 1;
+
+    if cfg!(feature = "single-h-commitment") {
+        // `compute_h_poly` keeps `(n - 1) * (cs_degree - 1)` coefficients of the
+        // quotient, which it then commits as one polynomial.
+        domain_degree.max(((n - 1) * (cs_degree - 1)).saturating_sub(1))
+    } else {
+        // The quotient is split into limbs that fit the circuit domain.
+        domain_degree
+    }
+}
+
 /// Computes the quotient polynomial `h(X) = nu(X) / (X^n - 1)` and commits to
 /// it, writing the commitment(s) to the transcript.
 ///

--- a/zk_stdlib/examples/identity/jwt/enrollment.rs
+++ b/zk_stdlib/examples/identity/jwt/enrollment.rs
@@ -14,8 +14,8 @@ use midnight_circuits::{
 };
 use midnight_curves::k256::K256;
 use midnight_proofs::{
+    MidnightPCS,
     circuit::{Layouter, Value},
-    pcs::kzg::KZGCommitmentScheme,
     plonk::{Error, commit_to_instances},
 };
 use midnight_zk_stdlib::{Relation, ZkStdLib, ZkStdLibArch, utils::plonk_api::srs_for_test};
@@ -200,7 +200,7 @@ fn main() {
     };
     let committed_credential = {
         let instance = CredentialEnrollment::format_committed_instances(&witness);
-        commit_to_instances::<_, KZGCommitmentScheme<_>>(&srs, vk.vk().get_domain(), &instance)
+        commit_to_instances::<_, MidnightPCS<_>>(&srs, vk.vk().get_domain(), &instance)
     };
     println!("... done\n{:?}", wit.elapsed());
 

--- a/zk_stdlib/examples/identity/jwt/property_check.rs
+++ b/zk_stdlib/examples/identity/jwt/property_check.rs
@@ -28,8 +28,8 @@ use midnight_circuits::{
 };
 use midnight_curves::k256::{Fq as K256Scalar, K256};
 use midnight_proofs::{
+    MidnightPCS,
     circuit::{Layouter, Value},
-    pcs::kzg::KZGCommitmentScheme,
     plonk::{Error, commit_to_instances},
 };
 use midnight_zk_stdlib::{Relation, ZkStdLib, ZkStdLibArch, utils::plonk_api::srs_for_test};
@@ -338,7 +338,7 @@ fn main() {
 
     let committed_credential = {
         let instance = CredentialProperty::format_committed_instances(&witness);
-        commit_to_instances::<_, KZGCommitmentScheme<_>>(&srs, vk.vk().get_domain(), &instance)
+        commit_to_instances::<_, MidnightPCS<_>>(&srs, vk.vk().get_domain(), &instance)
     };
     println!("... done ({:?})", wit.elapsed());
 

--- a/zk_stdlib/src/interface.rs
+++ b/zk_stdlib/src/interface.rs
@@ -19,11 +19,12 @@ use ff::Field;
 use midnight_circuits::types::ComposableChip;
 use midnight_curves::G1Projective;
 use midnight_proofs::{
+    MidnightPCS,
     circuit::{Layouter, SimpleFloorPlanner, Value},
     dev::cost_model::{CircuitModel, circuit_model},
     pcs::{
         Guard, Params,
-        kzg::{KZGCommitmentScheme, commitment::KZGMultiCommitment},
+        kzg::commitment::KZGMultiCommitment,
         params::{ParamsKZG, ParamsVerifierKZG},
     },
     plonk::{
@@ -96,7 +97,7 @@ pub struct MidnightVK {
     architecture: ZkStdLibArch,
     k: u8,
     nb_public_inputs: usize,
-    vk: VerifyingKey<midnight_curves::Fq, KZGCommitmentScheme<midnight_curves::Bls12>>,
+    vk: VerifyingKey<midnight_curves::Fq, MidnightPCS<midnight_curves::Bls12>>,
 }
 
 impl MidnightVK {
@@ -156,9 +157,7 @@ impl MidnightVK {
     }
 
     /// The underlying midnight-proofs verifying key.
-    pub fn vk(
-        &self,
-    ) -> &VerifyingKey<midnight_curves::Fq, KZGCommitmentScheme<midnight_curves::Bls12>> {
+    pub fn vk(&self) -> &VerifyingKey<midnight_curves::Fq, MidnightPCS<midnight_curves::Bls12>> {
         &self.vk
     }
 }
@@ -168,7 +167,7 @@ impl MidnightVK {
 pub struct MidnightPK<R: Relation> {
     k: u8,
     relation: R,
-    pk: ProvingKey<midnight_curves::Fq, KZGCommitmentScheme<midnight_curves::Bls12>>,
+    pk: ProvingKey<midnight_curves::Fq, MidnightPCS<midnight_curves::Bls12>>,
 }
 
 impl<Rel: Relation> MidnightPK<Rel> {
@@ -225,9 +224,7 @@ impl<Rel: Relation> MidnightPK<Rel> {
     }
 
     /// The underlying midnight-proofs proving key.
-    pub fn pk(
-        &self,
-    ) -> &ProvingKey<midnight_curves::Fq, KZGCommitmentScheme<midnight_curves::Bls12>> {
+    pub fn pk(&self) -> &ProvingKey<midnight_curves::Fq, MidnightPCS<midnight_curves::Bls12>> {
         &self.pk
     }
 }
@@ -624,7 +621,7 @@ where
             let mut transcript = CircuitTranscript::init_from_bytes(proof);
             let dual_msm = prepare::<
                 midnight_curves::Fq,
-                KZGCommitmentScheme<midnight_curves::Bls12>,
+                MidnightPCS<midnight_curves::Bls12>,
                 CircuitTranscript<H>,
             >(
                 &vk.vk,
@@ -677,10 +674,7 @@ pub fn cs_degree(arch: ZkStdLibArch) -> usize {
 /// computed automatically.
 pub fn cost_model<R: Relation>(relation: &R, k: Option<u32>) -> CircuitModel {
     let circuit = MidnightCircuit::from_relation(relation, k);
-    circuit_model::<_, KZGCommitmentScheme<midnight_curves::Bls12>>(
-        &circuit,
-        NB_COMMITTED_INSTANCES,
-    )
+    circuit_model::<_, MidnightPCS<midnight_curves::Bls12>>(&circuit, NB_COMMITTED_INSTANCES)
 }
 
 /// Finds the optimal `k` (log2 of the circuit size) for the given relation.

--- a/zk_stdlib/src/lib.rs
+++ b/zk_stdlib/src/lib.rs
@@ -79,6 +79,7 @@ use midnight_curves::{
     k256::{self as k256_mod, K256},
     p256::{self as p256_mod, P256},
 };
+pub use midnight_proofs::MidnightPCS;
 use midnight_proofs::{
     circuit::Layouter,
     plonk::{ConstraintSystem, Error},

--- a/zk_stdlib/src/utils/plonk_api.rs
+++ b/zk_stdlib/src/utils/plonk_api.rs
@@ -31,7 +31,8 @@ use midnight_proofs::{
         params::{ParamsKZG, ParamsVerifierKZG},
     },
     plonk::{
-        Circuit, Error, ProvingKey, VerifyingKey, create_proof, keygen_pk, keygen_vk, prepare,
+        Circuit, Error, ProvingKey, VerifyingKey, create_proof, keygen_pk, keygen_vk,
+        max_committed_degree, prepare,
     },
     transcript::{CircuitTranscript, Hashable, Sampleable, Transcript, TranscriptHash},
     utils::SerdeFormat,
@@ -258,25 +259,26 @@ pub enum SrsSource {
 /// Loads an SRS (over BLS12-381) for the given circuit size `k` and
 /// constraint-system degree `cs_degree`.
 ///
-/// The monomial basis is sized via the active PCS's
-/// [`PolynomialCommitmentScheme::srs_monomial_blowup`]: a blow-up factor of
-/// `1` keeps the monomial basis at the Lagrange size `2^k`; a blow-up of `B`
-/// extends it to `2^k · B`. The Lagrange basis stays at size `2^k`.
+/// The SRS is sized to hold the largest polynomial the protocol commits
+/// ([`max_committed_degree`]), as transformed by the commitment scheme
+/// ([`PolynomialCommitmentScheme::internal_degree`]). When that exceeds the
+/// circuit domain, the monomial basis is extended by splicing in a larger SRS;
+/// the Lagrange basis stays at size `2^k`.
 pub fn load_srs(source: SrsSource, k: u32, cs_degree: usize) -> ParamsKZG<Bls12> {
     let fetch = |k| match source {
         SrsSource::Filecoin => filecoin_srs(k),
         SrsSource::Midnight => midnight_srs(k),
     };
 
-    let blowup = <KZGCommitmentScheme<Bls12>>::srs_monomial_blowup(cs_degree);
-    assert_ne!(blowup, 0, "srs blowup should be >= 1");
+    let degree =
+        <KZGCommitmentScheme<Bls12>>::internal_degree(k, max_committed_degree(k, cs_degree));
+    let srs_k = (degree + 1).next_power_of_two().ilog2();
+
     let base = fetch(k);
-    if blowup == 1 {
+    if srs_k <= k {
         base
     } else {
-        let extended_k = k + (blowup as f64).log2().ceil() as u32;
-        let extended = fetch(extended_k);
-        base.with_extended_monomial(extended)
+        base.with_extended_monomial(fetch(srs_k))
     }
 }
 

--- a/zk_stdlib/src/utils/plonk_api.rs
+++ b/zk_stdlib/src/utils/plonk_api.rs
@@ -25,9 +25,10 @@ use std::{
 
 use midnight_curves::Bls12;
 use midnight_proofs::{
+    MidnightPCS,
     pcs::{
         Guard, PolynomialCommitmentScheme,
-        kzg::{KZGCommitmentScheme, commitment::KZGMultiCommitment},
+        kzg::commitment::KZGMultiCommitment,
         params::{ParamsKZG, ParamsVerifierKZG},
     },
     plonk::{
@@ -59,7 +60,7 @@ macro_rules! plonk_api {
             pub fn setup_vk(
                 params: &ParamsKZG<$engine>,
                 circuit: &Relation,
-            ) -> VerifyingKey<$native, KZGCommitmentScheme<$engine>> {
+            ) -> VerifyingKey<$native, MidnightPCS<$engine>> {
                 #[cfg(test)]
                 let start = Instant::now();
                 let vk = keygen_vk(params, circuit).expect("keygen_vk should not fail");
@@ -72,8 +73,8 @@ macro_rules! plonk_api {
             /// PLONK PK setup for the given circuit.
             pub fn setup_pk(
                 circuit: &Relation,
-                vk: &VerifyingKey<$native, KZGCommitmentScheme<$engine>>,
-            ) -> ProvingKey<$native, KZGCommitmentScheme<$engine>> {
+                vk: &VerifyingKey<$native, MidnightPCS<$engine>>,
+            ) -> ProvingKey<$native, MidnightPCS<$engine>> {
                 #[cfg(test)]
                 let start = Instant::now();
                 let pk = keygen_pk(vk.clone(), circuit).expect("keygen_pk should not fail");
@@ -86,7 +87,7 @@ macro_rules! plonk_api {
             /// PLONK proving algorithm.
             pub fn prove<H>(
                 params: &ParamsKZG<$engine>,
-                pk: &ProvingKey<$native, KZGCommitmentScheme<$engine>>,
+                pk: &ProvingKey<$native, MidnightPCS<$engine>>,
                 circuit: &Relation,
                 nb_instance_commitments: usize,
                 pi: &[&[$native]],
@@ -101,12 +102,7 @@ macro_rules! plonk_api {
                 let start = Instant::now();
                 let proof = {
                     let mut transcript = CircuitTranscript::init();
-                    create_proof::<
-                        $native,
-                        KZGCommitmentScheme<$engine>,
-                        CircuitTranscript<H>,
-                        Relation,
-                    >(
+                    create_proof::<$native, MidnightPCS<$engine>, CircuitTranscript<H>, Relation>(
                         params,
                         pk,
                         circuit,
@@ -130,7 +126,7 @@ macro_rules! plonk_api {
             /// PLONK verification algorithm.
             pub fn verify<H>(
                 params_verifier: &ParamsVerifierKZG<$engine>,
-                vk: &VerifyingKey<$native, KZGCommitmentScheme<$engine>>,
+                vk: &VerifyingKey<$native, MidnightPCS<$engine>>,
                 instance_commitments: &[KZGMultiCommitment<$engine>],
                 pi: &[&[$native]],
                 proof: &[u8],
@@ -144,7 +140,7 @@ macro_rules! plonk_api {
 
                 #[cfg(test)]
                 let start = Instant::now();
-                let res = prepare::<$native, KZGCommitmentScheme<$engine>, CircuitTranscript<H>>(
+                let res = prepare::<$native, MidnightPCS<$engine>, CircuitTranscript<H>>(
                     vk,
                     instance_commitments,
                     pi,
@@ -270,8 +266,7 @@ pub fn load_srs(source: SrsSource, k: u32, cs_degree: usize) -> ParamsKZG<Bls12>
         SrsSource::Midnight => midnight_srs(k),
     };
 
-    let degree =
-        <KZGCommitmentScheme<Bls12>>::internal_degree(k, max_committed_degree(k, cs_degree));
+    let degree = <MidnightPCS<Bls12>>::internal_degree(k, max_committed_degree(k, cs_degree));
     let srs_k = (degree + 1).next_power_of_two().ilog2();
 
     let base = fetch(k);


### PR DESCRIPTION
Last bits of refactoring in the library before implementing `PolynomialCommitmentScheme` for Fflonk.

1. Removed the function `srs_monomial_blowup` from the PCS trait as per @miguel-ambrona 's suggestions. 
2. Introducing a `MidnightPCS` alias for `KZGCommitmentScheme`. This way, once Fflonk is implemented, using it effectively will only be one line change. For now, some "facade" aliases are also defined for the external `blake2b_halo2` so that its compilation does not break, but ideally, we should use the name `MidnightPCS` there too. This way, it will be agnostic in the changes of PCS's.
3. Extracting the core of `multi_open` and `multi_prepare` that Fflonk will need. In short, there is a new file `multi_open.rs` that is a copy paste of the core code of `multi_open` and `multi_prepare` (minor modifs like updated some variable names e.g.), that is called in the prover/verifier codes, and that Fflonk will a priori not touch.

Each point above is one commit.