### PR TITLE
[Fflonk PR6] Implement PCS trait for fflonk

### DIFF
--- a/proofs/CHANGELOG.md
+++ b/proofs/CHANGELOG.md
@@ -20,6 +20,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * Derive `Ord` on `PolynomialLabel`, making it usable as a `BTreeMap` key [#430](https://github.com/midnightntwrk/midnight-zk/pull/430)
 * `commitment_byte_length` method on the `PolynomialCommitmentScheme` trait, defaulting to the per-commitment size times `n` and overridable for schemes that fold polynomials into a single proof element [#440](https://github.com/midnightntwrk/midnight-zk/pull/440)
 * `circuit_model_with` taking an explicit commitment-size closure [#440](https://github.com/midnightntwrk/midnight-zk/pull/440)
+* `fflonk` polynomial commitment scheme implem [#511](https://github.com/midnightntwrk/midnight-zk/pull/511)
 
 ### Fixed
 * Fix verifier evals bug [#356](https://github.com/midnightntwrk/midnight-zk/pull/356)

--- a/proofs/src/pcs/fflonk/bundle_expansion.rs
+++ b/proofs/src/pcs/fflonk/bundle_expansion.rs
@@ -1,0 +1,349 @@
+//! Bundle pre-expansion data structures and pure helpers.
+//!
+//! `FflonkScheme::multi_open` and `FflonkScheme::multi_prepare` each run a
+//! fflonk-specific phase before the standard multi-open argument:
+//!
+//! - Prover (`multi_open`): classify queries into bundles, materialise the
+//!   combined polynomial `g` for each `t > 1` bundle, compute the opening
+//!   point-set unions, expand into synthetic queries on `g` at the `t`-th roots
+//!   of each logical opening point.
+//! - Verifier (`multi_prepare`): classify queries into bundles, collect the
+//!   per-(slot, logical) evaluations the prover wrote, reconstruct `g(root)`
+//!   for each `t`-th root via Lemma 5.1 of the fflonk paper.
+//!
+//! The two sides must produce identical enumerations of (bundle, slot, point)
+//! so the transcript I/O matches.
+
+use std::{collections::HashMap, hash::Hash};
+
+use ff::{Field, WithSmallOrderMulGroup};
+use midnight_curves::pairing::MultiMillerLoop;
+use rustc_hash::FxHashMap;
+
+use super::{
+    FflonkScheme,
+    commitment::FflonkCommitment,
+    math::{eval_claims_as_poly, primitive_root_of_unity, roots as t_th_roots, t_th_root},
+    partition,
+};
+use crate::{
+    pcs::msm::MSMKZG,
+    poly::{
+        Error, ProverQuery,
+        query::{PolynomialLabel, VerifierQuery},
+    },
+    utils::{
+        arithmetic::{CurveAffine, CurveExt, MSM},
+        helpers::ProcessedSerdeObject,
+    },
+};
+
+/// Per-bundle prover-side preparation. Holds everything `multi_open` needs to
+/// (a) write over-opening evals to the transcript and (b) emit the synthetic
+/// queries on `g`.
+pub(super) struct MultiOpenPrepData<F> {
+    /// Index into the prover's `bundle_indices` vec, used to look up `g_poly`
+    /// and the canonical labels.
+    pub(super) bundle_idx: usize,
+    /// Synthetic label shared with the verifier (`fflonk_bundle[advice_0]`).
+    pub(super) synth_label: PolynomialLabel,
+    /// The bundle's logical packing factor `t = bundle_t(real_count, t_max)`.
+    /// It exceeds the number of real polynomials in the bundle when the
+    /// trailing bundle has padded zero slots.
+    pub(super) t: usize,
+    /// Distinct logical points seen for this bundle, sorted. The synthetic
+    /// queries on `g` are emitted at the `t` t-th roots of each.
+    pub(super) union_logicals: Vec<F>,
+    /// `(slot, logical_point)` pairs the prover must over-open and write to the
+    /// transcript, in [`missing_openings`] order (so the verifier reads them in
+    /// the same order). Slots are always real slot indices (in `[0,
+    /// real_count)`); pad slots are never over-opened, their eval being known
+    /// to be zero.
+    pub(super) missing: Vec<(usize, F)>,
+}
+
+/// Per-bundle verifier-side accumulator. Holds the bundle's G1 commitment, the
+/// canonical labels (so slot indices are well-defined), the `(slot, point)`
+/// pairs the verifier saw in queries order, and the eval lookup populated both
+/// from the original queries and from the over-opening reads.
+pub(super) struct BundleAcc<E: MultiMillerLoop> {
+    pub(super) bundle_g1: E::G1,
+    /// Real labels of the bundle's polynomials, in canonical order. Length
+    /// equals `real_count`, which is less than `t` for a padded trailing
+    /// bundle.
+    pub(super) canonical_labels: Vec<PolynomialLabel>,
+    /// Logical bundle size, `bundle_t(real_count, t_max)`. Slots
+    /// `[canonical_labels.len(), t)` are pad slots whose evals are implicitly
+    /// zero (never written / read on the transcript).
+    pub(super) t: usize,
+    pub(super) pairs: Vec<(usize, E::Fr)>,
+    pub(super) evals: FxHashMap<(usize, E::Fr), E::Fr>,
+}
+
+/// The `(index, point)` openings missing for every key of `pairs` to be opened
+/// at the union of all points, where `index` is the position of the key's first
+/// occurrence. Output order is deterministic (insertion order), so prover and
+/// verifier agree on the transcript order.
+///
+/// Every slot of a bundle must be opened at every logical point the bundle is
+/// opened at, since the verifier reconstructs `g` at a root from the
+/// evaluations of *all* slots. This is why the union is over all points, unlike
+/// `fewer-point-sets`'s
+/// `compute_dummy_queries`,
+/// which pads towards multi-point keys only.
+pub(super) fn missing_openings<K: PartialEq, P: PartialEq + Clone>(
+    pairs: &[(K, P)],
+) -> Vec<(usize, P)> {
+    // Group by key, tracking each key's first occurrence index.
+    let mut groups: Vec<(usize, Vec<P>)> = vec![];
+    for (i, (key, point)) in pairs.iter().enumerate() {
+        match groups.iter_mut().find(|(idx, _)| pairs[*idx].0 == *key) {
+            Some((_, points)) if !points.contains(point) => points.push(point.clone()),
+            Some(_) => panic!("duplicate (key, point) pair in missing_openings input"),
+            None => groups.push((i, vec![point.clone()])),
+        }
+    }
+
+    let mut union: Vec<P> = vec![];
+    for (_, points) in &groups {
+        for p in points {
+            if !union.contains(p) {
+                union.push(p.clone());
+            }
+        }
+    }
+
+    let mut missing = vec![];
+    for (idx, existing) in &groups {
+        for p in &union {
+            if !existing.contains(p) {
+                missing.push((*idx, p.clone()));
+            }
+        }
+    }
+    missing
+}
+
+/// Checks that the bundle layout a commitment carries is the one
+/// `partition::partition` derives from its labels at `t_max`.
+///
+/// The per-bundle sizes travel on the wire but are *not* absorbed into the
+/// transcript (only the committed points are), so on their own they are not
+/// bound by Fiat-Shamir. They are bound here instead: `t_max` comes from the
+/// `t_max_log` the prover wrote to the transcript, which *is* hashed, and the
+/// labels come from the verifier itself. The sizes are therefore only a parsing
+/// aid, telling the reader how many points to consume, and any deviation from
+/// the partition they must encode is rejected.
+pub(super) fn check_bundle_layout<E: MultiMillerLoop>(
+    pairs: &[(E::G1, Vec<PolynomialLabel>)],
+    t_max: usize,
+) -> Result<(), Error> {
+    let labels: Vec<PolynomialLabel> =
+        pairs.iter().flat_map(|(_, labels)| labels.iter().cloned()).collect();
+    let expected = partition::partition(t_max, &labels);
+    let matches = expected.len() == pairs.len()
+        && expected
+            .iter()
+            .zip(pairs)
+            .all(|(bundle, (_, labels))| bundle.len() == labels.len());
+    matches.then_some(()).ok_or(Error::OpeningError)
+}
+
+/// Build the prover-side per-bundle preparation list, sorted by `synth_label`
+/// so prover and verifier visit bundles in the same order. Pure function, no
+/// transcript I/O.
+pub(super) fn build_prover_multi_pre<E: MultiMillerLoop>(
+    bundle_indices: &[Vec<usize>],
+    all_labels: &[PolynomialLabel],
+    t_max: usize,
+    queries: &[ProverQuery<E::Fr>],
+) -> Vec<MultiOpenPrepData<E::Fr>>
+where
+    E::Fr: Ord,
+{
+    let mut multi_pre: Vec<MultiOpenPrepData<E::Fr>> = Vec::with_capacity(bundle_indices.len());
+    for (bundle_idx, indices) in bundle_indices.iter().enumerate() {
+        let t = partition::bundle_t(indices.len(), t_max);
+        if t <= 1 {
+            continue;
+        }
+        let bundle_labels: Vec<PolynomialLabel> =
+            indices.iter().map(|&i| all_labels[i].clone()).collect();
+        let synth_label = FflonkCommitment::<E>::synthetic_bundle_label(&bundle_labels);
+
+        // `(slot, point)` pairs in queries order.
+        let pairs: Vec<(usize, E::Fr)> = queries
+            .iter()
+            .filter_map(|q| {
+                let slot = bundle_labels.iter().position(|l| l == &q.label)?;
+                Some((slot, q.point))
+            })
+            .collect();
+        let missing: Vec<(usize, E::Fr)> = missing_openings(&pairs)
+            .into_iter()
+            .map(|(idx, point)| (pairs[idx].0, point))
+            .collect();
+
+        let mut union_logicals: Vec<E::Fr> = vec![];
+        for &(_, p) in &pairs {
+            if !union_logicals.contains(&p) {
+                union_logicals.push(p);
+            }
+        }
+        union_logicals.sort();
+
+        multi_pre.push(MultiOpenPrepData {
+            bundle_idx,
+            synth_label,
+            t,
+            union_logicals,
+            missing,
+        });
+    }
+    multi_pre.sort_by(|a, b| a.synth_label.to_string().cmp(&b.synth_label.to_string()));
+    multi_pre
+}
+
+/// Classify the verifier's queries into:
+/// - `multi_bundles_sorted`: `(synth_label, BundleAcc)` pairs, sorted by
+///   `synth_label` so the over-opening read order matches the prover's write
+///   order.
+/// - `label_to_msm`: per-label MSM source, populated for singletons and
+///   `Linear` bundles (the `t > 1` bundle MSMs are added by the caller, after
+///   the over-opening reads).
+/// - `singleton_triples`: `(label, point, eval)` triples for `t = 1`
+///   commitments and `Linear`.
+///
+/// Pure function, no transcript I/O. Mirror of [`build_prover_multi_pre`].
+#[allow(clippy::type_complexity)]
+pub(super) fn classify_verifier_queries<'com, E>(
+    queries: &[VerifierQuery<'com, E::Fr, FflonkScheme<E>>],
+    // Bundling ceiling for this proof (`2^t_max_log`), read from the transcript
+    // by `multi_prepare`. Must equal the `t_max` the prover used in
+    // `commit`/`multi_open`, or the reconstructed `bundle_t` (and thus the whole
+    // opening) diverges.
+    t_max: usize,
+) -> (
+    Vec<(PolynomialLabel, BundleAcc<E>)>,
+    HashMap<PolynomialLabel, MSMKZG<E>>,
+    Vec<(PolynomialLabel, E::Fr, E::Fr)>,
+)
+where
+    E: MultiMillerLoop,
+    E::Fr: WithSmallOrderMulGroup<3> + Hash,
+    E::G1: Default + CurveExt<ScalarExt = E::Fr> + ProcessedSerdeObject,
+    E::G1Affine: Default + CurveAffine<ScalarExt = E::Fr, CurveExt = E::G1>,
+    FflonkCommitment<E>: 'com,
+{
+    let mut multi_bundles: FxHashMap<PolynomialLabel, BundleAcc<E>> = FxHashMap::default();
+    let mut label_to_msm: HashMap<PolynomialLabel, MSMKZG<E>> = HashMap::new();
+    let mut singleton_triples: Vec<(PolynomialLabel, E::Fr, E::Fr)> = Vec::new();
+
+    for q in queries.iter() {
+        match q.commitment {
+            FflonkCommitment::Linear(points, scalars, labels) => {
+                // Linearization commitment: pass-through, expanded MSM with all
+                // (point, scalar, label) terms.
+                singleton_triples.push((q.label.clone(), q.point, q.eval));
+                let mut msm = MSMKZG::init();
+                for ((p, s), label) in points.iter().zip(scalars).zip(labels) {
+                    msm.append_term(*s, *p, label.clone());
+                }
+                label_to_msm.insert(q.label.clone(), msm);
+            }
+            FflonkCommitment::Regular(pairs) => {
+                let (p, labels) = FflonkCommitment::<E>::find_bundle(pairs, &q.label);
+                if labels.len() == 1 {
+                    // Singleton (t=1): pass-through, single-term MSM.
+                    singleton_triples.push((q.label.clone(), q.point, q.eval));
+                    let mut msm = MSMKZG::init();
+                    msm.append_term(E::Fr::ONE, *p, q.label.clone());
+                    label_to_msm.insert(q.label.clone(), msm);
+                } else {
+                    // `t > 1` bundle: accumulate per (synthetic label, logical point).
+                    // `labels` holds only the real labels; the logical bundle size `t`
+                    // is derived from their count, so a trailing bundle has pad slots
+                    // `[labels.len(), t)` whose evals are implicitly zero.
+                    let t = partition::bundle_t(labels.len(), t_max);
+                    let synth = FflonkCommitment::<E>::synthetic_bundle_label(labels);
+                    let acc = multi_bundles.entry(synth).or_insert_with(|| BundleAcc::<E> {
+                        bundle_g1: *p,
+                        canonical_labels: labels.clone(),
+                        t,
+                        pairs: Vec::new(),
+                        evals: FxHashMap::default(),
+                    });
+                    let slot = acc
+                        .canonical_labels
+                        .iter()
+                        .position(|l| l == &q.label)
+                        .expect("fflonk multi_prepare: query label missing from its bundle");
+                    acc.pairs.push((slot, q.point));
+                    acc.evals.insert((slot, q.point), q.eval);
+                }
+            }
+        }
+    }
+
+    let mut multi_bundles_sorted: Vec<(PolynomialLabel, BundleAcc<E>)> =
+        multi_bundles.into_iter().collect();
+    multi_bundles_sorted.sort_by(|a, b| a.0.to_string().cmp(&b.0.to_string()));
+
+    (multi_bundles_sorted, label_to_msm, singleton_triples)
+}
+
+/// Reconstruct the synthetic `(synth_label, root, g(root))` triples for one
+/// multi-poly bundle, using Lemma 5.1's forward Vandermonde
+/// ([`eval_claims_as_poly`]) to compute `g(root)` from the per-slot evaluations
+/// at each distinct logical point.
+///
+/// Caller must have filled `acc.evals` with every `(slot, logical)` pair for
+/// real slots (slots `< acc.canonical_labels.len()`) before calling this. Pad
+/// slots are zero by construction and not present in `acc.evals`; this function
+/// fills them with `E::Fr::ZERO`.
+pub(super) fn synth_triples_for_bundle<E: MultiMillerLoop>(
+    synth_label: &PolynomialLabel,
+    acc: &BundleAcc<E>,
+    t_th_root_cache: &mut FxHashMap<(E::Fr, usize), E::Fr>,
+) -> Vec<(PolynomialLabel, E::Fr, E::Fr)>
+where
+    E::Fr: Hash + Ord,
+{
+    let omega_t = primitive_root_of_unity::<E::Fr>(acc.t);
+    let real_count = acc.canonical_labels.len();
+
+    // Sorted, like the prover's `union_logicals`, so both sides emit the
+    // synthetic queries in the same order.
+    let mut union_logicals: Vec<E::Fr> = vec![];
+    for &(_, p) in &acc.pairs {
+        if !union_logicals.contains(&p) {
+            union_logicals.push(p);
+        }
+    }
+    union_logicals.sort();
+
+    let mut triples: Vec<(PolynomialLabel, E::Fr, E::Fr)> = Vec::new();
+    for logical in union_logicals {
+        // `t_th_root(logical, t)` only depends on the pair, but the function is called
+        // per (bundle, logical) and bundles typically share logical points (a point
+        // and its rotations), so the cache cuts redundant `log2(t)` sqrt chains.
+        let z = *t_th_root_cache
+            .entry((logical, acc.t))
+            .or_insert_with(|| t_th_root(logical, acc.t));
+        let slot_evals: Vec<E::Fr> = (0..acc.t)
+            .map(|slot| {
+                if slot < real_count {
+                    *acc.evals.get(&(slot, logical)).expect(
+                        "fflonk multi_prepare: over-opening should have filled every real slot",
+                    )
+                } else {
+                    E::Fr::ZERO
+                }
+            })
+            .collect();
+        for r in t_th_roots(z, omega_t, acc.t) {
+            triples.push((synth_label.clone(), r, eval_claims_as_poly(&slot_evals, r)));
+        }
+    }
+    triples
+}

--- a/proofs/src/pcs/fflonk/commitment.rs
+++ b/proofs/src/pcs/fflonk/commitment.rs
@@ -11,13 +11,20 @@
 //!   collapsed to one group element only when the guard verifies. It is never
 //!   serialized or hashed.
 
-use std::ops::{Add, Mul};
+use std::{
+    io::{self, Read},
+    ops::{Add, Mul},
+};
 
 use ff::Field;
 use group::Group;
 use midnight_curves::pairing::MultiMillerLoop;
 
-use crate::poly::query::PolynomialLabel;
+use crate::{
+    poly::query::PolynomialLabel,
+    transcript::{Hashable, TranscriptHash},
+    utils::helpers::{ProcessedSerdeObject, SerdeFormat},
+};
 
 /// A fflonk commitment: the output of a single `commit` call.
 #[derive(Clone, Debug)]
@@ -58,6 +65,18 @@ impl<E: MultiMillerLoop> FflonkCommitment<E> {
             },
             Self::Linear(..) => None,
         }
+    }
+
+    /// Bundle count as the `u8` written on the wire, so a commitment may hold
+    /// at most 255 bundles.
+    fn count_u8(len: usize) -> u8 {
+        u8::try_from(len).expect("FflonkCommitment holds more than 255 bundles.")
+    }
+
+    /// Polynomial count of a single bundle as the `u8` written on the wire.
+    /// Bounded by `t_max = 1 << FFLONK_T_MAX_LOG`, well under 255.
+    fn size_u8(size: usize) -> u8 {
+        u8::try_from(size).expect("fflonk bundle packs more than 255 polynomials.")
     }
 
     /// Decomposes into `(points, scalars, labels)` for `Add`/`Mul`. A single
@@ -105,6 +124,131 @@ impl<E: MultiMillerLoop> FflonkCommitment<E> {
     }
 }
 
+impl<E: MultiMillerLoop> FflonkCommitment<E>
+where
+    E::G1: Default + ProcessedSerdeObject,
+{
+    /// Parses the wire format: a bundle count, then per bundle the number of
+    /// polynomials it packs and its point. Labels are not on the wire, so each
+    /// bundle comes back with that count alone; see the wire-format doc on the
+    /// [`ProcessedSerdeObject`] impl.
+    fn read_wire<R: io::Read>(
+        reader: &mut R,
+        format: SerdeFormat,
+    ) -> io::Result<Vec<(E::G1, usize)>> {
+        let mut byte = [0u8; 1];
+        reader.read_exact(&mut byte)?;
+        let nb_bundles = byte[0] as usize;
+        (0..nb_bundles)
+            .map(|_| {
+                reader.read_exact(&mut byte)?;
+                let size = byte[0] as usize;
+                Ok((E::G1::read(reader, format)?, size))
+            })
+            .collect()
+    }
+
+    /// Reads a commitment and tags each bundle with its share of `labels`, in a
+    /// single pass. The chunk boundaries come from the per-bundle sizes on the
+    /// wire, since the prover's effective bundling factor depends on the SRS,
+    /// which the verifier cannot inspect. The ordering within those chunks is
+    /// `t_max`-independent and re-derived here through
+    /// [`canonical_order`](super::partition::canonical_order), so both sides
+    /// agree on the slot assignment whatever order `labels` are supplied in.
+    ///
+    /// A commitment whose sizes do not add up to `labels.len()` is rejected as
+    /// invalid data: the verifier expects a different number of polynomials
+    /// than the prover committed to.
+    pub(super) fn read_labeled<R: io::Read>(
+        reader: &mut R,
+        format: SerdeFormat,
+        labels: &[PolynomialLabel],
+    ) -> io::Result<Self> {
+        let ordered: Vec<PolynomialLabel> = super::partition::canonical_order(labels)
+            .into_iter()
+            .map(|i| labels[i].clone())
+            .collect();
+        let mut rest = ordered.as_slice();
+
+        let pairs = Self::read_wire(reader, format)?
+            .into_iter()
+            .map(|(point, size)| {
+                if size > rest.len() {
+                    return Err(io::Error::new(
+                        io::ErrorKind::InvalidData,
+                        format!(
+                            "FflonkCommitment: bundle packs {size} polynomials but only {} labels \
+                             are left",
+                            rest.len()
+                        ),
+                    ));
+                }
+                let (chunk, tail) = rest.split_at(size);
+                rest = tail;
+                Ok((point, chunk.to_vec()))
+            })
+            .collect::<io::Result<Vec<_>>>()?;
+
+        if !rest.is_empty() {
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidData,
+                format!(
+                    "FflonkCommitment: {} labels were supplied but the commitment carries fewer \
+                     polynomials",
+                    labels.len()
+                ),
+            ));
+        }
+        Ok(Self::Regular(pairs))
+    }
+
+    /// Attaches `labels` to a commitment read off a transcript, whose bundles
+    /// carry `NoLabel` placeholders because `Hashable::read` takes no labels.
+    /// The keys path parses and tags in one pass instead, see
+    /// [`read_labeled`](Self::read_labeled).
+    ///
+    /// The chunk boundaries come from the per-bundle sizes carried on the wire:
+    /// the prover's effective bundling factor depends on the SRS, which the
+    /// verifier cannot inspect. The ordering within those chunks is
+    /// `t_max`-independent and re-derived here through
+    /// [`canonical_order`](super::partition::canonical_order), so both sides
+    /// agree on the slot assignment whatever order `labels` are supplied in.
+    ///
+    /// # Panics
+    /// If `labels.len()` differs from the polynomial count the commitment
+    /// carries, i.e. the verifier expects a different number of polynomials
+    /// than the prover committed to.
+    pub(super) fn with_labels(self, labels: &[PolynomialLabel]) -> Self {
+        match self {
+            Self::Regular(pairs) => {
+                let total: usize = pairs.iter().map(|(_, l)| l.len()).sum();
+                assert_eq!(
+                    total,
+                    labels.len(),
+                    "FflonkCommitment: commitment carries {total} polynomials but {} labels were \
+                     supplied",
+                    labels.len(),
+                );
+                let ordered: Vec<PolynomialLabel> = super::partition::canonical_order(labels)
+                    .into_iter()
+                    .map(|i| labels[i].clone())
+                    .collect();
+                let mut rest = ordered.as_slice();
+                let new_pairs = pairs
+                    .into_iter()
+                    .map(|(p, placeholders)| {
+                        let (chunk, tail) = rest.split_at(placeholders.len());
+                        rest = tail;
+                        (p, chunk.to_vec())
+                    })
+                    .collect();
+                Self::Regular(new_pairs)
+            }
+            Self::Linear(..) => panic!("FflonkCommitment::Linear is never deserialized"),
+        }
+    }
+}
+
 // Manual `PartialEq` (deriving would demand `E: PartialEq`; only
 // `E::G1`/`E::Fr` are ever compared). Equality is on the committed points alone
 // (plus a `Linear`'s scalars): a commitment's identity is its curve points, and
@@ -131,6 +275,79 @@ where
 {
     fn default() -> Self {
         Self::Regular(vec![(E::G1::default(), vec![PolynomialLabel::NoLabel])])
+    }
+}
+
+/// Wire format: `u8 num_bundles`, then per bundle a `u8` count of the
+/// polynomials it packs followed by its G1 point. The counts make the grouping
+/// self-describing, which the verifier needs: the prover's effective bundling
+/// factor depends on the SRS and is not recoverable verifier-side. Labels
+/// themselves are never encoded, so `read` is unimplemented; commitments are
+/// read through `read_commitment` (from a transcript) or
+/// `deserialize_commitment` (from keys), whose `labels` argument tags each
+/// polynomial.
+impl<E: MultiMillerLoop> ProcessedSerdeObject for FflonkCommitment<E>
+where
+    E::G1: Default + ProcessedSerdeObject,
+{
+    fn read<R: io::Read>(_reader: &mut R, _format: SerdeFormat) -> io::Result<Self> {
+        unimplemented!(
+            "use `PolynomialCommitmentScheme::deserialize_commitment` to read a labeled commitment"
+        )
+    }
+
+    fn write<W: io::Write>(&self, writer: &mut W, format: SerdeFormat) -> io::Result<()> {
+        match self {
+            Self::Regular(pairs) => {
+                writer.write_all(&[Self::count_u8(pairs.len())])?;
+                for (p, labels) in pairs {
+                    writer.write_all(&[Self::size_u8(labels.len())])?;
+                    p.write(writer, format)?;
+                }
+                Ok(())
+            }
+            Self::Linear(..) => panic!("FflonkCommitment::Linear cannot be serialized"),
+        }
+    }
+
+    fn byte_length(&self, format: SerdeFormat) -> usize {
+        match self {
+            Self::Regular(pairs) => {
+                1 + pairs.iter().map(|(p, _)| 1 + p.byte_length(format)).sum::<usize>()
+            }
+            Self::Linear(..) => panic!("FflonkCommitment::Linear has no fixed byte length"),
+        }
+    }
+}
+
+impl<H: TranscriptHash, E: MultiMillerLoop> Hashable<H> for FflonkCommitment<E>
+where
+    E::G1: Hashable<H> + Default + ProcessedSerdeObject,
+{
+    fn to_input(&self) -> H::Input {
+        match self {
+            Self::Regular(pairs) => pairs.iter().flat_map(|(p, _)| p.to_input()).collect(),
+            Self::Linear(..) => panic!("FflonkCommitment::Linear cannot be hashed"),
+        }
+    }
+
+    // `to_bytes` / `read` share the `ProcessedSerdeObject` wire format:
+    // `SerdeFormat::Processed` is the compressed `GroupEncoding` the transcript
+    // uses, so the framing and per-point bytes are identical. Delegate rather
+    // than duplicate. (`to_input` cannot: it yields `H::Input`, not bytes.)
+    fn to_bytes(&self) -> Vec<u8> {
+        let mut bytes = Vec::new();
+        <Self as ProcessedSerdeObject>::write(self, &mut bytes, SerdeFormat::Processed)
+            .expect("writing to a Vec is infallible");
+        bytes
+    }
+
+    fn read(buffer: &mut impl Read) -> io::Result<Self> {
+        let pairs = Self::read_wire(buffer, SerdeFormat::Processed)?
+            .into_iter()
+            .map(|(point, size)| (point, vec![PolynomialLabel::NoLabel; size]))
+            .collect();
+        Ok(Self::Regular(pairs))
     }
 }
 

--- a/proofs/src/pcs/fflonk/commitment.rs
+++ b/proofs/src/pcs/fflonk/commitment.rs
@@ -1,0 +1,183 @@
+//! fflonk commitment type.
+//!
+//! A [`FflonkCommitment`] is the output of one `commit` call.
+//!
+//! - [`FflonkCommitment::Regular`] variant holds one G1 point per bundle
+//!   produced by `partition`, each paired with the labels of the `t =
+//!   labels.len()` polynomials packed into it via `combine`.
+//! - [`FflonkCommitment::Linear`] is a lazy linear combination: a
+//!   verifier-internal deferred MSM `\sum scalars[i] points[i]` accumulated
+//!   symbolically by `Add`/`Mul` on single `t=1` bundles for linearization, and
+//!   collapsed to one group element only when the guard verifies. It is never
+//!   serialized or hashed.
+
+use std::ops::{Add, Mul};
+
+use ff::Field;
+use group::Group;
+use midnight_curves::pairing::MultiMillerLoop;
+
+use crate::poly::query::PolynomialLabel;
+
+/// A fflonk commitment: the output of a single `commit` call.
+#[derive(Clone, Debug)]
+pub enum FflonkCommitment<E: MultiMillerLoop> {
+    /// One `(point, labels)` pair per bundle, where `point` commits to the
+    /// `labels.len()` polynomials combined into it. The bundle is interpreted
+    /// as a combination of `t = labels.len().next_power_of_two()` polynomials
+    /// (unused slots zero-padded), since the `t`-th roots fflonk opens at
+    /// require `t` to be a power of two.
+    Regular(Vec<(E::G1, Vec<PolynomialLabel>)>),
+    /// Verifier-internal lazy linear combination `\sum scalars[i] * points[i]`
+    /// with per-term labels, produced by `Add`/`Mul` on `t=1` bundles. Never
+    /// serialized or hashed.
+    Linear(Vec<E::G1>, Vec<E::Fr>, Vec<PolynomialLabel>),
+}
+
+impl<E: MultiMillerLoop> FflonkCommitment<E> {
+    /// A commitment to the zero polynomial: a single singleton bundle at the
+    /// identity point, carrying `label`.
+    pub fn commitment_to_zero(label: PolynomialLabel) -> Self {
+        Self::Regular(vec![(E::G1::identity(), vec![label])])
+    }
+
+    /// Returns a reference to the inner curve point. Panics unless the
+    /// commitment is a single `Regular` bundle.
+    pub fn as_point(&self) -> &E::G1 {
+        self.single_point().expect("expected a single-bundle Regular FflonkCommitment")
+    }
+
+    /// Like [`as_point`](Self::as_point), but returns `None` instead of
+    /// panicking. Used on commitments read off the transcript, where a
+    /// malformed proof must be rejected rather than crash the verifier.
+    pub(super) fn single_point(&self) -> Option<&E::G1> {
+        match self {
+            Self::Regular(pairs) => match pairs.as_slice() {
+                [(point, _)] => Some(point),
+                _ => None,
+            },
+            Self::Linear(..) => None,
+        }
+    }
+
+    /// Decomposes into `(points, scalars, labels)` for `Add`/`Mul`. A single
+    /// `t=1` `Regular` bundle becomes a one-term combination with scalar `1`; a
+    /// `Linear` returns its parts unchanged. Panics on `t > 1`.
+    fn into_linear_parts(self) -> (Vec<E::G1>, Vec<E::Fr>, Vec<PolynomialLabel>) {
+        match self {
+            Self::Regular(pairs) => {
+                assert_eq!(
+                    pairs.len(),
+                    1,
+                    "Add/Mul on FflonkCommitment requires exactly one bundle"
+                );
+                let (p, labels) = pairs.into_iter().next().unwrap();
+                assert_eq!(
+                    labels.len(),
+                    1,
+                    "Add/Mul requires t=1; got t={}",
+                    labels.len()
+                );
+                (vec![p], vec![E::Fr::ONE], labels)
+            }
+            Self::Linear(points, scalars, labels) => (points, scalars, labels),
+        }
+    }
+
+    /// Locate the bundle inside a `Regular` commitment's `pairs` whose label
+    /// set contains `label`. Used by `FflonkScheme::multi_prepare` to
+    /// recover bundle structure from the verifier's commitment objects.
+    pub(super) fn find_bundle<'a>(
+        pairs: &'a [(E::G1, Vec<PolynomialLabel>)],
+        label: &PolynomialLabel,
+    ) -> &'a (E::G1, Vec<PolynomialLabel>) {
+        pairs
+            .iter()
+            .find(|(_, labels)| labels.contains(label))
+            .expect("fflonk multi_prepare: query label not found in any bundle of its commitment")
+    }
+
+    /// Canonical synthetic label for a `t > 1` bundle. Both prover and verifier
+    /// compute this for the same bundle.
+    pub(super) fn synthetic_bundle_label(bundle_labels: &[PolynomialLabel]) -> PolynomialLabel {
+        let first = bundle_labels.first().expect("fflonk: multi-poly bundle must be non-empty");
+        PolynomialLabel::Custom(format!("fflonk_bundle[{first}]"))
+    }
+}
+
+// Manual `PartialEq` (deriving would demand `E: PartialEq`; only
+// `E::G1`/`E::Fr` are ever compared). Equality is on the committed points alone
+// (plus a `Linear`'s scalars): a commitment's identity is its curve points, and
+// labels are routing metadata attached after reading.
+impl<E: MultiMillerLoop> PartialEq for FflonkCommitment<E>
+where
+    E::G1: PartialEq,
+    E::Fr: PartialEq,
+{
+    fn eq(&self, other: &Self) -> bool {
+        match (self, other) {
+            (Self::Regular(a), Self::Regular(b)) => {
+                a.len() == b.len() && a.iter().zip(b).all(|((p, _), (q, _))| p == q)
+            }
+            (Self::Linear(ps, rs, _), Self::Linear(qs, ss, _)) => ps == qs && rs == ss,
+            _ => false,
+        }
+    }
+}
+
+impl<E: MultiMillerLoop> Default for FflonkCommitment<E>
+where
+    E::G1: Default,
+{
+    fn default() -> Self {
+        Self::Regular(vec![(E::G1::default(), vec![PolynomialLabel::NoLabel])])
+    }
+}
+
+impl<E: MultiMillerLoop> Mul<E::Fr> for FflonkCommitment<E> {
+    type Output = Self;
+
+    /// Only valid for a single `t == 1` bundle (or an existing `Linear`).
+    /// Panics otherwise: a `t > 1` commitment cannot enter linearization, since
+    /// a scalar mul would scale all slots uniformly.
+    fn mul(self, scalar: E::Fr) -> Self {
+        match self {
+            Self::Linear(points, scalars, labels) => Self::Linear(
+                points,
+                scalars.into_iter().map(|s| s * scalar).collect(),
+                labels,
+            ),
+            committed => {
+                let (points, _, labels) = committed.into_linear_parts();
+                Self::Linear(points, vec![scalar], labels)
+            }
+        }
+    }
+}
+
+impl<E: MultiMillerLoop> Add for FflonkCommitment<E> {
+    type Output = Self;
+
+    /// Single `t == 1` bundles (or existing `Linear`s) fold into a `Linear`
+    /// deferred MSM for linearization. Two `t > 1` bundles with identical
+    /// layout (same size and labels) add homomorphically into a single
+    /// point, since `combine` and KZG commitment are both linear. Any other
+    /// `t > 1` combination panics.
+    fn add(self, other: Self) -> Self {
+        // Same-layout t>1 bundles: `commit(P) + commit(Q) = commit(P + Q)`,
+        // still a single point over the same slots.
+        if let (Self::Regular(a), Self::Regular(b)) = (&self, &other)
+            && let ([(pa, la)], [(pb, lb)]) = (a.as_slice(), b.as_slice())
+            && la.len() > 1
+            && la == lb
+        {
+            return Self::Regular(vec![(*pa + *pb, la.clone())]);
+        }
+        let (mut points, mut scalars, mut labels) = self.into_linear_parts();
+        let (other_points, other_scalars, other_labels) = other.into_linear_parts();
+        points.extend(other_points);
+        scalars.extend(other_scalars);
+        labels.extend(other_labels);
+        Self::Linear(points, scalars, labels)
+    }
+}

--- a/proofs/src/pcs/fflonk/math.rs
+++ b/proofs/src/pcs/fflonk/math.rs
@@ -1,0 +1,95 @@
+//! Curve-free fflonk math. Naming follows the
+//! [paper](https://eprint.iacr.org/2021/1167.pdf).
+
+use ff::{Field, PrimeField};
+
+/// Paper's `combine_t`: interleaves up to `t` coefficient slots of equal
+/// length `n` into `g` of length `t·n`, where `g[j·t + i] = slots[i][j]` —
+/// encoding `g(X) = Σ_i X^i · f_i(X^t)`. Passing fewer than `t` slots leaves
+/// the trailing (pad) slots zero, so a padded bundle can pass its real slots
+/// only.
+///
+/// # Panics
+/// If `slots.len() > t`, or the slots have unequal lengths.
+pub(super) fn combine<F: Field>(slots: &[&[F]], t: usize) -> Vec<F> {
+    let n = slots.first().map_or(0, |s| s.len());
+    assert!(
+        slots.len() <= t,
+        "combine: {} slots exceeds t = {t}",
+        slots.len()
+    );
+    assert!(
+        slots.iter().all(|s| s.len() == n),
+        "combine: all slots must have equal length"
+    );
+    let mut values = vec![F::ZERO; t * n];
+    for (i, slot) in slots.iter().enumerate() {
+        for (j, &c) in slot.iter().enumerate() {
+            values[j * t + i] = c;
+        }
+    }
+    values
+}
+
+/// Returns a primitive `t`-th root of unity in `F`, where `t` is a power of
+/// two not exceeding the field's 2-adicity `F::S`. Computed as
+/// `F::ROOT_OF_UNITY^(2^(S − log2 t))`, the same value
+/// `EvaluationDomain::new(1, log2 t)` derives for its `omega`; computed here
+/// standalone to avoid building a whole domain for the small `t` fflonk uses.
+///
+/// # Panics
+/// If `t` is not a power of two, or `log2 t > F::S`.
+pub(super) fn primitive_root_of_unity<F: PrimeField>(t: usize) -> F {
+    assert!(t.is_power_of_two(), "t must be a power of two");
+    let log_t = t.trailing_zeros();
+    assert!(log_t <= F::S, "t exceeds field 2-adicity (F::S)");
+    let exp: u64 = 1u64 << (F::S - log_t);
+    F::ROOT_OF_UNITY.pow_vartime([exp])
+}
+
+/// Paper's `roots_t(x)`: returns `[z, z ω_t, z ω_t², ..., z ω_t^{t−1}]`, the
+/// `t` t-th roots of `x = z^t`, given any `t`-th root `z` of `x` and a
+/// primitive `t`-th root of unity `omega_t`.
+pub(super) fn roots<F: Field>(z: F, omega_t: F, t: usize) -> Vec<F> {
+    let mut out = Vec::with_capacity(t);
+    let mut acc = z;
+    for _ in 0..t {
+        out.push(acc);
+        acc *= omega_t;
+    }
+    out
+}
+
+/// Paper's `S̄(root)`: evaluates the vector of claimed evaluations `claimed` as
+/// a polynomial at `root`: `Σ_i root^i · claimed[i]`.
+///
+/// When `root` is a `t`-th root of `x` and `claimed = (f_0(x), …, f_{t-1}(x))`,
+/// this equals `g(root)` by Lemma 5.1 of the paper.
+pub(super) fn eval_claims_as_poly<F: Field>(claimed: &[F], root: F) -> F {
+    let mut acc = F::ZERO;
+    let mut root_pow = F::ONE;
+    for &c in claimed {
+        acc += root_pow * c;
+        root_pow *= root;
+    }
+    acc
+}
+
+/// Returns one specific `t`-th root of `x`, computed by `log2(t)` applications
+/// of `Field::sqrt`. Deterministic, so prover and verifier compute the same
+/// root (the `t` roots of `x` are then `{z, z ω_t, ..., z ω_t^{t-1}}`).
+///
+/// # Panics
+/// If `t` is not a power of two, or if `x` is not a `t`-th power in `F`
+/// (an intermediate `sqrt()` returns `None`). For fflonk, the caller guarantees
+/// `x` is a `t`-th power by construction (logical points are `s^t · ω_n^r`).
+pub(super) fn t_th_root<F: PrimeField>(x: F, t: usize) -> F {
+    assert!(t.is_power_of_two(), "t must be a power of two");
+    let log_t = t.trailing_zeros();
+    let mut r = x;
+    for _ in 0..log_t {
+        r = Option::<F>::from(r.sqrt())
+            .expect("t_th_root: input is not a square — protocol-level error");
+    }
+    r
+}

--- a/proofs/src/pcs/fflonk/mod.rs
+++ b/proofs/src/pcs/fflonk/mod.rs
@@ -34,7 +34,7 @@
 //! coefficient form; `commit_many` converts otherwise. Native support for the
 //! other bases will be implemented in the future.
 
-use std::{fmt::Debug, hash::Hash, marker::PhantomData};
+use std::{borrow::Borrow, collections::BTreeMap, fmt::Debug, hash::Hash, marker::PhantomData};
 
 use ff::{Field, PrimeField, WithSmallOrderMulGroup};
 use midnight_curves::pairing::{Engine, MultiMillerLoop};
@@ -192,6 +192,68 @@ where
         1 + n * (single - 1)
     }
 
+    fn commit_many<B: PolynomialRepresentation, P: Borrow<Polynomial<E::Fr, B>> + Sync>(
+        params: &Self::Parameters,
+        polynomials: &BTreeMap<PolynomialLabel, P>,
+    ) -> Self::Commitment {
+        assert!(!polynomials.is_empty(), "cannot commit to zero polynomials");
+
+        // The map fixes the bundling order to the labels' `Ord` order, which is the
+        // order `read_commitment` tags the bundles it reads in.
+        let labels: Vec<PolynomialLabel> = polynomials.keys().cloned().collect();
+        let polynomials: Vec<&Polynomial<E::Fr, B>> =
+            polynomials.values().map(Borrow::borrow).collect();
+
+        // All polys of one call must share their length, so that the bundle's `n`
+        // is well-defined and `combine` produces a length-`t·n` g.
+        let n = polynomials[0].values.len();
+        assert!(
+            polynomials.iter().all(|p| p.values.len() == n),
+            "fflonk commit: all polys in one call must have equal length"
+        );
+
+        // Shrink the bundling exponent to whatever the loaded SRS can afford for
+        // this `n`. `multi_open` writes the same exponent to the transcript, and
+        // the per-bundle sizes travel with the commitment, so the verifier
+        // reconstructs the same partition.
+        let t_max = 1usize << effective_t_max_log(params, n);
+        let bundle_indices = partition::partition(t_max, &labels);
+
+        let bases_b = params.bases::<B>();
+        let mono_bases = &params.g;
+
+        let bundles: Vec<(E::G1, Vec<PolynomialLabel>)> = bundle_indices
+            .into_par_iter()
+            .map(|indices| {
+                let t = partition::bundle_t(indices.len(), t_max);
+                if t == 1 {
+                    // Singleton: MSM over the polynomial's own basis, as in KZG.
+                    let idx = indices[0];
+                    let p = polynomials[idx];
+                    let size = p.values.len();
+                    assert!(bases_b.len() >= size);
+                    let g1 = msm_specific::<E::G1Affine>(&p.values, &bases_b[..size]);
+                    (g1, vec![labels[idx].clone()])
+                } else {
+                    // Multi-poly bundle: convert to coefficient form (if needed), combine
+                    // into `g` over `t` slots (padding with null polys), and MSM over the
+                    // monomial bases.
+                    let coeff_values_per_slot =
+                        to_coeff_slots::<E, B>(&polynomials, &indices, n.trailing_zeros());
+                    let slot_refs: Vec<&[E::Fr]> =
+                        coeff_values_per_slot.iter().map(Vec::as_slice).collect();
+                    let g_values = combine(&slot_refs, t);
+                    let g1 = msm_specific::<E::G1Affine>(&g_values, &mono_bases[..t * n]);
+                    let bundle_labels: Vec<PolynomialLabel> =
+                        indices.iter().map(|&i| labels[i].clone()).collect();
+                    (g1, bundle_labels)
+                }
+            })
+            .collect();
+
+        FflonkCommitment::Regular(bundles)
+    }
+
     fn read_commitment<T: Transcript>(
         transcript: &mut T,
         labels: &[PolynomialLabel],
@@ -223,4 +285,51 @@ where
         // All bundles of one commitment go out as a single transcript object.
         transcript.write(commitment)
     }
+}
+
+/// The polynomials of a bundle, in coefficient form, in bundle-slot order.
+/// Lagrange-family bases are reinterpreted in their concrete basis, folded back
+/// to `LagrangeCoeff` and interpolated; only that fold-back differs per basis.
+fn to_coeff_slots<E: MultiMillerLoop, B: PolynomialRepresentation>(
+    polynomials: &[&Polynomial<E::Fr, B>],
+    indices: &[usize],
+    log_n: u32,
+) -> Vec<Vec<E::Fr>>
+where
+    E::Fr: WithSmallOrderMulGroup<3>,
+{
+    if let PolynomialBasis::Coeff = B::BASIS {
+        return indices.iter().map(|&i| polynomials[i].values.clone()).collect();
+    }
+
+    let domain = EvaluationDomain::<E::Fr>::new(1, log_n);
+    let to_lagrange = |values: Vec<E::Fr>| -> Polynomial<E::Fr, LagrangeCoeff> {
+        match B::BASIS {
+            PolynomialBasis::Lagrange => Polynomial {
+                values,
+                _marker: PhantomData,
+            },
+            PolynomialBasis::LagrangeDelta => Polynomial::<E::Fr, LagrangeDeltaCoeff> {
+                values,
+                _marker: PhantomData,
+            }
+            .into_lagrange(),
+            PolynomialBasis::LagrangeDoubleDelta => Polynomial::<E::Fr, LagrangeDoubleDeltaCoeff> {
+                values,
+                _marker: PhantomData,
+            }
+            .into_lagrange(),
+            other => panic!(
+                "fflonk t>1 bundling not supported for basis {other:?} (Coeff, Lagrange, \
+                 LagrangeDelta, LagrangeDoubleDelta only)"
+            ),
+        }
+    };
+    indices
+        .iter()
+        .map(|&i| {
+            let lagrange = to_lagrange(polynomials[i].values.clone());
+            domain.lagrange_to_coeff(lagrange).values
+        })
+        .collect()
 }

--- a/proofs/src/pcs/fflonk/mod.rs
+++ b/proofs/src/pcs/fflonk/mod.rs
@@ -423,6 +423,103 @@ where
 
         multi_open_core::<E::Fr, Self, T>(params, &expanded_queries, transcript)
     }
+
+    fn multi_prepare<'com, T: Transcript>(
+        queries: &[VerifierQuery<'com, E::Fr, FflonkScheme<E>>],
+        transcript: &mut T,
+    ) -> Result<FflonkVerificationGuard<E>, Error>
+    where
+        E::Fr: Sampleable<T::Hash> + Ord + Hash + Hashable<T::Hash>,
+        E::G1: CurveExt<ScalarExt = E::Fr>,
+        FflonkCommitment<E>: Hashable<T::Hash> + 'com,
+    {
+        // The prover's bundling ceiling, sent as a field element. Recover the
+        // integer by matching against the field encoding of each value in the valid
+        // band `[0, FFLONK_T_MAX_LOG]`. The SRS-room and 2-adicity caps are not
+        // re-enforced here: an out-of-band claim just yields a partition that
+        // mismatches the committed one, which the pairing check rejects.
+        let claimed: E::Fr = transcript.read().map_err(|_| Error::SamplingError)?;
+        let t_max_log = (0..=FFLONK_T_MAX_LOG)
+            .find(|&i| claimed == E::Fr::from(i as u64))
+            .ok_or(Error::OpeningError)?;
+        let t_max = 1usize << t_max_log;
+
+        // Bind the bundle sizes read off the wire to the transcript, see
+        // `check_bundle_layout`. Commitments are deduplicated by address, since the
+        // same one backs one query per polynomial it holds.
+        let mut checked: Vec<*const FflonkCommitment<E>> = Vec::new();
+        for q in queries.iter() {
+            if let FflonkCommitment::Regular(pairs) = q.commitment {
+                let addr = q.commitment as *const _;
+                if !checked.contains(&addr) {
+                    bundle_expansion::check_bundle_layout::<E>(pairs, t_max)?;
+                    checked.push(addr);
+                }
+            }
+        }
+
+        // === Bundle pre-expansion (fflonk-specific) ===
+        //
+        // Singletons and `Linear` commitments pass through with their own (label,
+        // point, eval) triple. Queries on a `t > 1` bundle are gathered per logical
+        // point and expanded into synthetic triples on the bundle's `g`, whose
+        // evaluations at the `t`-th roots are reconstructed through Lemma 5.1.
+
+        // `singleton_triples` is only extended under `fewer-point-sets`.
+        #[allow(unused_mut)]
+        let (mut multi_bundles_sorted, mut label_to_msm, mut singleton_triples) =
+            bundle_expansion::classify_verifier_queries::<E>(queries, t_max);
+
+        // Over-opening reads, paired with the writes in `multi_open`.
+        for (_synth, acc) in multi_bundles_sorted.iter_mut() {
+            for (pair_idx, point) in bundle_expansion::missing_openings(&acc.pairs) {
+                let slot = acc.pairs[pair_idx].0;
+                let eval: E::Fr = transcript.read().map_err(|_| Error::SamplingError)?;
+                acc.evals.insert((slot, point), eval);
+            }
+        }
+
+        #[cfg(feature = "fewer-point-sets")]
+        {
+            let pairs: Vec<(PolynomialLabel, E::Fr)> = singleton_triples
+                .iter()
+                .map(|(label, point, _)| (label.clone(), *point))
+                .collect();
+            for (idx, point) in compute_dummy_queries(&pairs) {
+                let label = singleton_triples[idx].0.clone();
+                let eval: E::Fr = transcript.read().map_err(|_| Error::SamplingError)?;
+                // `label_to_msm` already maps `label`, so no new entry is needed.
+                singleton_triples.push((label, point, eval));
+            }
+        }
+
+        let mut triples = singleton_triples;
+        let mut t_th_root_cache: FxHashMap<(E::Fr, usize), E::Fr> = FxHashMap::default();
+        for (synth_label, acc) in multi_bundles_sorted.into_iter() {
+            triples.extend(bundle_expansion::synth_triples_for_bundle::<E>(
+                &synth_label,
+                &acc,
+                &mut t_th_root_cache,
+            ));
+            let mut msm = MSMKZG::init();
+            msm.append_term(E::Fr::ONE, acc.bundle_g1, synth_label.clone());
+            label_to_msm.insert(synth_label, msm);
+        }
+
+        let msm_accumulator = multi_prepare_core::<E, MSMKZG<E>, T>(
+            &triples,
+            &label_to_msm,
+            transcript,
+            |transcript| {
+                // `f` and `π` commit to a single polynomial, so anything else on the
+                // wire is a malformed proof and must be rejected, not panicked on.
+                let commitment: FflonkCommitment<E> =
+                    transcript.read().map_err(|_| Error::SamplingError)?;
+                commitment.single_point().copied().ok_or(Error::OpeningError)
+            },
+        )?;
+        Ok(FflonkVerificationGuard(msm_accumulator))
+    }
 }
 
 /// The polynomials of a bundle, in coefficient form, in bundle-slot order.
@@ -470,4 +567,17 @@ where
             domain.lagrange_to_coeff(lagrange).values
         })
         .collect()
+}
+
+/// The final pairing check is identical to KZG's; we delegate to the inner
+/// [`DualMSM`].
+impl<E: MultiMillerLoop> Guard<E::Fr, FflonkScheme<E>> for FflonkVerificationGuard<E>
+where
+    E::Fr: WithSmallOrderMulGroup<3>,
+    E::G1: Default + CurveExt<ScalarExt = E::Fr> + ProcessedSerdeObject,
+    E::G1Affine: Default + CurveAffine<ScalarExt = E::Fr, CurveExt = E::G1>,
+{
+    fn verify(self, params: &ParamsVerifierKZG<E>) -> Result<(), Error> {
+        self.0.check(params).then_some(()).ok_or(Error::OpeningError)
+    }
 }

--- a/proofs/src/pcs/fflonk/mod.rs
+++ b/proofs/src/pcs/fflonk/mod.rs
@@ -1,0 +1,39 @@
+//! fflonk-style polynomial commitment scheme ([reference](https://eprint.iacr.org/2021/1167.pdf)).
+//!
+//! Packs groups of `t` polynomials of degree `< n` into a single polynomial `g`
+//! of degree `< t·n` via `g(X) = Σ_i X^i · f_i(X^t)`, commits once to `g`, and
+//! opens at the `t` t-th roots of each logical query point.
+//!
+//! # Layout
+//! - `math`: the curve-free fflonk paper math (`combine`, roots, ...).
+//! - `partition`: the deterministic bundling policy.
+//! - `commitment`: the `FflonkCommitment` type and its wire format.
+//! - `bundle_expansion`: multi-open bundle pre-expansion.
+//!
+//! # Implementation
+//! `commit_many` bundles via `partition::partition`. For each bundle of size
+//! `t > 1` it builds `g(X) = Σ_i X^i · f_i(X^t)` from the `f_i` converted to
+//! coefficient form; singleton bundles are committed in whichever basis they
+//! were given.
+//!
+//! `multi_open` / `multi_prepare` pre-expand bundled queries into synthetic
+//! queries on `g` at the `t`-th roots of each distinct logical opening point,
+//! which is the characterisation of Lemma 5.1 of the paper (see
+//! `eval_claims_as_poly`). The expansion is the only fflonk-specific phase;
+//! everything downstream is the standard Halo2 multi-open argument, shared with
+//! KZG through `multi_open_core`.
+//!
+//! # Protocol invariant
+//! All polynomials of one bundlable family must be committed in a single
+//! `commit_many` call: `multi_open` re-derives the bundles by partitioning the
+//! labels it is queried on, and that partition has to reproduce the one used at
+//! commit time. A prover violating this opens polynomials the commitments do
+//! not contain, which the final pairing check rejects.
+//!
+//! TODO: for now, computing `g` is only possible if each `f_i` is in
+//! coefficient form; `commit_many` converts otherwise. Native support for the
+//! other bases will be implemented in the future.
+
+pub mod commitment;
+
+pub use commitment::FflonkCommitment;

--- a/proofs/src/pcs/fflonk/mod.rs
+++ b/proofs/src/pcs/fflonk/mod.rs
@@ -36,6 +36,7 @@
 
 pub mod commitment;
 
+mod math;
 mod partition;
 
 pub use commitment::FflonkCommitment;

--- a/proofs/src/pcs/fflonk/mod.rs
+++ b/proofs/src/pcs/fflonk/mod.rs
@@ -34,9 +34,193 @@
 //! coefficient form; `commit_many` converts otherwise. Native support for the
 //! other bases will be implemented in the future.
 
+use std::{fmt::Debug, hash::Hash, marker::PhantomData};
+
+use ff::{Field, PrimeField, WithSmallOrderMulGroup};
+use midnight_curves::pairing::{Engine, MultiMillerLoop};
+use rand_core::OsRng;
+use rayon::iter::{IntoParallelIterator, ParallelIterator};
+use rustc_hash::{FxHashMap, FxHashSet};
+
 pub mod commitment;
 
 mod math;
 mod partition;
 
 pub use commitment::FflonkCommitment;
+
+use self::math::{combine, primitive_root_of_unity, roots as t_th_roots, t_th_root};
+#[cfg(feature = "fewer-point-sets")]
+use crate::pcs::utils::compute_dummy_queries;
+use crate::{
+    pcs::{
+        msm::{DualMSM, MSMKZG, msm_specific},
+        multi_open::{multi_open_core, multi_prepare_core},
+        params::{ParamsKZG, ParamsVerifierKZG},
+        scheme::{Guard, Params, PolynomialCommitmentScheme},
+    },
+    poly::{
+        Coeff, Error, EvaluationDomain, LagrangeCoeff, LagrangeDeltaCoeff,
+        LagrangeDoubleDeltaCoeff, Polynomial, PolynomialBasis, PolynomialRepresentation,
+        ProverQuery,
+        query::{PolynomialLabel, VerifierQuery},
+    },
+    transcript::{Hashable, Sampleable, Transcript},
+    utils::{
+        arithmetic::{CurveAffine, CurveExt, MSM, eval_polynomial},
+        helpers::{ProcessedSerdeObject, SerdeFormat},
+    },
+};
+
+/// The scheme-wide bundling exponent: fflonk packs up to `1 <<
+/// FFLONK_T_MAX_LOG` polynomials into a single commitment. `0` means no
+/// bundling (algebraically identical to classic KZG).
+pub const FFLONK_T_MAX_LOG: u32 = 0;
+
+/// Bundling ceiling actually usable for a circuit over a domain of size `n`.
+/// The maximal bundle size is `1 << t_max_log`, capped by three independent
+/// limits:
+///
+///   * the scheme-wide exponent [`FFLONK_T_MAX_LOG`],
+///   * SRS room: `t_max_log ≤ log2(g_monomial_size) − log2(n)`,
+///   * field 2-adicity: `t_max_log ≤ F::S − log2(n)`, so that the `t`-th roots
+///     of the evaluation points exist.
+///
+/// The prover writes the resulting `t_max_log` to the transcript; the verifier
+/// reads it back and range-checks it against `[0, FFLONK_T_MAX_LOG]` only. The
+/// two other caps are not re-enforced verifier-side: a mismatched value yields
+/// a partition that disagrees with the committed one, which the final pairing
+/// check rejects.
+// The caps are vacuous while `FFLONK_T_MAX_LOG` is 0, which clippy reports as a
+// pointless `min`; they are load-bearing as soon as it is raised.
+#[allow(clippy::unnecessary_min_or_max)]
+fn effective_t_max_log<E: Engine>(params: &ParamsKZG<E>, n: usize) -> u32
+where
+    E::G1Affine: CurveAffine,
+{
+    let log_n = n.ilog2();
+    let srs_room = params.g_monomial_size().ilog2().saturating_sub(log_n);
+    let field_room = <E::Fr as PrimeField>::S.saturating_sub(log_n);
+    FFLONK_T_MAX_LOG.min(srs_room).min(field_room)
+}
+
+/// The fflonk polynomial commitment scheme over a pairing-friendly curve `E`.
+#[derive(Clone, Debug)]
+pub struct FflonkScheme<E: Engine> {
+    _marker: PhantomData<E>,
+}
+
+/// Verification guard for [`FflonkScheme`], a transparent wrapper around the
+/// [`DualMSM`] KZG guard: fflonk's final check is the same pairing check.
+///
+/// It is a distinct type rather than `DualMSM` itself because a second
+/// `Guard` impl on `DualMSM` would make `guard.verify(params)` ambiguous for
+/// callers that do not name the scheme.
+#[derive(Clone, Debug)]
+pub struct FflonkVerificationGuard<E: MultiMillerLoop>(DualMSM<E>);
+
+impl<E: MultiMillerLoop + Debug> FflonkVerificationGuard<E>
+where
+    E::G1Affine: CurveAffine<ScalarExt = E::Fr, CurveExt = E::G1>,
+{
+    /// Extracts the underlying [`DualMSM`], for callers that batch guards
+    /// across proofs before a joint pairing check.
+    pub fn into_dual_msm(self) -> DualMSM<E> {
+        self.0
+    }
+}
+
+impl<E: MultiMillerLoop> PolynomialCommitmentScheme<E::Fr> for FflonkScheme<E>
+where
+    E::Fr: WithSmallOrderMulGroup<3>,
+    E::G1: Default + CurveExt<ScalarExt = E::Fr> + ProcessedSerdeObject,
+    E::G1Affine: Default + CurveAffine<ScalarExt = E::Fr, CurveExt = E::G1>,
+{
+    type Parameters = ParamsKZG<E>;
+    type VerifierParameters = ParamsVerifierKZG<E>;
+    type Commitment = FflonkCommitment<E>;
+    type VerificationGuard = FflonkVerificationGuard<E>;
+
+    fn gen_params(k: u32) -> Self::Parameters {
+        ParamsKZG::unsafe_setup(k, OsRng)
+    }
+
+    fn get_verifier_params(params: &Self::Parameters) -> Self::VerifierParameters {
+        params.verifier_params()
+    }
+
+    /// A bundle of `t` polynomials over the circuit domain is a single
+    /// polynomial of degree `t·2^k − 1`, so the scheme commits up to
+    /// `T_MAX·2^k − 1` unless a larger polynomial is committed as a singleton
+    /// (the quotient under `single-h-commitment`).
+    fn internal_degree(k: u32, max_poly_degree: usize) -> usize {
+        let bundle_degree = (1usize << (k + FFLONK_T_MAX_LOG)) - 1;
+        bundle_degree.max(max_poly_degree)
+    }
+
+    /// fflonk requires the evaluation point to be a `T_MAX`-th power, so that
+    /// the verifier can compute `t`-th roots for each bundle (each `t` divides
+    /// `T_MAX = 2^FFLONK_T_MAX_LOG`, so any `T_MAX`-th power is also a `t`-th
+    /// power). We squeeze `s` and return `s^T_MAX`.
+    ///
+    /// Soundness / ZK: `x = s^T_MAX` is uniformly distributed in the
+    /// `T_MAX`-th-power subgroup of `F*` (order `(p-1)/T_MAX`), which is
+    /// essentially full-sized for the BLS12 scalar field (`p-1 ≈ 2^254`).
+    /// Schwartz-Zippel arguments and protocol blinding are unaffected.
+    fn squeeze_evaluation_point<T: Transcript>(transcript: &mut T) -> E::Fr
+    where
+        E::Fr: Sampleable<T::Hash>,
+    {
+        // `FFLONK_T_MAX_LOG` must not exceed the field's 2-adicity: otherwise
+        // `s^(2^FFLONK_T_MAX_LOG)` collapses into the odd-order subgroup and the
+        // shift below overflows. Both operands are compile-time constants, so
+        // this is a static check evaluated once per curve.
+        #[allow(clippy::absurd_extreme_comparisons)]
+        const {
+            assert!(FFLONK_T_MAX_LOG <= <E::Fr as PrimeField>::S)
+        };
+        let s: E::Fr = transcript.squeeze_challenge();
+        s.pow_vartime([1u64 << FFLONK_T_MAX_LOG])
+    }
+
+    fn commitment_byte_length(n: usize) -> usize {
+        // A commitment is a bundle count followed by, per bundle, a polynomial
+        // count and a group element. The `n` polynomials are assumed unbundled,
+        // which is what the shipped `FFLONK_T_MAX_LOG = 0` produces; the cost
+        // model does not track bundling.
+        let single = Self::Commitment::default().byte_length(SerdeFormat::Processed);
+        1 + n * (single - 1)
+    }
+
+    fn read_commitment<T: Transcript>(
+        transcript: &mut T,
+        labels: &[PolynomialLabel],
+    ) -> std::io::Result<Self::Commitment>
+    where
+        Self::Commitment: Hashable<T::Hash>,
+    {
+        // The bundle sizes are on the wire, so the read yields the grouping with
+        // placeholder labels; `with_labels` fills in the real ones.
+        let commitment: FflonkCommitment<E> = transcript.read()?;
+        Ok(commitment.with_labels(labels))
+    }
+
+    fn deserialize_commitment<R: std::io::Read>(
+        reader: &mut R,
+        format: SerdeFormat,
+        labels: &[PolynomialLabel],
+    ) -> std::io::Result<Self::Commitment> {
+        FflonkCommitment::<E>::read_labeled(reader, format, labels)
+    }
+
+    fn write_commitment<T: Transcript>(
+        transcript: &mut T,
+        commitment: &Self::Commitment,
+    ) -> std::io::Result<()>
+    where
+        Self::Commitment: Hashable<T::Hash>,
+    {
+        // All bundles of one commitment go out as a single transcript object.
+        transcript.write(commitment)
+    }
+}

--- a/proofs/src/pcs/fflonk/mod.rs
+++ b/proofs/src/pcs/fflonk/mod.rs
@@ -44,6 +44,7 @@ use rustc_hash::{FxHashMap, FxHashSet};
 
 pub mod commitment;
 
+mod bundle_expansion;
 mod math;
 mod partition;
 

--- a/proofs/src/pcs/fflonk/mod.rs
+++ b/proofs/src/pcs/fflonk/mod.rs
@@ -286,6 +286,143 @@ where
         // All bundles of one commitment go out as a single transcript object.
         transcript.write(commitment)
     }
+
+    fn multi_open<T: Transcript>(
+        params: &Self::Parameters,
+        queries: &[ProverQuery<E::Fr>],
+        transcript: &mut T,
+    ) -> Result<(), Error>
+    where
+        E::Fr: Sampleable<T::Hash> + Hash + Ord + Hashable<T::Hash>,
+        FflonkCommitment<E>: Hashable<T::Hash>,
+    {
+        // === Bundle pre-expansion (fflonk-specific) ===
+        //
+        // Replace the queries targeting a `t > 1` bundle with synthetic queries on
+        // the bundle's combined polynomial `g`, at the `t`-th roots of each distinct
+        // logical opening point.
+
+        // Distinct query labels, in first-appearance order, and the polynomial each
+        // one identifies.
+        let mut poly_lookup: FxHashMap<PolynomialLabel, &Polynomial<E::Fr, Coeff>> =
+            FxHashMap::default();
+        let mut all_labels: Vec<PolynomialLabel> = Vec::new();
+        for q in queries.iter() {
+            if poly_lookup.insert(q.label.clone(), q.poly).is_none() {
+                all_labels.push(q.label.clone());
+            }
+        }
+
+        // Bundling ceiling, mirroring the one `commit_many` derived from the SRS.
+        let t_max_log = all_labels
+            .iter()
+            .find(|l| partition::poly_is_combinable(l))
+            .map(|l| poly_lookup[l].values.len())
+            .map_or(0, |n| effective_t_max_log(params, n));
+        transcript
+            .write(&E::Fr::from(t_max_log as u64))
+            .map_err(|_| Error::OpeningError)?;
+        let t_max = 1usize << t_max_log;
+
+        // Theoretically unreachable, but the code below would panic on it.
+        if all_labels.is_empty() {
+            return Ok(());
+        }
+        let bundle_indices = partition::partition(t_max, &all_labels);
+
+        // Materialise `g` for each `t > 1` bundle, indexed by bundle position.
+        let g_polys: Vec<Option<Polynomial<E::Fr, Coeff>>> = bundle_indices
+            .iter()
+            .map(|indices| {
+                let t = partition::bundle_t(indices.len(), t_max);
+                if t <= 1 {
+                    return None;
+                }
+                let n_bundle = poly_lookup[&all_labels[indices[0]]].values.len();
+                assert!(
+                    indices.iter().all(|&i| poly_lookup[&all_labels[i]].values.len() == n_bundle),
+                    "fflonk multi_open: polys within a `t > 1` bundle must have equal length"
+                );
+                let slot_refs: Vec<&[E::Fr]> = indices
+                    .iter()
+                    .map(|&i| poly_lookup[&all_labels[i]].values.as_slice())
+                    .collect();
+                Some(Polynomial {
+                    values: combine(&slot_refs, t),
+                    _marker: PhantomData,
+                })
+            })
+            .collect();
+
+        // Per-bundle preparation: union of logical points, the (slot, point) pairs to
+        // over-open, and the synthetic label.
+        let multi_pre = bundle_expansion::build_prover_multi_pre::<E>(
+            &bundle_indices,
+            &all_labels,
+            t_max,
+            queries,
+        );
+
+        // Over-opening writes: a `t > 1` bundle needs every slot opened at every
+        // point of the bundle's logical union.
+        for pre in &multi_pre {
+            for &(slot, logical) in &pre.missing {
+                let poly = poly_lookup[&all_labels[bundle_indices[pre.bundle_idx][slot]]];
+                let eval = eval_polynomial(&poly[..], logical);
+                transcript.write(&eval).map_err(|_| Error::OpeningError)?;
+            }
+        }
+
+        // Queries on singleton bundles are opened as they are.
+        let bundled: FxHashSet<PolynomialLabel> = bundle_indices
+            .iter()
+            .filter(|indices| indices.len() > 1)
+            .flat_map(|indices| indices.iter().map(|&i| all_labels[i].clone()))
+            .collect();
+        // Only extended under `fewer-point-sets`.
+        #[allow(unused_mut)]
+        let mut singleton_queries: Vec<ProverQuery<E::Fr>> =
+            queries.iter().filter(|q| !bundled.contains(&q.label)).cloned().collect();
+
+        // `fewer-point-sets` applies to the singleton slice only: the bundled
+        // queries have been replaced by synthetic ones on `g`, whose point sets are
+        // the `t`-th roots.
+        #[cfg(feature = "fewer-point-sets")]
+        {
+            let pairs: Vec<(PolynomialLabel, E::Fr)> =
+                singleton_queries.iter().map(|q| (q.label.clone(), q.point)).collect();
+            for (idx, point) in compute_dummy_queries(&pairs) {
+                let poly = singleton_queries[idx].poly;
+                let label = singleton_queries[idx].label.clone();
+                transcript
+                    .write(&eval_polynomial(&poly[..], point))
+                    .map_err(|_| Error::OpeningError)?;
+                singleton_queries.push(ProverQuery::new(point, poly, label));
+            }
+        }
+
+        // Bundle-synth slice: `t` queries on `g` at the t-th roots of each logical
+        // point of the union (uniform across slots after over-opening). The
+        // `t_th_root(logical, t)` cache is shared across bundles, which typically
+        // open at the same logical points (ζ, ζ·ω, ...).
+        let mut t_th_root_cache: FxHashMap<(E::Fr, usize), E::Fr> = FxHashMap::default();
+        let mut expanded_queries = singleton_queries;
+        for pre in &multi_pre {
+            let g_poly =
+                g_polys[pre.bundle_idx].as_ref().expect("g_poly must be Some for a t>1 bundle");
+            let omega_t = primitive_root_of_unity::<E::Fr>(pre.t);
+            for &logical in &pre.union_logicals {
+                let z = *t_th_root_cache
+                    .entry((logical, pre.t))
+                    .or_insert_with(|| t_th_root(logical, pre.t));
+                for r in t_th_roots(z, omega_t, pre.t) {
+                    expanded_queries.push(ProverQuery::new(r, g_poly, pre.synth_label.clone()));
+                }
+            }
+        }
+
+        multi_open_core::<E::Fr, Self, T>(params, &expanded_queries, transcript)
+    }
 }
 
 /// The polynomials of a bundle, in coefficient form, in bundle-slot order.

--- a/proofs/src/pcs/fflonk/mod.rs
+++ b/proofs/src/pcs/fflonk/mod.rs
@@ -581,3 +581,419 @@ where
         self.0.check(params).then_some(()).ok_or(Error::OpeningError)
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use std::{collections::BTreeMap, hash::Hash};
+
+    use blake2b_simd::State as Blake2bState;
+    use ff::WithSmallOrderMulGroup;
+    use midnight_curves::{CurveAffine, CurveExt, pairing::MultiMillerLoop, serde::SerdeObject};
+    use rand_core::OsRng;
+
+    use super::{FFLONK_T_MAX_LOG, FflonkCommitment, FflonkScheme, effective_t_max_log};
+    use crate::{
+        pcs::{
+            Guard, PolynomialCommitmentScheme,
+            params::{ParamsKZG, ParamsVerifierKZG},
+        },
+        poly::{
+            EvaluationDomain, PolynomialLabel,
+            query::{ProverQuery, VerifierQuery},
+        },
+        transcript::{CircuitTranscript, Hashable, Sampleable, Transcript},
+        utils::{
+            arithmetic::eval_polynomial,
+            helpers::{ProcessedSerdeObject, SerdeFormat},
+        },
+    };
+
+    /// Round-trip mirroring `kzg::tests::test_roundtrip_gwc`: commits three
+    /// polynomials, runs `multi_open` + `multi_prepare` end-to-end, and asserts
+    /// the pairing check passes (and fails when one eval is tampered with).
+    #[test]
+    fn test_roundtrip_gwc() {
+        use midnight_curves::Bls12;
+
+        const K: u32 = 4;
+
+        let params: ParamsKZG<Bls12> = ParamsKZG::unsafe_setup(K, OsRng);
+
+        let proof = create_proof::<_, CircuitTranscript<Blake2bState>>(&params);
+
+        let verifier_params = params.verifier_params();
+        verify::<Bls12, CircuitTranscript<Blake2bState>>(&verifier_params, &proof[..], false);
+        verify::<Bls12, CircuitTranscript<Blake2bState>>(&verifier_params, &proof[..], true);
+    }
+
+    /// `deserialize_commitment` groups the labels it is given by the per-bundle
+    /// sizes read off the wire, and re-sorts deliberately shuffled labels into
+    /// canonical order. This is what lets the verifier follow the prover's
+    /// effective bundling factor instead of re-deriving it.
+    #[test]
+    fn read_groups_by_bundle_sizes_and_reorders() {
+        use group::Group;
+        use midnight_curves::{Bls12, G1Projective};
+
+        // Three bundles packing 2, 2 and 1 polynomials.
+        let g = G1Projective::generator();
+        let com = FflonkCommitment::<Bls12>::Regular(vec![
+            (g, vec![PolynomialLabel::NoLabel; 2]),
+            (g + g, vec![PolynomialLabel::NoLabel; 2]),
+            (g + g + g, vec![PolynomialLabel::NoLabel; 1]),
+        ]);
+        let mut bytes = vec![];
+        com.write(&mut bytes, SerdeFormat::Processed).unwrap();
+
+        // Labels supplied out of order: the read sorts them canonically, then
+        // chunks them by the bundle sizes.
+        let labels: Vec<_> = [4usize, 1, 3, 0, 2].map(PolynomialLabel::Advice).to_vec();
+        let read = FflonkScheme::<Bls12>::deserialize_commitment(
+            &mut &bytes[..],
+            SerdeFormat::Processed,
+            &labels,
+        )
+        .unwrap();
+
+        let FflonkCommitment::Regular(pairs) = read else {
+            panic!("expected Regular");
+        };
+        let groups: Vec<Vec<_>> = pairs.into_iter().map(|(_, l)| l).collect();
+        assert_eq!(
+            groups,
+            vec![
+                vec![PolynomialLabel::Advice(0), PolynomialLabel::Advice(1)],
+                vec![PolynomialLabel::Advice(2), PolynomialLabel::Advice(3)],
+                vec![PolynomialLabel::Advice(4)],
+            ]
+        );
+    }
+
+    /// A commitment whose wire sizes do not encode `partition(t_max, labels)`
+    /// is rejected: the sizes are not hashed, so they are bound to the
+    /// transcript-carried `t_max` by this check. Const-independent.
+    #[test]
+    fn forged_bundle_layout_is_rejected() {
+        use group::Group;
+        use midnight_curves::{Bls12, G1Projective};
+
+        use super::bundle_expansion::check_bundle_layout;
+
+        let g = G1Projective::generator();
+        let labels = [PolynomialLabel::Advice(0), PolynomialLabel::Advice(1)];
+        let as_bundle = vec![(g, labels.to_vec())];
+        let as_singletons = vec![(g, vec![labels[0].clone()]), (g, vec![labels[1].clone()])];
+
+        // Without bundling the only legal layout is one bundle per polynomial.
+        assert!(check_bundle_layout::<Bls12>(&as_singletons, 1).is_ok());
+        assert!(check_bundle_layout::<Bls12>(&as_bundle, 1).is_err());
+
+        // At `t_max = 2` both advice polys must be packed together.
+        assert!(check_bundle_layout::<Bls12>(&as_bundle, 2).is_ok());
+        assert!(check_bundle_layout::<Bls12>(&as_singletons, 2).is_err());
+    }
+
+    /// End-to-end round-trip through a real `t > 1` bundle (provisioned SRS, so
+    /// the effective bundling factor equals the const). Commits `t` combinable
+    /// polynomials in one `commit_many`, opens them, and checks the pairing.
+    /// No-op at the shipped `FFLONK_T_MAX_LOG = 0`; bump the const to activate
+    /// it in a test round.
+    #[test]
+    fn bundled_roundtrip_with_provisioned_srs() {
+        use midnight_curves::{Bls12, Fq};
+
+        if FFLONK_T_MAX_LOG == 0 {
+            return;
+        }
+        const K: u32 = 4;
+        let n = 1usize << K;
+        let t = 1usize << FFLONK_T_MAX_LOG;
+
+        // Extended monomial basis 2^(K + FFLONK_T_MAX_LOG) => effective == const.
+        let mut params: ParamsKZG<Bls12> = ParamsKZG::unsafe_setup(K + FFLONK_T_MAX_LOG, OsRng);
+        params.downsize_lagrange(K);
+        assert_eq!(effective_t_max_log(&params, n), FFLONK_T_MAX_LOG);
+
+        let domain = EvaluationDomain::new(1, K);
+        let polys: Vec<_> = (0..t)
+            .map(|j| {
+                let mut p = domain.empty_coeff();
+                for (i, c) in p.iter_mut().enumerate() {
+                    *c = Fq::from((j * n + i + 1) as u64);
+                }
+                p
+            })
+            .collect();
+        let labels: Vec<_> = (0..t).map(PolynomialLabel::Advice).collect();
+
+        // Prover.
+        let mut transcript = CircuitTranscript::<Blake2bState>::init();
+        let polys_map: BTreeMap<_, _> = labels.iter().cloned().zip(polys.iter()).collect();
+        let com = FflonkScheme::<Bls12>::commit_many(&params, &polys_map);
+        match &com {
+            FflonkCommitment::Regular(p) => assert_eq!(p.len(), 1, "expected one t>1 bundle"),
+            _ => panic!("expected Regular"),
+        }
+        FflonkScheme::<Bls12>::write_commitment(&mut transcript, &com).unwrap();
+        let x = FflonkScheme::<Bls12>::squeeze_evaluation_point(&mut transcript);
+        for p in &polys {
+            transcript.write(&eval_polynomial(p, x)).unwrap();
+        }
+        let queries: Vec<_> = polys
+            .iter()
+            .zip(&labels)
+            .map(|(p, l)| ProverQuery::new(x, p, l.clone()))
+            .collect();
+        FflonkScheme::<Bls12>::multi_open(&params, &queries, &mut transcript).unwrap();
+        let proof = transcript.finalize();
+
+        // Verifier.
+        let vp = params.verifier_params();
+        let mut vt = CircuitTranscript::<Blake2bState>::init_from_bytes(&proof);
+        let read_com = FflonkScheme::<Bls12>::read_commitment(&mut vt, &labels).unwrap();
+        match &read_com {
+            FflonkCommitment::Regular(p) => {
+                assert_eq!(p.len(), 1);
+                assert_eq!(p[0].1.len(), t, "bundle must carry all t labels");
+            }
+            _ => panic!("expected Regular"),
+        }
+        let vx = FflonkScheme::<Bls12>::squeeze_evaluation_point(&mut vt);
+        let vevals: Vec<Fq> = (0..t).map(|_| vt.read().unwrap()).collect();
+        let vqueries: Vec<_> = labels
+            .iter()
+            .zip(&vevals)
+            .map(|(l, e)| VerifierQuery::new(vx, &read_com, l.clone(), *e))
+            .collect();
+        let guard = FflonkScheme::<Bls12>::multi_prepare(&vqueries, &mut vt).unwrap();
+        assert!(
+            Guard::<Fq, FflonkScheme<Bls12>>::verify(guard, &vp).is_ok(),
+            "bundled proof must verify"
+        );
+    }
+
+    /// Round-trip over several bundles whose slots are opened at *different*
+    /// points, which is what forces the over-opening writes/reads, plus a
+    /// padded trailing bundle and a non-combinable singleton. No-op at the
+    /// shipped `FFLONK_T_MAX_LOG = 0`.
+    #[test]
+    fn bundled_roundtrip_with_rotations_and_singleton() {
+        use midnight_curves::{Bls12, Fq};
+
+        if FFLONK_T_MAX_LOG == 0 {
+            return;
+        }
+        const K: u32 = 4;
+        let n = 1usize << K;
+        let t = 1usize << FFLONK_T_MAX_LOG;
+
+        let mut params: ParamsKZG<Bls12> = ParamsKZG::unsafe_setup(K + FFLONK_T_MAX_LOG, OsRng);
+        params.downsize_lagrange(K);
+
+        let domain = EvaluationDomain::new(1, K);
+        let omega = domain.get_omega();
+
+        // `t + 3` advice polys: one full bundle plus a trailing one, padded when
+        // `t > 4`. The `Fixed` poly is not combinable, so it stays a singleton.
+        let nb_advice = t + 3;
+        let polys: Vec<_> = (0..nb_advice + 1)
+            .map(|j| {
+                let mut p = domain.empty_coeff();
+                for (i, c) in p.iter_mut().enumerate() {
+                    *c = Fq::from((j * n + i + 1) as u64);
+                }
+                p
+            })
+            .collect();
+        let labels: Vec<_> = (0..nb_advice)
+            .map(PolynomialLabel::Advice)
+            .chain([PolynomialLabel::Fixed(0)])
+            .collect();
+
+        // Prover.
+        let mut transcript = CircuitTranscript::<Blake2bState>::init();
+        let polys_map: BTreeMap<_, _> = labels.iter().cloned().zip(polys.iter()).collect();
+        let com = FflonkScheme::<Bls12>::commit_many(&params, &polys_map);
+        FflonkScheme::<Bls12>::write_commitment(&mut transcript, &com).unwrap();
+
+        let x = FflonkScheme::<Bls12>::squeeze_evaluation_point(&mut transcript);
+        // Every other polynomial is opened at the rotated point, so the slots of a
+        // bundle disagree on their opening points.
+        let point_of = |i: usize| if i.is_multiple_of(2) { x } else { x * omega };
+        let evals: Vec<Fq> =
+            polys.iter().enumerate().map(|(i, p)| eval_polynomial(p, point_of(i))).collect();
+        for e in &evals {
+            transcript.write(e).unwrap();
+        }
+        let queries: Vec<_> = polys
+            .iter()
+            .zip(&labels)
+            .enumerate()
+            .map(|(i, (p, l))| ProverQuery::new(point_of(i), p, l.clone()))
+            .collect();
+        FflonkScheme::<Bls12>::multi_open(&params, &queries, &mut transcript).unwrap();
+        let proof = transcript.finalize();
+
+        // Verifier.
+        let vp = params.verifier_params();
+        let mut vt = CircuitTranscript::<Blake2bState>::init_from_bytes(&proof);
+        let read_com = FflonkScheme::<Bls12>::read_commitment(&mut vt, &labels).unwrap();
+        let vx = FflonkScheme::<Bls12>::squeeze_evaluation_point(&mut vt);
+        let vevals: Vec<Fq> = (0..labels.len()).map(|_| vt.read().unwrap()).collect();
+        assert_eq!(vevals, evals);
+        let vqueries: Vec<_> = labels
+            .iter()
+            .zip(&vevals)
+            .enumerate()
+            .map(|(i, (l, e))| {
+                let point = if i % 2 == 0 { vx } else { vx * omega };
+                VerifierQuery::new(point, &read_com, l.clone(), *e)
+            })
+            .collect();
+        let guard = FflonkScheme::<Bls12>::multi_prepare(&vqueries, &mut vt).unwrap();
+        assert!(
+            Guard::<Fq, FflonkScheme<Bls12>>::verify(guard, &vp).is_ok(),
+            "bundled proof with rotations must verify"
+        );
+    }
+
+    /// Two `t > 1` bundles with identical layout add homomorphically:
+    /// `commit(P) + commit(Q)` equals `commit(P + Q)` slot-wise, a single
+    /// point. No-op at the shipped `FFLONK_T_MAX_LOG = 0`.
+    #[test]
+    fn add_same_layout_bundles_is_homomorphic() {
+        use midnight_curves::{Bls12, Fq};
+
+        if FFLONK_T_MAX_LOG == 0 {
+            return;
+        }
+        const K: u32 = 4;
+        let n = 1usize << K;
+        let t = 1usize << FFLONK_T_MAX_LOG;
+
+        let mut params: ParamsKZG<Bls12> = ParamsKZG::unsafe_setup(K + FFLONK_T_MAX_LOG, OsRng);
+        params.downsize_lagrange(K);
+
+        let domain = EvaluationDomain::new(1, K);
+        let labels: Vec<_> = (0..t).map(PolynomialLabel::Advice).collect();
+
+        let bundle = |seed: u64| -> Vec<_> {
+            (0..t)
+                .map(|j| {
+                    let mut p = domain.empty_coeff();
+                    for (i, c) in p.iter_mut().enumerate() {
+                        *c = Fq::from(seed * 1000 + (j * n + i + 1) as u64);
+                    }
+                    p
+                })
+                .collect()
+        };
+        let polys_a = bundle(1);
+        let polys_b = bundle(2);
+        let polys_sum: Vec<_> = polys_a.iter().zip(&polys_b).map(|(a, b)| a.clone() + b).collect();
+
+        let map_a: BTreeMap<_, _> = labels.iter().cloned().zip(polys_a.iter()).collect();
+        let map_b: BTreeMap<_, _> = labels.iter().cloned().zip(polys_b.iter()).collect();
+        let map_sum: BTreeMap<_, _> = labels.iter().cloned().zip(polys_sum.iter()).collect();
+        let com_a = FflonkScheme::<Bls12>::commit_many(&params, &map_a);
+        let com_b = FflonkScheme::<Bls12>::commit_many(&params, &map_b);
+        let com_sum = FflonkScheme::<Bls12>::commit_many(&params, &map_sum);
+
+        match (com_a + com_b, com_sum) {
+            (FflonkCommitment::Regular(added), FflonkCommitment::Regular(expected)) => {
+                assert_eq!(added.len(), 1);
+                assert_eq!(expected.len(), 1);
+                assert_eq!(added[0].0, expected[0].0, "homomorphic point sum mismatch");
+                assert_eq!(added[0].1, expected[0].1, "labels must be preserved");
+            }
+            _ => panic!("expected Regular commitments"),
+        }
+    }
+
+    fn verify<E, T>(verifier_params: &ParamsVerifierKZG<E>, proof: &[u8], should_fail: bool)
+    where
+        E: MultiMillerLoop,
+        T: Transcript,
+        E::Fr: WithSmallOrderMulGroup<3> + Hashable<T::Hash> + Sampleable<T::Hash> + Ord + Hash,
+        E::G1: Hashable<T::Hash> + CurveExt<ScalarExt = E::Fr, AffineExt = E::G1Affine>,
+        E::G1Affine: CurveAffine<ScalarExt = E::Fr, CurveExt = E::G1> + SerdeObject,
+        FflonkCommitment<E>: Hashable<T::Hash>,
+    {
+        let mut transcript = T::init_from_bytes(proof);
+
+        let label = |name: &str| PolynomialLabel::Custom(name.into());
+        let a = FflonkScheme::<E>::read_commitment(&mut transcript, &[label("a")]).unwrap();
+        let b = FflonkScheme::<E>::read_commitment(&mut transcript, &[label("b")]).unwrap();
+        let c = FflonkScheme::<E>::read_commitment(&mut transcript, &[label("c")]).unwrap();
+
+        let x: E::Fr = transcript.squeeze_challenge();
+        let y: E::Fr = transcript.squeeze_challenge();
+
+        let avx: E::Fr = transcript.read().unwrap();
+        let bvx: E::Fr = transcript.read().unwrap();
+        let cvy: E::Fr = transcript.read().unwrap();
+
+        // When tampering, `b`'s eval is swapped for `a`'s to force the pairing
+        // check to fail.
+        let queries = vec![
+            VerifierQuery::new(x, &a, label("a"), avx),
+            VerifierQuery::new(x, &b, label("b"), if should_fail { avx } else { bvx }),
+            VerifierQuery::new(y, &c, label("c"), cvy),
+        ];
+
+        let guard = FflonkScheme::<E>::multi_prepare(&queries, &mut transcript).unwrap();
+        let result = Guard::<E::Fr, FflonkScheme<E>>::verify(guard, verifier_params);
+
+        if should_fail {
+            assert!(result.is_err());
+        } else {
+            assert!(result.is_ok());
+        }
+    }
+
+    fn create_proof<E, T>(params: &ParamsKZG<E>) -> Vec<u8>
+    where
+        E: MultiMillerLoop,
+        T: Transcript,
+        E::Fr: WithSmallOrderMulGroup<3> + Hashable<T::Hash> + Hash + Sampleable<T::Hash> + Ord,
+        E::G1: Hashable<T::Hash> + CurveExt<ScalarExt = E::Fr, AffineExt = E::G1Affine>,
+        E::G1Affine: SerdeObject + CurveAffine<ScalarExt = E::Fr, CurveExt = E::G1>,
+    {
+        let k = (params.g.len() - 1).ilog2() + 1;
+        let domain = EvaluationDomain::new(1, k);
+
+        let poly = |offset: u64| {
+            let mut p = domain.empty_coeff();
+            for (i, a) in p.iter_mut().enumerate() {
+                *a = <E::Fr>::from(offset + i as u64);
+            }
+            p
+        };
+        let (ax, bx, cx) = (poly(10), poly(100), poly(100));
+
+        let mut transcript = T::init();
+
+        let label = |name: &str| PolynomialLabel::Custom(name.into());
+        for (p, name) in [(&ax, "a"), (&bx, "b"), (&cx, "c")] {
+            let com = FflonkScheme::<E>::commit(params, p, label(name));
+            FflonkScheme::<E>::write_commitment(&mut transcript, &com).unwrap();
+        }
+
+        let x: E::Fr = transcript.squeeze_challenge();
+        let y: E::Fr = transcript.squeeze_challenge();
+
+        transcript.write(&eval_polynomial(&ax, x)).unwrap();
+        transcript.write(&eval_polynomial(&bx, x)).unwrap();
+        transcript.write(&eval_polynomial(&cx, y)).unwrap();
+
+        let queries = [
+            ProverQuery::new(x, &ax, label("a")),
+            ProverQuery::new(x, &bx, label("b")),
+            ProverQuery::new(y, &cx, label("c")),
+        ];
+
+        FflonkScheme::<E>::multi_open(params, &queries, &mut transcript).unwrap();
+
+        transcript.finalize()
+    }
+}

--- a/proofs/src/pcs/fflonk/mod.rs
+++ b/proofs/src/pcs/fflonk/mod.rs
@@ -36,4 +36,6 @@
 
 pub mod commitment;
 
+mod partition;
+
 pub use commitment::FflonkCommitment;

--- a/proofs/src/pcs/fflonk/partition.rs
+++ b/proofs/src/pcs/fflonk/partition.rs
@@ -1,0 +1,300 @@
+//! Bundling policy for fflonk: how the polynomials of a `commit` call are
+//! partitioned into bundles of size `t ≤ t_max` each.
+//!
+//! `t_max` is the prover's effective bundling ceiling, capped by
+//! [`FFLONK_T_MAX_LOG`](super::FFLONK_T_MAX_LOG); it travels to the verifier on
+//! the transcript (for `multi_open`) and through the per-bundle sizes of the
+//! serialized commitment (for `commit`). Any change to the partition strategy
+//! is a protocol-level change: the commitments produced differ.
+//!
+//! ## Bundling policy
+//!
+//! - Bundlable families (`Advice`, `PermutationAccumulator`, `LogupHelper`,
+//!   `LogupMultiplicities`, `LogupAggregator`, `Trash`) are grouped per-family,
+//!   sorted by label, and chunked into bundles of size `≤ t_max`.
+//! - Non-bundlable labels are committed as their own singleton bundles (`t =
+//!   1`).
+//!
+//! Polynomials whose standalone commitment the protocol still needs stay
+//! singletons; `poly_is_combinable` lists the reason per label.
+//!
+//! ## Requirements on a bundlable family
+//!
+//! `multi_open` re-derives the bundles by partitioning every label it is
+//! queried on, so a family must satisfy both of:
+//!
+//! - It is committed in a single `commit_many` call, which is what makes that
+//!   global partition agree with the per-call one.
+//! - Every one of its polynomials is queried. A committed but unqueried member
+//!   is absent from the partition `multi_open` derives, shifting the chunk
+//!   boundaries away from the committed ones. For `Advice` this would take a
+//!   column that appears in no gate expression and in no copy constraint, since
+//!   `advice_queries` is filled only by `query_advice` and permutation columns
+//!   are always queried at the current rotation. A violation is rejected by
+//!   `bundle_expansion::check_bundle_layout`, never silently accepted.
+
+use std::mem;
+
+use crate::poly::query::PolynomialLabel;
+
+/// Indicates whether a polynomial can be bundled by fflonk, i.e. whether the
+/// protocol never needs its commitment on its own. A bundle exposes only the
+/// combined group element, so every other label is committed as a singleton:
+///
+/// - `CommittedInstance`: committed out-of-band, one `CS::commit` per column,
+///   and handed to the verifier as separate commitments, so a bundle spanning
+///   several of them has nothing to correspond to.
+/// - `Fixed`: `compute_linearization_commitment` scales the individual
+///   simple-selector commitment `vk.fixed_commitments[i]`. Also an in-circuit
+///   fixed base.
+/// - `PermutationFixed`: not folded into linearisation, but still an in-circuit
+///   fixed base, which maps one label to one curve point.
+/// - `Quotient`, `QuotientPiece`: linearisation folds each limb with its own
+///   scalar `(1 - x^n) * s^i`.
+/// - `Linearization`: never committed, the verifier rebuilds it as an MSM.
+/// - `Custom`: scheme-internal single commitments, such as `multi_open`'s batch
+///   polynomial and opening proof.
+/// - `NoLabel`: carries no polynomial identity, e.g. a collapsed MSM.
+///
+/// TODO: this function should be removed once linearisation and fflonk are made
+/// compatible.
+pub(super) fn poly_is_combinable(label: &PolynomialLabel) -> bool {
+    matches!(
+        label,
+        PolynomialLabel::Advice(_)
+            | PolynomialLabel::PermutationAccumulator(_)
+            | PolynomialLabel::LogupHelper(..)
+            | PolynomialLabel::LogupMultiplicities(_)
+            | PolynomialLabel::LogupAggregator(_)
+            | PolynomialLabel::Trash(_)
+    )
+}
+
+/// Chunk one family's indices into bundles of size `<= t_max`, appending
+/// each chunk to `result`. Trailing chunks may have fewer than `t_max` entries;
+/// their logical bundle size is the next power of two.
+fn chunk_family(result: &mut Vec<Vec<usize>>, family_indices: &[usize], t_max: usize) {
+    // Always true in practice, but the property is required for termination.
+    assert!(t_max > 0);
+
+    let mut start = 0usize;
+    while start < family_indices.len() {
+        let take = (family_indices.len() - start).min(t_max);
+        result.push(family_indices[start..start + take].to_vec());
+        start += take;
+    }
+}
+
+/// Canonical order of `labels` shared by prover and verifier, *without*
+/// chunking: combinable polynomials first, sorted by label, then singletons in
+/// input order. `PolynomialLabel`'s derived `Ord` clusters equal variants
+/// together and orders within a variant by index, which is exactly the
+/// per-family canonical key both sides must agree on. This ordering is
+/// independent of the bundling factor; only the chunk boundaries drawn over it
+/// depend on `t_max`.
+pub(super) fn canonical_order(labels: &[PolynomialLabel]) -> Vec<usize> {
+    let mut combinable: Vec<usize> = Vec::new();
+    let mut singletons: Vec<usize> = Vec::new();
+    for (idx, label) in labels.iter().enumerate() {
+        if poly_is_combinable(label) {
+            combinable.push(idx);
+        } else {
+            singletons.push(idx);
+        }
+    }
+    combinable.sort_by(|&a, &b| labels[a].cmp(&labels[b]));
+    combinable.extend(singletons);
+    combinable
+}
+
+/// Bundle partition of `labels`. Returns a list of index-vecs into `labels`;
+/// each inner vec is one bundle, with indices in the canonical order shared
+/// between prover and verifier.
+///
+/// Output order: combinable polynomials first, grouped by label variant and
+/// sorted within each group by label, then singletons in input order.
+///
+/// # Soundness for linearised polynomials
+/// Any polynomial whose *individual* commitment is used downstream must be
+/// committed as a singleton, typically the quotient pieces and simple-selector
+/// fixed columns, because of their use in linearisation. A multi-poly bundle
+/// exposes only the combined group element, from which the individual
+/// commitments cannot be recovered.
+pub(super) fn partition(t_max: usize, labels: &[PolynomialLabel]) -> Vec<Vec<usize>> {
+    let order = canonical_order(labels);
+
+    let mut result: Vec<Vec<usize>> = Vec::new();
+    // Walk the canonical order: chunk each maximal run of one combinable variant
+    // (hence a single basis) into bundles of at most `t_max`, and emit each
+    // singleton as its own bundle.
+    let mut start = 0;
+    while start < order.len() {
+        if !poly_is_combinable(&labels[order[start]]) {
+            result.push(vec![order[start]]);
+            start += 1;
+            continue;
+        }
+        let mut end = start + 1;
+        while end < order.len()
+            && poly_is_combinable(&labels[order[end]])
+            && mem::discriminant(&labels[order[end]]) == mem::discriminant(&labels[order[start]])
+        {
+            end += 1;
+        }
+        chunk_family(&mut result, &order[start..end], t_max);
+        start = end;
+    }
+    result
+}
+
+/// Logical bundle size for a bundle holding `real_count` real polynomials at
+/// ceiling `t_max`. fflonk requires bundle sizes to be a power of two, so
+/// bundles are padded with null polynomials up to the next power.
+pub(super) fn bundle_t(real_count: usize, t_max: usize) -> usize {
+    real_count.next_power_of_two().min(t_max)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn advice(n: usize) -> Vec<PolynomialLabel> {
+        (0..n).map(PolynomialLabel::Advice).collect()
+    }
+
+    #[test]
+    fn advice_only_chunks_by_t_max() {
+        let p = partition(4, &advice(4));
+        assert_eq!(p, vec![vec![0, 1, 2, 3]]);
+    }
+
+    #[test]
+    fn advice_splits_when_exceeds_t_max() {
+        let p = partition(4, &advice(10));
+        assert_eq!(p, vec![vec![0, 1, 2, 3], vec![4, 5, 6, 7], vec![8, 9]]);
+    }
+
+    #[test]
+    fn advice_sorted_by_index() {
+        let labels = vec![
+            PolynomialLabel::Advice(3),
+            PolynomialLabel::Advice(0),
+            PolynomialLabel::Advice(2),
+            PolynomialLabel::Advice(1),
+        ];
+        let p = partition(4, &labels);
+        assert_eq!(p, vec![vec![1, 3, 2, 0]]);
+    }
+
+    #[test]
+    fn singletons_isolated_from_advice() {
+        let labels = vec![
+            PolynomialLabel::Fixed(0),
+            PolynomialLabel::Advice(0),
+            PolynomialLabel::Advice(1),
+            PolynomialLabel::Quotient,
+        ];
+        let p = partition(4, &labels);
+        assert_eq!(p, vec![vec![1, 2], vec![0], vec![3]]);
+    }
+
+    #[test]
+    fn t_max_one_means_all_singletons() {
+        let p = partition(1, &advice(4));
+        assert_eq!(p, vec![vec![0], vec![1], vec![2], vec![3]]);
+    }
+
+    #[test]
+    fn perm_acc_in_own_bundle() {
+        let labels = vec![
+            PolynomialLabel::PermutationAccumulator(2),
+            PolynomialLabel::PermutationAccumulator(0),
+            PolynomialLabel::PermutationAccumulator(1),
+        ];
+        let p = partition(4, &labels);
+        // Sorted by inner index: [PermAcc(0)=idx 1, PermAcc(1)=idx 2, PermAcc(2)=idx 0]
+        assert_eq!(p, vec![vec![1, 2, 0]]);
+    }
+
+    #[test]
+    fn committed_instances_stay_singletons() {
+        let labels = vec![
+            PolynomialLabel::CommittedInstance(0),
+            PolynomialLabel::Advice(0),
+            PolynomialLabel::CommittedInstance(1),
+        ];
+        let p = partition(4, &labels);
+        // Advice bundles; each committed instance is its own bundle, in input order.
+        assert_eq!(p, vec![vec![1], vec![0], vec![2]]);
+    }
+
+    #[test]
+    fn trash_in_own_bundle() {
+        let labels = vec![
+            PolynomialLabel::Trash(1),
+            PolynomialLabel::Advice(0),
+            PolynomialLabel::Trash(0),
+        ];
+        let p = partition(4, &labels);
+        // Advice first, then Trash sorted by argument index.
+        assert_eq!(p, vec![vec![1], vec![2, 0]]);
+    }
+
+    #[test]
+    fn logup_multiplicities_sorted_by_index() {
+        let labels = vec![
+            PolynomialLabel::LogupMultiplicities(2),
+            PolynomialLabel::LogupMultiplicities(0),
+            PolynomialLabel::LogupMultiplicities(1),
+        ];
+        let p = partition(4, &labels);
+        // Sorted by argument index: 0 (pos 1), 1 (pos 2), 2 (pos 0)
+        assert_eq!(p, vec![vec![1, 2, 0]]);
+    }
+
+    #[test]
+    fn families_emit_in_label_variant_order() {
+        // Advice + PermAcc + Logup* + singleton: each variant gets its own bundle,
+        // emitted in label variant order, then singletons in input order.
+        let labels = vec![
+            PolynomialLabel::LogupAggregator(0),
+            PolynomialLabel::Fixed(0),
+            PolynomialLabel::PermutationAccumulator(0),
+            PolynomialLabel::Advice(0),
+        ];
+        let p = partition(4, &labels);
+        assert_eq!(
+            p,
+            vec![
+                vec![3], // Advice
+                vec![2], // PermutationAccumulator
+                vec![0], // LogupAggregator
+                vec![1], // Fixed (singleton)
+            ]
+        );
+    }
+
+    #[test]
+    fn advice_trailing_bundle_is_padded() {
+        let p = partition(16, &advice(3));
+        assert_eq!(p, vec![vec![0, 1, 2]]);
+        assert_eq!(bundle_t(3, 16), 4);
+    }
+
+    #[test]
+    fn advice_partial_trailing_bundle() {
+        let p = partition(16, &advice(19));
+        let mut expected = vec![(0..16).collect::<Vec<_>>()];
+        expected.push(vec![16, 17, 18]);
+        assert_eq!(p, expected);
+        assert_eq!(bundle_t(16, 16), 16);
+        assert_eq!(bundle_t(3, 16), 4);
+    }
+
+    #[test]
+    fn advice_exact_power_of_two_trailing() {
+        let p = partition(4, &advice(6));
+        assert_eq!(p, vec![vec![0, 1, 2, 3], vec![4, 5]]);
+        assert_eq!(bundle_t(2, 4), 2);
+    }
+}

--- a/proofs/src/pcs/mod.rs
+++ b/proofs/src/pcs/mod.rs
@@ -1,10 +1,12 @@
 //! Polynomial commitment schemes.
 //!
 //! [`scheme`] holds the generic `PolynomialCommitmentScheme` trait and its
-//! supporting traits; [`kzg`] holds the concrete KZG scheme. [`msm`],
-//! [`params`] and the `utils` module hold the shared KZG-style / GWC machinery
-//! reused across schemes.
+//! supporting traits; [`kzg`] and [`fflonk`] hold the concrete schemes.
+//! [`msm`], [`params`] and the `utils` module hold the shared KZG-style / GWC
+//! machinery reused across schemes.
 
+/// The fflonk polynomial commitment scheme.
+pub mod fflonk;
 /// The KZG polynomial commitment scheme.
 pub mod kzg;
 /// Multi-scalar-multiplication accumulators ([`MSMKZG`](msm::MSMKZG),

--- a/proofs/src/pcs/multi_open.rs
+++ b/proofs/src/pcs/multi_open.rs
@@ -261,6 +261,35 @@ where
     }
 }
 
+// fflonk accumulates directly in MSM space: its commitments are bundles, so the
+// per-label sources the argument combines are already MSMs (one term for a
+// bundle, several for a linearization commitment).
+impl<E: MultiMillerLoop + Debug> BatchAccumulator<E> for MSMKZG<E>
+where
+    E::G1Affine: CurveAffine<ScalarExt = E::Fr, CurveExt = E::G1>,
+{
+    fn from_point(point: E::G1, label: PolynomialLabel) -> Self {
+        MSMKZG::new(&[E::Fr::ONE], &[point], &[label])
+    }
+
+    fn scale(&mut self, factor: E::Fr) {
+        MSM::scale(self, factor)
+    }
+
+    fn add(&mut self, other: &Self) {
+        MSM::add_msm(self, other)
+    }
+
+    #[cfg(feature = "truncated-challenges")]
+    fn collapse(&mut self, label: PolynomialLabel) {
+        MSMKZG::collapse(self, label)
+    }
+
+    fn into_msm(self) -> MSMKZG<E> {
+        self
+    }
+}
+
 /// `sum_i coms[i] * scalars[i]`, in the accumulator's own representation.
 fn com_inner_product<E: MultiMillerLoop + Debug, C: BatchAccumulator<E>>(
     coms: &[C],

--- a/proofs/src/pcs/utils.rs
+++ b/proofs/src/pcs/utils.rs
@@ -136,12 +136,14 @@ pub(crate) fn construct_intermediate_sets<F: Field + Hash + Ord>(
 /// Computes the dummy openings needed to reduce the number of distinct
 /// multi-open point sets. Each input `(key, point)` pair represents a query
 /// (e.g., a commitment opened at a given point). The function groups queries
-/// by key (by commitment) computes the union of all point sets that contain
+/// by key (by commitment), computes the union of all point sets that contain
 /// more than one point, and returns the missing `(index, point)` pairs that,
-/// once added, make every such point set identical. Keys with a single point
-/// are left untouched (we do this because there are many commitments opened
-/// at a single point, e.g. most selectors; we could also pad those, but the
-/// impact on the proof size would be more significant).
+/// once added, make every point set equal to that union.
+///
+/// Single-point keys do not *contribute* to the union, but are padded against
+/// it like any other: there are many commitments opened at a single point (e.g.
+/// most selectors), and letting them widen the union would cost more proof size
+/// than it saves.
 ///
 /// Each returned `index` refers to the position of the key's first occurrence
 /// in the input, so callers can index back into the original query slice.

--- a/proofs/src/plonk/circuit.rs
+++ b/proofs/src/plonk/circuit.rs
@@ -2198,6 +2198,28 @@ impl<F: Field> ConstraintSystem<F> {
         *[degree_without_lookup, degree].iter().max().unwrap()
     }
 
+    /// Panics if some advice column is never queried, at any rotation.
+    ///
+    /// An unqueried column is committed to but absent from the opening
+    /// argument, so it contributes nothing to the statement being proven. Both
+    /// `enable_equality` and every use of a column in an expression register a
+    /// query, so this can only happen to a column no constraint touches.
+    pub fn assert_all_columns_queried(&self) {
+        let unqueried: Vec<usize> = self
+            .num_advice_queries
+            .iter()
+            .enumerate()
+            .filter(|&(_, &nb)| nb == 0)
+            .map(|(i, _)| i)
+            .collect();
+        assert!(
+            unqueried.is_empty(),
+            "advice columns {unqueried:?} are never queried, your circuit is likely doing \
+             something wrong: they are committed to but appear in no gate, lookup or copy \
+             constraint, so nothing constrains them."
+        );
+    }
+
     /// Compute the number of blinding factors necessary to perfectly blind
     /// each of the prover's witness polynomials.
     pub fn blinding_factors(&self) -> usize {

--- a/proofs/src/plonk/keygen.rs
+++ b/proofs/src/plonk/keygen.rs
@@ -40,6 +40,12 @@ where
     #[cfg(not(feature = "circuit-params"))]
     let config = ConcreteCircuit::configure(&mut cs);
 
+    // Enforces that no orphan advice column remains. Otherwise fflonk's prover
+    // bundles from the queries and its verifier from the commitment, the two
+    // disagree in the multi-open argument, and the verifier typically panics on a
+    // bundle slot it has no evaluation for.
+    cs.assert_all_columns_queried();
+
     let degree = cs.degree();
 
     let domain = EvaluationDomain::new(degree as u32, k);

--- a/proofs/src/poly/mod.rs
+++ b/proofs/src/poly/mod.rs
@@ -348,12 +348,9 @@ impl<F: Field> Polynomial<F, LagrangeCoeff> {
     }
 }
 
-#[cfg(test)]
 impl<F: Field> Polynomial<F, LagrangeDeltaCoeff> {
     /// Inverse of `to_delta`: prefix-sum the deltas back to Lagrange form:
     /// a_0 = b_0; a_i = a_{i-1} + b_i, in place.
-    ///
-    /// Test-only: used to assert round-trip identity of the delta transform.
     pub(crate) fn into_lagrange(mut self) -> Polynomial<F, LagrangeCoeff> {
         for i in 1..self.values.len() {
             let prev = self.values[i - 1];
@@ -372,6 +369,7 @@ impl<F: Field> Polynomial<F, LagrangeDeltaCoeff> {
     /// Test-only: used to assert the fused
     /// [`Polynomial::<_, LagrangeCoeff>::to_double_delta`] matches the
     /// two-step delta-of-delta path.
+    #[cfg(test)]
     pub(crate) fn into_double_delta(mut self) -> Polynomial<F, LagrangeDoubleDeltaCoeff> {
         for i in (1..self.values.len()).rev() {
             let prev = self.values[i - 1];
@@ -384,7 +382,6 @@ impl<F: Field> Polynomial<F, LagrangeDeltaCoeff> {
     }
 }
 
-#[cfg(test)]
 impl<F: Field> Polynomial<F, LagrangeDoubleDeltaCoeff> {
     /// Inverse of [`Polynomial::<_, LagrangeDeltaCoeff>::into_double_delta`]:
     /// prefix-sum the double-deltas back to delta form,
@@ -392,6 +389,7 @@ impl<F: Field> Polynomial<F, LagrangeDoubleDeltaCoeff> {
     ///
     /// Test-only: used to assert round-trip identity of the stepwise
     /// double-delta path.
+    #[cfg(test)]
     pub(crate) fn into_lagrange_delta(mut self) -> Polynomial<F, LagrangeDeltaCoeff> {
         for i in 1..self.values.len() {
             let prev = self.values[i - 1];
@@ -408,9 +406,6 @@ impl<F: Field> Polynomial<F, LagrangeDoubleDeltaCoeff> {
     /// forward sweep using two running accumulators (the partial sums for
     /// `b` and for `a`). Two field additions per element, single memory
     /// pass, no allocation.
-    ///
-    /// Test-only: used to assert round-trip identity of the fused
-    /// double-delta path.
     pub(crate) fn into_lagrange(mut self) -> Polynomial<F, LagrangeCoeff> {
         let mut b_running = F::ZERO;
         let mut a_running = F::ZERO;

--- a/proofs/src/transcript/mod.rs
+++ b/proofs/src/transcript/mod.rs
@@ -13,8 +13,18 @@ const BLAKE2B_PREFIX_COMMON: u8 = 1;
 
 /// Hash function that can be used for transcript
 pub trait TranscriptHash: Clone {
-    /// Input type of the hash function
-    type Input;
+    /// Input type of the hash function.
+    ///
+    /// Bounded `IntoIterator + FromIterator` so that a commitment holding
+    /// several group elements (e.g. an `FflonkCommitment` with multiple
+    /// bundles) can build its transcript input by concatenating the per-element
+    /// inputs.
+    ///
+    /// # Requirement
+    ///
+    /// `IntoIterator` must iterate in a deterministic order, so that the prover
+    /// and the verifier agree on it. Otherwise, verification could fail.
+    type Input: IntoIterator + FromIterator<<Self::Input as IntoIterator>::Item>;
     /// Output type of the hash function
     type Output;
 


### PR DESCRIPTION
Implements the PCS trait for the Fflonk scheme. This is the main PR of the stack. The missing steps afterwards are to implement the verifier gadget, after what Fflonk will be deployable by switching the value of `MidnightPCS`.