### PR TITLE
[Fflonk PR7] [Verifier Gadget PR1] Better failure diagnosis in verifier gadget

### DIFF
--- a/circuits/CHANGELOG.md
+++ b/circuits/CHANGELOG.md
@@ -17,6 +17,7 @@ We use [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 * Fix cost model to pass correct number of committed instances [#280](https://github.com/midnightntwrk/midnight-zk/pull/280)
 
 ### Changed
+* The verifier gadget reports a proof it does not fully consume as `Err(Synthesis(..))`, instead of silently producing an unsatisfiable circuit [#516](https://github.com/midnightntwrk/midnight-zk/pull/516)
 * Adapt the in-circuit verifier gadget to the batched cross-argument commitment layout [#493](https://github.com/midnightntwrk/midnight-zk/pull/493)
 * Removes the Labelable trait [#491](https://github.com/midnightntwrk/midnight-zk/pull/491)
 * Migrate to Rust edition 2024; declare MSRV 1.90. Both are now inherited from the workspace [#508](https://github.com/midnightntwrk/midnight-zk/pull/508)

--- a/circuits/src/lib.rs
+++ b/circuits/src/lib.rs
@@ -45,6 +45,8 @@ pub use crate::utils::ComposableChip;
 pub mod testing_utils {
     pub use crate::utils::ecdsa;
     #[cfg(any(test, feature = "testing"))]
+    pub use crate::utils::transcript_trace;
+    #[cfg(any(test, feature = "testing"))]
     pub use crate::{
         instructions::hash::tests::test_hash,
         utils::{

--- a/circuits/src/utils/mod.rs
+++ b/circuits/src/utils/mod.rs
@@ -18,6 +18,8 @@ pub(crate) mod circuit_modeling;
 mod composable;
 pub mod ecdsa;
 mod test_native_gadget;
+#[cfg(any(test, feature = "testing"))]
+pub mod transcript_trace;
 pub mod types;
 pub mod util;
 

--- a/circuits/src/utils/transcript_trace.rs
+++ b/circuits/src/utils/transcript_trace.rs
@@ -1,0 +1,314 @@
+// This file is part of MIDNIGHT-ZK.
+// Copyright (C) Midnight Foundation
+// SPDX-License-Identifier: Apache-2.0
+// Licensed under the Apache License, Version 2.0 (the "License");
+// You may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// http://www.apache.org/licenses/LICENSE-2.0
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Test-only comparison of the in-circuit and off-circuit Fiat-Shamir
+//! transcripts.
+//!
+//! Both verifiers must absorb the same field elements in the same order and
+//! squeeze at the same points. When they do not, the only symptom is an
+//! unsatisfiable circuit at some unrelated row. Recording both event streams
+//! and diffing them names the operation where they diverged.
+//!
+//! Off-circuit, use [`TracingTranscript`] in place of a [`CircuitTranscript`].
+//! In-circuit, the gadget is out of a test's reach, so [`in_circuit`] collects
+//! its events on a per-thread channel that is off by default.
+
+use std::io;
+
+use ff::PrimeField;
+use midnight_proofs::{
+    circuit::Value,
+    transcript::{CircuitTranscript, Hashable, Sampleable, Transcript},
+};
+
+use crate::hash::poseidon::{PoseidonState, constants::PoseidonField};
+
+/// One observable Fiat-Shamir event.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum TranscriptEvent {
+    /// A field element absorbed, in canonical byte representation.
+    Absorbed(Vec<u8>),
+    /// A field element absorbed whose in-circuit value was unknown.
+    AbsorbedUnknown,
+    /// A challenge squeezed.
+    Squeezed,
+}
+
+impl TranscriptEvent {
+    fn summary(&self) -> String {
+        match self {
+            TranscriptEvent::Absorbed(bytes) => {
+                let hex: String = bytes.iter().rev().map(|b| format!("{b:02x}")).collect();
+                format!("absorb 0x{hex}")
+            }
+            TranscriptEvent::AbsorbedUnknown => "absorb <unknown>".into(),
+            TranscriptEvent::Squeezed => "squeeze".into(),
+        }
+    }
+}
+
+fn absorbed<F: PrimeField>(value: &F) -> TranscriptEvent {
+    TranscriptEvent::Absorbed(value.to_repr().as_ref().to_vec())
+}
+
+/// A [`CircuitTranscript`] that also records what it absorbs and squeezes.
+///
+/// Drop-in replacement in any function generic over [`Transcript`], such as
+/// `plonk::prepare`.
+#[derive(Clone, Debug)]
+pub struct TracingTranscript<F: PoseidonField> {
+    inner: CircuitTranscript<PoseidonState<F>>,
+    events: Vec<TranscriptEvent>,
+}
+
+impl<F: PoseidonField> TracingTranscript<F> {
+    /// The events recorded so far.
+    pub fn events(&self) -> &[TranscriptEvent] {
+        &self.events
+    }
+
+    fn record<T: Hashable<PoseidonState<F>>>(&mut self, input: &T) {
+        self.events.extend(input.to_input().iter().map(absorbed))
+    }
+}
+
+impl<F: PoseidonField> Transcript for TracingTranscript<F> {
+    type Hash = PoseidonState<F>;
+
+    fn init() -> Self {
+        Self {
+            inner: CircuitTranscript::init(),
+            events: Vec::new(),
+        }
+    }
+
+    fn init_from_bytes(bytes: &[u8]) -> Self {
+        Self {
+            inner: CircuitTranscript::init_from_bytes(bytes),
+            events: Vec::new(),
+        }
+    }
+
+    fn squeeze_challenge<T: Sampleable<Self::Hash>>(&mut self) -> T {
+        self.events.push(TranscriptEvent::Squeezed);
+        self.inner.squeeze_challenge()
+    }
+
+    fn common<T: Hashable<Self::Hash>>(&mut self, input: &T) -> io::Result<()> {
+        self.record(input);
+        self.inner.common(input)
+    }
+
+    fn read<T: Hashable<Self::Hash>>(&mut self) -> io::Result<T> {
+        let value: T = self.inner.read()?;
+        self.record(&value);
+        Ok(value)
+    }
+
+    fn write<T: Hashable<Self::Hash>>(&mut self, input: &T) -> io::Result<()> {
+        self.record(input);
+        self.inner.write(input)
+    }
+
+    fn finalize(self) -> Vec<u8> {
+        self.inner.finalize()
+    }
+
+    fn assert_empty(&mut self) -> io::Result<()> {
+        self.inner.assert_empty()
+    }
+}
+
+/// Per-thread channel for the in-circuit verifier's events.
+///
+/// The gadget runs deep inside circuit synthesis, out of reach of the test that
+/// wants its events, hence the channel rather than a return value.
+pub mod in_circuit {
+    use std::cell::RefCell;
+
+    use super::*;
+
+    #[derive(Default)]
+    struct Channel {
+        on: bool,
+        events: Vec<TranscriptEvent>,
+    }
+
+    thread_local! {
+        static CHANNEL: RefCell<Channel> = RefCell::new(Channel::default());
+    }
+
+    /// Starts recording, discarding anything recorded before.
+    pub fn start() {
+        CHANNEL.with(|c| {
+            let mut c = c.borrow_mut();
+            c.on = true;
+            c.events.clear();
+        })
+    }
+
+    /// Stops recording and returns the events.
+    pub fn take() -> Vec<TranscriptEvent> {
+        CHANNEL.with(|c| {
+            let mut c = c.borrow_mut();
+            c.on = false;
+            std::mem::take(&mut c.events)
+        })
+    }
+
+    /// Drops the events recorded so far, keeping only those of the run starting
+    /// here.
+    ///
+    /// Synthesis runs more than once per proof (`MockProver` sizes the circuit
+    /// before assigning it) and each pass replays the whole transcript.
+    pub fn new_run() {
+        CHANNEL.with(|c| {
+            let mut c = c.borrow_mut();
+            if c.on {
+                c.events.clear()
+            }
+        })
+    }
+
+    /// Records absorbed field elements.
+    pub fn absorbed<F: PrimeField>(values: &[Value<F>]) {
+        push_many(values.iter().map(|value| {
+            let mut event = TranscriptEvent::AbsorbedUnknown;
+            value.map(|f| event = super::absorbed(&f));
+            event
+        }))
+    }
+
+    /// Records a squeezed challenge.
+    pub fn squeezed() {
+        push_many(std::iter::once(TranscriptEvent::Squeezed))
+    }
+
+    fn push_many(events: impl Iterator<Item = TranscriptEvent>) {
+        CHANNEL.with(|c| {
+            let mut c = c.borrow_mut();
+            if c.on {
+                c.events.extend(events)
+            }
+        })
+    }
+}
+
+/// Panics if the two event streams differ, reporting the first divergence.
+///
+/// `AbsorbedUnknown` matches any absorbed element: an in-circuit value is
+/// unknown exactly when the circuit is synthesized without a witness, where
+/// there is nothing to compare.
+pub fn assert_streams_match(off_circuit: &[TranscriptEvent], in_circuit: &[TranscriptEvent]) {
+    let matches = |a: &TranscriptEvent, b: &TranscriptEvent| match (a, b) {
+        (TranscriptEvent::Absorbed(_), TranscriptEvent::AbsorbedUnknown) => true,
+        (TranscriptEvent::AbsorbedUnknown, TranscriptEvent::Absorbed(_)) => true,
+        _ => a == b,
+    };
+
+    assert!(
+        !off_circuit.is_empty(),
+        "no off-circuit transcript events were recorded"
+    );
+    assert!(
+        !in_circuit.is_empty(),
+        "no in-circuit transcript events were recorded"
+    );
+
+    let divergence = (0..off_circuit.len().max(in_circuit.len())).find(|&i| {
+        match (off_circuit.get(i), in_circuit.get(i)) {
+            (Some(a), Some(b)) => !matches(a, b),
+            _ => true,
+        }
+    });
+
+    let Some(i) = divergence else { return };
+
+    // Set TRANSCRIPT_TRACE_DUMP to print both streams in full.
+    if std::env::var("TRANSCRIPT_TRACE_DUMP").is_ok() {
+        for (n, e) in off_circuit.iter().enumerate() {
+            eprintln!("off {n}: {}", e.summary());
+        }
+        for (n, e) in in_circuit.iter().enumerate() {
+            eprintln!("in  {n}: {}", e.summary());
+        }
+    }
+
+    // The challenge count localises the divergence to a protocol phase.
+    let nb_squeezes = off_circuit[..i].iter().filter(|e| **e == TranscriptEvent::Squeezed).count();
+    let context: Vec<String> =
+        off_circuit[i.saturating_sub(4)..i].iter().map(|e| e.summary()).collect();
+    let describe = |events: &[TranscriptEvent]| match events.get(i) {
+        Some(e) => e.summary(),
+        None => format!("<end of stream, {} events>", events.len()),
+    };
+
+    panic!(
+        "in-circuit and off-circuit transcripts diverge at event {i} \
+         (after {nb_squeezes} challenges)\n  \
+         off-circuit: {}\n  in-circuit:  {}\n  preceding:   [{}]",
+        describe(off_circuit),
+        describe(in_circuit),
+        context.join(", "),
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn absorb(byte: u8) -> TranscriptEvent {
+        TranscriptEvent::Absorbed(vec![byte])
+    }
+
+    #[test]
+    fn identical_streams_match() {
+        let events = [absorb(1), TranscriptEvent::Squeezed, absorb(2)];
+        assert_streams_match(&events, &events);
+    }
+
+    #[test]
+    fn unknown_absorptions_match_anything_absorbed() {
+        assert_streams_match(
+            &[absorb(1), TranscriptEvent::Squeezed],
+            &[TranscriptEvent::AbsorbedUnknown, TranscriptEvent::Squeezed],
+        );
+    }
+
+    #[test]
+    #[should_panic(expected = "diverge at event 1")]
+    fn differing_values_are_reported() {
+        assert_streams_match(&[absorb(1), absorb(2)], &[absorb(1), absorb(3)]);
+    }
+
+    #[test]
+    #[should_panic(expected = "diverge at event 2")]
+    fn a_missing_squeeze_is_reported() {
+        assert_streams_match(
+            &[absorb(1), absorb(2), TranscriptEvent::Squeezed],
+            &[absorb(1), absorb(2), absorb(3)],
+        );
+    }
+
+    #[test]
+    #[should_panic(expected = "diverge at event 2")]
+    fn a_prefix_is_reported() {
+        assert_streams_match(&[absorb(1), absorb(2), absorb(3)], &[absorb(1), absorb(2)]);
+    }
+
+    #[test]
+    #[should_panic(expected = "no in-circuit transcript events")]
+    fn an_empty_stream_is_reported() {
+        assert_streams_match(&[absorb(1)], &[]);
+    }
+}

--- a/circuits/src/verifier/transcript_gadget.rs
+++ b/circuits/src/verifier/transcript_gadget.rs
@@ -22,6 +22,8 @@ use midnight_proofs::{
     transcript::{CircuitTranscript, Transcript},
 };
 
+#[cfg(any(test, feature = "testing"))]
+use crate::utils::transcript_trace::in_circuit;
 use crate::{
     instructions::{AssignmentInstructions, PublicInputInstructions, SpongeInstructions},
     types::AssignedNative,
@@ -50,6 +52,11 @@ pub struct TranscriptGadget<S: SelfEmulation> {
     // Transcript reader is included, to help parse the proof. This parsing
     // *does not* need to be verified in-circuit.
     transcript_reader: Option<CircuitTranscript<S::Hash>>,
+    // Length in bytes of the proof given to `init_with_proof`, and the number of
+    // reads from it that fell back to a default. Both feed
+    // `assert_proof_fully_consumed`.
+    proof_len: usize,
+    nb_failed_reads: usize,
 }
 
 impl<S: SelfEmulation> TranscriptGadget<S> {
@@ -66,6 +73,8 @@ impl<S: SelfEmulation> TranscriptGadget<S> {
             sponge_state: None,
             input_len: 0,
             transcript_reader: None,
+            proof_len: 0,
+            nb_failed_reads: 0,
         }
     }
 
@@ -86,6 +95,11 @@ impl<S: SelfEmulation> TranscriptGadget<S> {
         // all the relevant bytes have been read. This is not an issue anyway.
         let mut proof_bytes = Vec::new();
         proof.clone().map(|pi| proof_bytes.extend_from_slice(&pi));
+        #[cfg(any(test, feature = "testing"))]
+        in_circuit::new_run();
+
+        self.proof_len = proof_bytes.len();
+        self.nb_failed_reads = 0;
         self.transcript_reader = Some(CircuitTranscript::init_from_bytes(&proof_bytes));
 
         Ok(())
@@ -97,6 +111,9 @@ impl<S: SelfEmulation> TranscriptGadget<S> {
         layouter: &mut impl Layouter<S::F>,
         scalar: &AssignedNative<S::F>,
     ) -> Result<(), Error> {
+        #[cfg(any(test, feature = "testing"))]
+        in_circuit::absorbed(&[scalar.value().copied()]);
+
         self.input_len += 1;
         let state = self.sponge_state.as_mut().expect("You must init the transcript gadget");
         self.sponge_chip.absorb(layouter, state, std::slice::from_ref(scalar))
@@ -122,6 +139,9 @@ impl<S: SelfEmulation> TranscriptGadget<S> {
                 ))),
             }?;
 
+            #[cfg(any(test, feature = "testing"))]
+            in_circuit::absorbed(&pis.iter().map(|pi| pi.value().copied()).collect::<Vec<_>>());
+
             self.input_len += pis.len();
 
             let state = self.sponge_state.as_mut().expect("You must init the transcript gadget");
@@ -135,6 +155,9 @@ impl<S: SelfEmulation> TranscriptGadget<S> {
         &mut self,
         layouter: &mut impl Layouter<S::F>,
     ) -> Result<AssignedNative<S::F>, Error> {
+        #[cfg(any(test, feature = "testing"))]
+        in_circuit::squeezed();
+
         let state = self.sponge_state.as_mut().expect("You must init the transcript gadget");
         self.sponge_chip.squeeze(layouter, state)
     }
@@ -159,7 +182,10 @@ impl<S: SelfEmulation> TranscriptGadget<S> {
             // (This allows us to parse dummy proofs.)
             let point: Value<S::C> = match reader.read::<S::C>() {
                 Ok(point) => Value::known(point),
-                Err(_) => Value::known(S::C::default()),
+                Err(_) => {
+                    self.nb_failed_reads += 1;
+                    Value::known(S::C::default())
+                }
             };
             let assigned_point =
                 S::assign_without_subgroup_check(layouter, &self.curve_chip, point)?;
@@ -183,13 +209,49 @@ impl<S: SelfEmulation> TranscriptGadget<S> {
         // (This allows us to parse dummy proofs.)
         let scalar: Value<S::F> = match reader.read::<S::F>() {
             Ok(scalar) => Value::known(scalar),
-            Err(_) => Value::known(S::F::ZERO),
+            Err(_) => {
+                self.nb_failed_reads += 1;
+                Value::known(S::F::ZERO)
+            }
         };
 
         let assigned_scalar = self.scalar_chip.assign(layouter, scalar)?;
         self.common_scalar(layouter, &assigned_scalar)?;
 
         Ok(assigned_scalar)
+    }
+
+    /// Asserts that the proof was read in full: every read succeeded and no
+    /// bytes are left over.
+    ///
+    /// A diagnostic, not a circuit constraint. Reads that run past the end of
+    /// the proof, or that stop short of it, mean the gadget and the prover
+    /// disagree on the transcript layout; without this check the only symptom
+    /// is an unsatisfiable circuit at some unrelated row, because
+    /// [`Self::read_scalar`] and [`Self::read_commitment`] silently substitute
+    /// defaults on a failed read.
+    ///
+    /// A gadget initialised without a proof (key generation, where every read
+    /// legitimately fails) is exempt.
+    pub fn assert_proof_fully_consumed(&mut self) -> Result<(), Error> {
+        if self.proof_len == 0 {
+            return Ok(());
+        }
+
+        if self.nb_failed_reads > 0 {
+            return Err(Synthesis(format!(
+                "{} transcript read(s) ran past the end of a {}-byte proof",
+                self.nb_failed_reads, self.proof_len
+            )));
+        }
+
+        let reader = self.transcript_reader.as_mut().expect("You must init the transcript gadget");
+        reader.assert_empty().map_err(|_| {
+            Synthesis(format!(
+                "the verifier gadget left trailing bytes in a {}-byte proof",
+                self.proof_len
+            ))
+        })
     }
 }
 

--- a/circuits/src/verifier/verifier_gadget.rs
+++ b/circuits/src/verifier/verifier_gadget.rs
@@ -848,13 +848,17 @@ impl<S: SelfEmulation> VerifierGadget<S> {
         // We are now convinced the circuit is satisfied so long as the
         // polynomial commitments open to the correct values, which is true as long
         // as the following accumulator passes the invariant.
-        PCS::multi_prepare(
+        let accumulator = PCS::multi_prepare(
             layouter,
             &self.curve_chip,
             &self.scalar_chip,
             &mut transcript,
             &queries,
-        )
+        )?;
+
+        transcript.assert_proof_fully_consumed()?;
+
+        Ok(accumulator)
     }
 
     /// Prepares a plonk proof into a PCS instance that can be finalized or
@@ -933,7 +937,10 @@ pub(crate) mod tests {
             AssignmentInstructions,
             hash::{HashCPU, HashInstructions},
         },
-        testing_utils::FromScratch,
+        testing_utils::{
+            FromScratch,
+            transcript_trace::{TracingTranscript, assert_streams_match, in_circuit},
+        },
         types::{ComposableChip, Instantiable},
         verifier::{
             AssignedKZGCommitment, BlstrsEmulation, InCircuitKZG, accumulator::Accumulator,
@@ -1178,19 +1185,16 @@ pub(crate) mod tests {
             transcript.finalize()
         };
 
-        let inner_dual_msm = {
-            let mut transcript =
-                CircuitTranscript::<PoseidonState<F>>::init_from_bytes(&inner_proof);
-            prepare::<F, MidnightPCS<E>, CircuitTranscript<PoseidonState<F>>>(
-                &inner_vk,
-                &[KZGMultiCommitment::commitment_to_zero(
-                    PolynomialLabel::CommittedInstance(0),
-                )],
-                &[&inner_public_inputs],
-                &mut transcript,
-            )
-            .expect("Problem preparing the inner proof")
-        };
+        let mut off_circuit_transcript = TracingTranscript::<F>::init_from_bytes(&inner_proof);
+        let inner_dual_msm = prepare::<F, MidnightPCS<E>, TracingTranscript<F>>(
+            &inner_vk,
+            &[KZGMultiCommitment::commitment_to_zero(
+                PolynomialLabel::CommittedInstance(0),
+            )],
+            &[&inner_public_inputs],
+            &mut off_circuit_transcript,
+        )
+        .expect("Problem preparing the inner proof");
 
         let fixed_bases = crate::verifier::fixed_bases::<S>(&inner_vk);
 
@@ -1219,8 +1223,16 @@ pub(crate) mod tests {
             inner_proof: Value::known(inner_proof),
         };
 
+        in_circuit::start();
         let prover =
             MockProver::run(&circuit, vec![vec![], public_inputs]).expect("MockProver failed");
+
+        // The two verifiers must absorb the same field elements in the same order
+        // and squeeze at the same points. This diff names the first operation where
+        // they part ways; without it a mismatch only shows up as an unsatisfiable
+        // circuit at an unrelated row.
+        assert_streams_match(off_circuit_transcript.events(), &in_circuit::take());
+
         prover.assert_satisfied();
     }
 }


### PR DESCRIPTION
Adds better error tracking in the verifier gadget: in short, tracks the transcript more precisely to display error messages indicating more precisely where the desync between the verifier and the verifier gadget happens. This was useful for debugging during the development.

With this, a soft bug was found testing, the verifier gadget was making a proof it does not fully consume silently unsatisfiable, whereas an Err(Synthesis(..)) is more consistent with the verifier's behaviour. Patch included in this PR.