### PR TITLE
[Fflonk PR8] [Verifier Gadget PR2] Refactoring for the verifier gadget

### DIFF
--- a/aggregation/examples/single_circuit_aggregation.rs
+++ b/aggregation/examples/single_circuit_aggregation.rs
@@ -68,7 +68,7 @@ pub struct InnerCircuitContext {
 
 impl InnerCircuitContext {
     fn fixed_bases(&self) -> BTreeMap<PolynomialLabel, C> {
-        verifier::fixed_bases::<S>(self.vk.vk())
+        verifier::fixed_bases::<S, _>(self.vk.vk())
     }
 }
 

--- a/aggregation/src/ivc/prover.rs
+++ b/aggregation/src/ivc/prover.rs
@@ -65,7 +65,7 @@ impl<T: Ivc> IvcProver<T> {
         let vk = self.pk.pk().get_vk();
         let vk_repr = vk.transcript_repr();
 
-        let fixed_bases = midnight_circuits::verifier::fixed_bases::<S>(vk);
+        let fixed_bases = midnight_circuits::verifier::fixed_bases::<S, _>(vk);
 
         // Off-circuit verification of the previous proof.
         let proof_acc = if T::is_genesis(self.relation.ctx(), &self.state) {

--- a/aggregation/src/ivc/setup.rs
+++ b/aggregation/src/ivc/setup.rs
@@ -39,7 +39,7 @@ pub fn setup<T: Ivc>(
     let pk = midnight_zk_stdlib::setup_pk(&relation, &vk);
 
     let fixed_base_labels: Vec<PolynomialLabel> =
-        fixed_bases::<S>(vk.vk()).keys().cloned().collect();
+        fixed_bases::<S, _>(vk.vk()).keys().cloned().collect();
 
     let verifier = IvcVerifier {
         ctx: ctx.clone(),

--- a/aggregation/src/ivc/verifier.rs
+++ b/aggregation/src/ivc/verifier.rs
@@ -55,7 +55,7 @@ impl<T: Ivc> IvcVerifier<T> {
             return Err(IvcError::DeciderFailed);
         }
 
-        let fixed_bases = midnight_circuits::verifier::fixed_bases::<S>(self.vk.vk());
+        let fixed_bases = midnight_circuits::verifier::fixed_bases::<S, _>(self.vk.vk());
 
         let pi =
             IvcCircuit::<T>::format_instance(instance).map_err(|_| IvcError::InvalidInstance)?;

--- a/aggregation/src/multi_circuit_aggregator/circuit.rs
+++ b/aggregation/src/multi_circuit_aggregator/circuit.rs
@@ -274,7 +274,7 @@ impl IvcTransition for ProofAggregation {
                 "invalid inner proof"
             );
 
-            let vk_bases = verifier::fixed_bases::<S>(witness.claim.vk.vk());
+            let vk_bases = verifier::fixed_bases::<S, _>(witness.claim.vk.vk());
             let mut acc = Accumulator::from_dual_msm(dual_msm, &vk_bases);
             acc.collapse();
             acc.resolve_fixed_bases(&vk_bases);

--- a/circuits/src/verifier/kzg.rs
+++ b/circuits/src/verifier/kzg.rs
@@ -31,7 +31,7 @@ use group::Group;
 use midnight_proofs::{
     circuit::{Layouter, Value},
     pcs::kzg::commitment::KZGCommitment,
-    plonk::Error,
+    plonk::Error::{self, Synthesis},
     poly::PolynomialLabel,
 };
 
@@ -559,9 +559,12 @@ pub(crate) fn multi_prepare_kzg<S: SelfEmulation>(
         (q_coms, q_eval_sets, point_sets)
     };
 
-    let f_com = transcript_gadget
-        .read_commitment(layouter, &[PolynomialLabel::Custom("kzg_batch".into())])?
-        .into_single();
+    let f_com = InCircuitKZG::<S>::read_commitment(
+        transcript_gadget,
+        layouter,
+        &[PolynomialLabel::Custom("kzg_batch".into())],
+    )?
+    .into_single();
 
     let x3 = transcript_gadget.squeeze_challenge(layouter)?;
     #[cfg(feature = "truncated-challenges")]
@@ -638,9 +641,12 @@ pub(crate) fn multi_prepare_kzg<S: SelfEmulation>(
         )
     };
 
-    let pi = transcript_gadget
-        .read_commitment(layouter, &[PolynomialLabel::Custom("π".into())])?
-        .into_single();
+    let pi = InCircuitKZG::<S>::read_commitment(
+        transcript_gadget,
+        layouter,
+        &[PolynomialLabel::Custom("π".into())],
+    )?
+    .into_single();
     let pi_msm = pi.into_msm(layouter, scalar_chip)?;
 
     // Scale zπ
@@ -677,7 +683,23 @@ impl<S: SelfEmulation> InCircuitPCS<S> for InCircuitKZG<S> {
         layouter: &mut impl Layouter<S::F>,
         labels: &[PolynomialLabel],
     ) -> Result<Self::AssignedCommitment, Error> {
-        transcript.read_commitment(layouter, labels)
+        // KZG commits each polynomial independently, so a commitment to
+        // `labels.len()` polynomials is that many points on the wire.
+        let points = labels
+            .iter()
+            .map(|_| transcript.read_point(layouter))
+            .collect::<Result<Vec<_>, Error>>()?;
+
+        let commitment = AssignedKZGMultiCommitment(
+            points
+                .into_iter()
+                .zip(labels)
+                .map(|(point, label)| AssignedKZGCommitment::simple(point, label.clone()))
+                .collect(),
+        );
+        Self::common_commitment(transcript, layouter, &commitment)?;
+
+        Ok(commitment)
     }
 
     fn assign_commitment(
@@ -696,7 +718,20 @@ impl<S: SelfEmulation> InCircuitPCS<S> for InCircuitKZG<S> {
         layouter: &mut impl Layouter<S::F>,
         commitment: &AssignedKZGMultiCommitment<S>,
     ) -> Result<(), Error> {
-        transcript.common_commitment(layouter, commitment)
+        for inner in commitment.0.iter() {
+            match inner {
+                AssignedKZGCommitment::Simple(AssignedPoint::Variable(p), _label) => {
+                    transcript.absorb_point(layouter, p)
+                }
+                AssignedKZGCommitment::Simple(AssignedPoint::Fixed, label) => Err(Synthesis(
+                    format!("Fixed commitments cannot be added to the transcript: {label}"),
+                )),
+                AssignedKZGCommitment::Linear(_, _, labels) => Err(Synthesis(format!(
+                    "Linear commitments cannot be added to the transcript: {labels:?}"
+                ))),
+            }?
+        }
+        Ok(())
     }
 
     fn multi_prepare(

--- a/circuits/src/verifier/kzg.rs
+++ b/circuits/src/verifier/kzg.rs
@@ -11,22 +11,15 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-//! Multiopen argument for GWC version of the KZG commitment scheme.
+//! In-circuit KZG commitment scheme.
 //!
-//! This file provides the in-circuit version of the KZG multiopen argument from
-//! halo2. In particular, we try to follow the exact same structure used in
-//! halo2, concretely in halo2 files:
-//!  - src/poly/kzg/utils.rs,
-//!  - src/poly/query.rs
-//!  - src/utils/arithmetic.rs
-//!  - src/poly/kzg/mod.rs
+//! Holds the in-circuit commitment type and the KZG-specific parts of the
+//! multi-open argument: the wire format of a commitment and the peeling of a
+//! multi-commitment down to the polynomial a query targets. The
+//! scheme-independent remainder lives in `super::multi_open`.
 
-use std::{
-    collections::{BTreeSet, HashMap},
-    marker::PhantomData,
-};
+use std::{collections::HashMap, marker::PhantomData};
 
-use ff::Field;
 use group::Group;
 use midnight_curves::pairing::MultiMillerLoop;
 use midnight_proofs::{
@@ -39,27 +32,22 @@ use midnight_proofs::{
     poly::PolynomialLabel,
 };
 
-#[cfg(feature = "truncated-challenges")]
-use crate::verifier::utils::truncate;
 use crate::{
-    CircuitField,
     field::AssignedNative,
-    instructions::{ArithInstructions, AssignmentInstructions},
+    instructions::AssignmentInstructions,
     types::InnerValue,
     verifier::{
         AssignedAccumulator, SelfEmulation, SingletonCommitment,
         msm::{AssignedMsm, AssignedPoint},
+        multi_open::multi_prepare_core,
         pcs::{InCircuitHomomorphicCommitment, InCircuitPCS, VerifierQuery},
         transcript_gadget::TranscriptGadget,
-        utils::{
-            AssignedBoundedScalar, evaluate_interpolated_polynomial, inner_product, mul_add,
-            mul_bounded_scalars, truncated_powers,
-        },
+        utils::{AssignedBoundedScalar, mul_bounded_scalars},
     },
 };
 
 // -------------------------------------
-// See proofs/src/poly/kzg/commitment.rs
+// See proofs/src/pcs/kzg/commitment.rs
 // -------------------------------------
 
 /// In-circuit analog of
@@ -128,22 +116,17 @@ impl<S: SelfEmulation> AssignedKZGCommitment<S> {
         curve_chip.assign(layouter, point).map(|p| Self::simple(p, label))
     }
 
-    /// Converts this commitment into an [`AssignedMsm`] for use in the
-    /// multiopen accumulation.
+    /// Views this commitment as an [`AssignedMsm`] for use in the multiopen
+    /// accumulation. `one` is an assigned constant 1.
     ///
     /// `Simple(p, l)` becomes a one-term MSM `[(1, p, l)]`.
     /// `Linear(points, scalars, labels)` becomes the corresponding multi-term
     /// MSM.
-    pub fn into_msm(
-        self,
-        layouter: &mut impl Layouter<S::F>,
-        scalar_chip: &S::ScalarChip,
-    ) -> Result<AssignedMsm<S>, Error> {
-        let one = AssignedBoundedScalar::one(layouter, scalar_chip)?;
-        Ok(match self {
-            Self::Simple(p, label) => AssignedMsm::new(&[one], &[p], &[label]),
-            Self::Linear(points, scalars, labels) => AssignedMsm::new(&scalars, &points, &labels),
-        })
+    pub fn to_msm(&self, one: &AssignedBoundedScalar<S::F>) -> AssignedMsm<S> {
+        match self {
+            Self::Simple(p, label) => AssignedMsm::from_term(one.clone(), p.clone(), label.clone()),
+            Self::Linear(points, scalars, labels) => AssignedMsm::new(scalars, points, labels),
+        }
     }
 }
 
@@ -270,407 +253,6 @@ impl<S: SelfEmulation> InCircuitHomomorphicCommitment<S> for AssignedKZGMultiCom
     }
 }
 
-// --------------------------------
-// See proofs/src/poly/kzg/utils.rs
-// --------------------------------
-
-#[derive(Clone, Debug)]
-pub(crate) struct CommitmentData<S: SelfEmulation> {
-    label: PolynomialLabel,
-    set_index: usize,
-    point_indices: Vec<usize>,
-    evals: Vec<AssignedNative<S::F>>,
-}
-
-impl<S: SelfEmulation> CommitmentData<S> {
-    fn new(label: PolynomialLabel) -> Self {
-        CommitmentData {
-            label,
-            set_index: 0,
-            point_indices: vec![],
-            evals: vec![],
-        }
-    }
-}
-
-type IntermediateSets<S> = (
-    Vec<CommitmentData<S>>,
-    Vec<Vec<AssignedNative<<S as SelfEmulation>::F>>>,
-);
-
-#[allow(clippy::type_complexity)]
-fn construct_intermediate_sets<S: SelfEmulation>(
-    queries: &[(PolynomialLabel, AssignedNative<S::F>, AssignedNative<S::F>)],
-    default_eval: AssignedNative<S::F>,
-) -> Result<IntermediateSets<S>, Error> {
-    // Construct sets of unique commitments and corresponding information about
-    // their queries.
-    let mut commitment_map: Vec<CommitmentData<S>> = vec![];
-
-    // Also construct mapping from a unique point to a point_index. This defines
-    // an ordering on the points.
-    // Note that we use a HashMap, whereas halo2 uses a BTreeMap. This is because
-    // `AssignedScalar` does not implement `Ord`, but implements `Hash`.
-    // This difference is not a problem, since the order of keys does not matter
-    // for this algorithm.
-    let mut point_index_map = HashMap::new();
-
-    // Iterate over all of the queries, computing the ordering of the points
-    // while also creating new commitment data.
-    for (query_label, query_point, _query_eval) in queries.iter() {
-        let num_points = point_index_map.len();
-        let point_idx = point_index_map.entry(query_point).or_insert(num_points);
-
-        if let Some(pos) = commitment_map.iter().position(|comm| &comm.label == query_label) {
-            if commitment_map[pos].point_indices.contains(point_idx) {
-                return Err(Error::Synthesis("repeated query".into()));
-            }
-            commitment_map[pos].point_indices.push(*point_idx);
-        } else {
-            let mut tmp = CommitmentData::new(query_label.clone());
-            tmp.point_indices.push(*point_idx);
-            commitment_map.push(tmp);
-        }
-    }
-
-    // Also construct inverse mapping from point_index to the point
-    let mut inverse_point_index_map = HashMap::new();
-    for (&point, &point_index) in point_index_map.iter() {
-        inverse_point_index_map.insert(point_index, point.clone());
-    }
-
-    // Construct map of unique ordered point_idx_sets to their set_idx.
-    let mut point_idx_sets = HashMap::new();
-    // Also construct mapping from commitment to point_idx_set
-    let mut commitment_set_map = Vec::new();
-
-    for commitment_data in commitment_map.iter() {
-        let mut point_index_set = BTreeSet::new();
-        // Note that point_index_set is ordered, unlike point_indices
-        for &point_index in commitment_data.point_indices.iter() {
-            point_index_set.insert(point_index);
-        }
-
-        // Push point_index_set to CommitmentData for the relevant commitment
-        commitment_set_map.push((commitment_data.label.clone(), point_index_set.clone()));
-
-        let num_sets = point_idx_sets.len();
-        point_idx_sets.entry(point_index_set).or_insert(num_sets);
-    }
-
-    // Initialise empty evals vec for each unique commitment
-    for commitment_data in commitment_map.iter_mut() {
-        let len = commitment_data.point_indices.len();
-        commitment_data.evals = vec![default_eval.clone(); len];
-    }
-
-    // Populate set_index, evals and points for each commitment using point_idx_sets
-    for (query_label, query_point, query_eval) in queries.iter() {
-        // The index of the point at which the commitment is queried
-        let point_index = point_index_map.get(&query_point).unwrap();
-
-        // The point_index_set at which the commitment was queried
-        let mut point_index_set = BTreeSet::new();
-        for (l, point_idx_set) in commitment_set_map.iter() {
-            if l == query_label {
-                point_index_set.clone_from(point_idx_set);
-            }
-        }
-        assert!(!point_index_set.is_empty());
-
-        // The set_index of the point_index_set
-        let set_index = point_idx_sets.get(&point_index_set).unwrap();
-        for commitment_data in commitment_map.iter_mut() {
-            if query_label == &commitment_data.label {
-                commitment_data.set_index = *set_index;
-            }
-        }
-        let point_index_set: Vec<usize> = point_index_set.iter().cloned().collect();
-
-        // The offset of the point_index in the point_index_set
-        let point_index_in_set = point_index_set.iter().position(|i| i == point_index).unwrap();
-
-        for commitment_data in commitment_map.iter_mut() {
-            if *query_label == commitment_data.label {
-                // Insert the eval using the ordering of the point_index_set
-                commitment_data.evals[point_index_in_set] = query_eval.clone();
-            }
-        }
-    }
-
-    // Get actual points in each point set
-    let mut point_sets: Vec<Vec<AssignedNative<S::F>>> = vec![Vec::new(); point_idx_sets.len()];
-    for (point_idx_set, &set_idx) in point_idx_sets.iter() {
-        for &point_idx in point_idx_set.iter() {
-            let point = inverse_point_index_map.get(&point_idx).unwrap();
-            point_sets[set_idx].push((*point).clone());
-        }
-    }
-
-    Ok((commitment_map, point_sets))
-}
-
-// ----------------------------------
-// See proofs/src/utils/arithmetic.rs
-// ----------------------------------
-
-fn msm_inner_product<S: SelfEmulation>(
-    layouter: &mut impl Layouter<S::F>,
-    scalar_chip: &S::ScalarChip,
-    msms: &[AssignedMsm<S>],
-    scalars: &[AssignedBoundedScalar<S::F>],
-) -> Result<AssignedMsm<S>, Error> {
-    let mut res = AssignedMsm::empty();
-    let mut msms = msms.to_vec();
-    for (msm, s) in msms.iter_mut().zip(scalars) {
-        msm.scale(layouter, scalar_chip, s)?;
-        res.add_msm(msm)?;
-    }
-    Ok(res)
-}
-
-/// Computes the inner product of a set of polynomial evaluations and a set of
-/// scalar values. This function computes the weighted sum of polynomial
-/// evaluations. Each vector in `evals_set` is multiplied element-wise by a
-/// corresponding scalar from `scalars`, and the results are accumulated
-/// into a single vector.
-fn evals_inner_product<F: CircuitField>(
-    layouter: &mut impl Layouter<F>,
-    scalar_chip: &impl ArithInstructions<F, AssignedNative<F>>,
-    evals_set: &[Vec<AssignedNative<F>>],
-    scalars: &[AssignedBoundedScalar<F>],
-) -> Result<Vec<AssignedNative<F>>, Error> {
-    let zero = scalar_chip.assign_fixed(layouter, F::ZERO)?;
-    let mut res = vec![zero.clone(); evals_set[0].len()];
-    for (poly_evals, s) in evals_set.iter().zip(scalars) {
-        for i in 0..res.len() {
-            // res[i] := s.scalar * poly_evals[i] + res[i]
-            res[i] = mul_add(layouter, scalar_chip, &s.scalar, &poly_evals[i], &res[i])?;
-        }
-    }
-    Ok(res)
-}
-
-// ------------------------------
-// See proofs/src/poly/kzg/mod.rs
-// ------------------------------
-
-/// Verifies a bunch of KZG queries in a multi-open argument.
-/// The resulting accumulator satisfies the invariant iff all queries are valid.
-pub(crate) fn multi_prepare_kzg<S: SelfEmulation>(
-    layouter: &mut impl Layouter<S::F>,
-    #[cfg(feature = "truncated-challenges")] curve_chip: &S::CurveChip,
-    scalar_chip: &S::ScalarChip,
-    transcript_gadget: &mut TranscriptGadget<S>,
-    queries: &[VerifierQuery<S, InCircuitKZG<S>>],
-) -> Result<AssignedAccumulator<S>, Error> {
-    let one = AssignedBoundedScalar::one(layouter, scalar_chip)?;
-
-    // Add dummy queries to reduce the number of distinct multi-open point sets.
-    #[cfg(feature = "fewer-point-sets")]
-    let queries = &{
-        let pairs: Vec<_> = queries.iter().map(|q| (q.label.clone(), q.point.clone())).collect();
-        let dummy_openings = midnight_proofs::pcs::compute_dummy_queries(&pairs);
-        let mut queries = queries.to_vec();
-        for (idx, dummy_point) in dummy_openings {
-            queries.push(VerifierQuery {
-                point: dummy_point,
-                commitment: queries[idx].commitment,
-                label: queries[idx].label.clone(),
-                eval: transcript_gadget.read_scalar(layouter)?,
-            });
-        }
-        queries
-    };
-
-    let x1 = transcript_gadget.squeeze_challenge(layouter)?;
-    let x2 = transcript_gadget.squeeze_challenge(layouter)?;
-
-    // Peel each query's multi-commitment down to the single inner commitment it
-    // targets, keyed by the query label. A length-1 commitment (the common case,
-    // including the `Linear` linearization commitment) peels to its sole inner;
-    // a batched commitment holds several `Simple`s, so we pick the one whose own
-    // label matches the query.
-    let label_to_commitment: HashMap<PolynomialLabel, &AssignedKZGCommitment<S>> = queries
-        .iter()
-        .map(|q| {
-            let inners = &q.commitment.0;
-            let inner = if inners.len() == 1 {
-                &inners[0]
-            } else {
-                inners
-                    .iter()
-                    .find(|c| matches!(c, AssignedKZGCommitment::Simple(_, label) if *label == q.label))
-                    .expect("batched commitment has no polynomial matching the query label")
-            };
-            (q.label.clone(), inner)
-        })
-        .collect();
-
-    let default_eval = scalar_chip.assign_fixed(layouter, S::F::default())?;
-    let kzg_queries = queries
-        .iter()
-        .map(|query| (query.label.clone(), query.point.clone(), query.eval.clone()))
-        .collect::<Vec<_>>();
-    let (commitment_map, point_sets) =
-        construct_intermediate_sets::<S>(&kzg_queries, default_eval)?;
-
-    let mut q_coms: Vec<_> = vec![vec![]; point_sets.len()];
-    let mut q_eval_sets = vec![vec![]; point_sets.len()];
-
-    for com_data in commitment_map.into_iter() {
-        let mut msm = AssignedMsm::empty();
-        match label_to_commitment[&com_data.label] {
-            AssignedKZGCommitment::Simple(p, label) => msm.add_term(&one, p, label),
-            AssignedKZGCommitment::Linear(points, scalars, labels) => {
-                msm.add_msm(&AssignedMsm::new(scalars, points, labels))?;
-            }
-        }
-        q_coms[com_data.set_index].push(msm);
-        q_eval_sets[com_data.set_index].push(com_data.evals);
-    }
-
-    let truncated_x1_powers = {
-        let nb_x1_powers = q_coms.iter().map(|v| v.len()).max().unwrap_or(0);
-        assert!(nb_x1_powers >= q_eval_sets.iter().map(|v| v.len()).max().unwrap_or(0));
-        truncated_powers(layouter, scalar_chip, &x1, nb_x1_powers)?
-    };
-
-    let q_coms = q_coms
-        .iter()
-        .map(|msms| msm_inner_product(layouter, scalar_chip, msms, &truncated_x1_powers))
-        .collect::<Result<Vec<_>, Error>>()?;
-
-    let q_eval_sets = q_eval_sets
-        .iter()
-        .map(|evals| evals_inner_product(layouter, scalar_chip, evals, &truncated_x1_powers))
-        .collect::<Result<Vec<_>, Error>>()?;
-
-    // Sort point sets by ascending cardinality to ensure the first set is the one
-    // that contains fixed commitments (which are evaluated at x only). This
-    // property is not necessary for the actual proving system, but it is important
-    // for in-circuit verification of proofs. (It enables an optimization based on
-    // an internal collapse.)
-    //
-    // The (len, i) key provides a deterministic total order even when two sets
-    // share the same cardinality.
-    let (q_coms, q_eval_sets, point_sets) = {
-        let mut order: Vec<usize> = (0..point_sets.len()).collect();
-        order.sort_by_key(|&i| (point_sets[i].len(), i));
-        let q_coms: Vec<_> = order.iter().map(|&i| q_coms[i].clone()).collect();
-        let q_eval_sets: Vec<_> = order.iter().map(|&i| q_eval_sets[i].clone()).collect();
-        let point_sets: Vec<_> = order.iter().map(|&i| point_sets[i].clone()).collect();
-        (q_coms, q_eval_sets, point_sets)
-    };
-
-    let f_com = InCircuitKZG::<S>::read_commitment(
-        transcript_gadget,
-        layouter,
-        &[PolynomialLabel::Custom("kzg_batch".into())],
-    )?
-    .into_single();
-
-    let x3 = transcript_gadget.squeeze_challenge(layouter)?;
-    #[cfg(feature = "truncated-challenges")]
-    let x3 = truncate::<S::F>(layouter, scalar_chip, &x3)?;
-    #[cfg(not(feature = "truncated-challenges"))]
-    let x3 = AssignedBoundedScalar::new(&x3, None);
-
-    let mut q_evals_on_x3 = Vec::with_capacity(q_eval_sets.len());
-    for _ in 0..q_eval_sets.len() {
-        q_evals_on_x3.push(transcript_gadget.read_scalar(layouter)?);
-    }
-
-    let zero = scalar_chip.assign_fixed(layouter, S::F::ZERO)?;
-    let f_eval = point_sets
-        .iter()
-        .zip(q_eval_sets.iter())
-        .zip(q_evals_on_x3.iter())
-        .rev()
-        .try_fold(zero, |acc_eval, ((points, evals), proof_eval)| {
-            let r_eval =
-                evaluate_interpolated_polynomial(layouter, scalar_chip, points, evals, &x3.scalar)?;
-
-            // eval = (proof_eval - r_eval) / prod_i (x3 - point_i)
-            let den = points.iter().skip(1).try_fold(
-                scalar_chip.sub(layouter, &x3.scalar, &points[0])?,
-                |acc, point| {
-                    // acc * (x3 - point) computed as acc * x3 - acc * point
-                    scalar_chip.add_and_double_mul(
-                        layouter,
-                        (S::F::ZERO, &acc),
-                        (S::F::ZERO, &x3.scalar),
-                        (S::F::ZERO, point),
-                        S::F::ZERO,
-                        (S::F::ONE, -S::F::ONE),
-                    )
-                },
-            )?;
-            let mut eval = scalar_chip.sub(layouter, proof_eval, &r_eval)?;
-            eval = scalar_chip.div(layouter, &eval, &den)?;
-
-            // acc_eval * x2 + eval
-            mul_add(layouter, scalar_chip, &acc_eval, &x2, &eval)
-        })?;
-
-    let x4 = transcript_gadget.squeeze_challenge(layouter)?;
-    let truncated_x4_powers =
-        truncated_powers::<S::F>(layouter, scalar_chip, &x4, q_coms.len() + 1)?;
-
-    let final_com = {
-        let mut coms = q_coms;
-
-        // We collapse all AssignedMsm at this point to later leverage the fact that x4
-        // powers are truncated. Exceptionally, the first one is not collapsed,
-        // as the first x4 power is 1.
-        #[cfg(feature = "truncated-challenges")]
-        coms.iter_mut().skip(1).try_for_each(|com| {
-            com.collapse(layouter, curve_chip, scalar_chip, PolynomialLabel::NoLabel)
-        })?;
-        coms.push(f_com.into_msm(layouter, scalar_chip)?);
-
-        msm_inner_product(layouter, scalar_chip, &coms, &truncated_x4_powers)?
-    };
-
-    let v = {
-        let mut evals = q_evals_on_x3;
-        evals.push(f_eval);
-
-        let scalar_x4_powers: Vec<_> =
-            truncated_x4_powers.iter().map(|s| s.scalar.clone()).collect();
-
-        AssignedBoundedScalar::new(
-            &inner_product(layouter, scalar_chip, &evals, &scalar_x4_powers)?,
-            None,
-        )
-    };
-
-    let pi = InCircuitKZG::<S>::read_commitment(
-        transcript_gadget,
-        layouter,
-        &[PolynomialLabel::Custom("π".into())],
-    )?
-    .into_single();
-    let pi_msm = pi.into_msm(layouter, scalar_chip)?;
-
-    // Scale zπ
-    let mut scaled_pi = pi_msm.clone();
-    scaled_pi.scale(layouter, scalar_chip, &x3)?;
-
-    // (π, C − vG + zπ)
-    let left = pi_msm; // π
-
-    let right = {
-        let mut right = final_com; // C
-        let minus_v_gen = AssignedMsm::from_fixed_term(v, PolynomialLabel::Custom("-G".into()));
-        right.add_msm(&minus_v_gen)?; // -vG
-        right.add_msm(&scaled_pi)?; // zπ
-        right
-    };
-
-    Ok(AssignedAccumulator::new(left, right))
-}
-
 /// KZG instantiation of [`InCircuitPCS`].
 #[derive(Clone, Copy, Debug)]
 pub struct InCircuitKZG<S: SelfEmulation>(PhantomData<S>);
@@ -752,13 +334,72 @@ impl<S: SelfEmulation> InCircuitPCS<S> for InCircuitKZG<S> {
         transcript: &mut TranscriptGadget<S>,
         queries: &[VerifierQuery<'_, S, Self>],
     ) -> Result<AssignedAccumulator<S>, Error> {
-        multi_prepare_kzg(
+        let one = AssignedBoundedScalar::one(layouter, scalar_chip)?;
+
+        // Add dummy queries to reduce the number of distinct multi-open point sets.
+        #[cfg(feature = "fewer-point-sets")]
+        let queries = &{
+            let pairs: Vec<_> =
+                queries.iter().map(|q| (q.label.clone(), q.point.clone())).collect();
+            let dummy_openings = midnight_proofs::pcs::compute_dummy_queries(&pairs);
+            let mut queries = queries.to_vec();
+            for (idx, dummy_point) in dummy_openings {
+                queries.push(VerifierQuery {
+                    point: dummy_point,
+                    commitment: queries[idx].commitment,
+                    label: queries[idx].label.clone(),
+                    eval: transcript.read_scalar(layouter)?,
+                });
+            }
+            queries
+        };
+
+        // Peel each query's multi-commitment down to the single inner commitment it
+        // targets, keyed by the query label. A length-1 commitment (the common case,
+        // including the `Linear` linearization commitment) peels to its sole inner;
+        // a batched commitment holds several `Simple`s, so we pick the one whose own
+        // label matches the query.
+        let label_to_com: HashMap<PolynomialLabel, AssignedMsm<S>> = queries
+            .iter()
+            .map(|q| {
+                let inners = &q.commitment.0;
+                let inner = if inners.len() == 1 {
+                    &inners[0]
+                } else {
+                    inners
+                        .iter()
+                        .find(|c| matches!(c, AssignedKZGCommitment::Simple(_, label) if *label == q.label))
+                        .expect("batched commitment has no polynomial matching the query label")
+                };
+                (q.label.clone(), inner.to_msm(&one))
+            })
+            .collect();
+
+        let triples = queries
+            .iter()
+            .map(|query| (query.label.clone(), query.point.clone(), query.eval.clone()))
+            .collect::<Vec<_>>();
+
+        multi_prepare_core(
             layouter,
             #[cfg(feature = "truncated-challenges")]
             _curve_chip,
             scalar_chip,
             transcript,
-            queries,
+            &triples,
+            &label_to_com,
+            |layouter, transcript, label| match Self::read_commitment(
+                transcript,
+                layouter,
+                &[label],
+            )?
+            .into_single()
+            {
+                AssignedKZGCommitment::Simple(p, _) => Ok(p),
+                AssignedKZGCommitment::Linear(_, _, labels) => Err(Synthesis(format!(
+                    "the multi-open argument reads plain commitments, got a linear one: {labels:?}"
+                ))),
+            },
         )
     }
 }

--- a/circuits/src/verifier/kzg.rs
+++ b/circuits/src/verifier/kzg.rs
@@ -28,9 +28,13 @@ use std::{
 
 use ff::Field;
 use group::Group;
+use midnight_curves::pairing::MultiMillerLoop;
 use midnight_proofs::{
     circuit::{Layouter, Value},
-    pcs::kzg::commitment::KZGCommitment,
+    pcs::kzg::{
+        KZGCommitmentScheme,
+        commitment::{KZGCommitment, KZGMultiCommitment},
+    },
     plonk::Error::{self, Synthesis},
     poly::PolynomialLabel,
 };
@@ -43,7 +47,7 @@ use crate::{
     instructions::{ArithInstructions, AssignmentInstructions},
     types::InnerValue,
     verifier::{
-        AssignedAccumulator, SelfEmulation,
+        AssignedAccumulator, SelfEmulation, SingletonCommitment,
         msm::{AssignedMsm, AssignedPoint},
         pcs::{InCircuitHomomorphicCommitment, InCircuitPCS, VerifierQuery},
         transcript_gadget::TranscriptGadget,
@@ -59,7 +63,7 @@ use crate::{
 // -------------------------------------
 
 /// In-circuit analog of
-/// [`KZGCommitment`](midnight_proofs::pcs::kzg::commitment::KZGCommitment).
+/// [`KZGCommitment`].
 ///
 /// Carries a polynomial commitment (or a lazy linear combination of them)
 /// together with its `PolynomialLabel`(s).
@@ -192,7 +196,7 @@ impl<S: SelfEmulation> AssignedKZGCommitment<S> {
 }
 
 /// In-circuit analog of
-/// [`KZGMultiCommitment`](midnight_proofs::pcs::kzg::commitment::KZGMultiCommitment):
+/// [`KZGMultiCommitment`]:
 /// a commitment to one or more polynomials.
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct AssignedKZGMultiCommitment<S: SelfEmulation>(pub Vec<AssignedKZGCommitment<S>>);
@@ -671,7 +675,14 @@ pub(crate) fn multi_prepare_kzg<S: SelfEmulation>(
 #[derive(Clone, Copy, Debug)]
 pub struct InCircuitKZG<S: SelfEmulation>(PhantomData<S>);
 
+impl<E: MultiMillerLoop> SingletonCommitment<E::G1> for KZGMultiCommitment<E> {
+    fn point(&self) -> E::G1 {
+        *self.0[0].as_point()
+    }
+}
+
 impl<S: SelfEmulation> InCircuitPCS<S> for InCircuitKZG<S> {
+    type OffCircuit = KZGCommitmentScheme<S::Engine>;
     type AssignedCommitment = AssignedKZGMultiCommitment<S>;
 
     fn fixed_commitment(label: PolynomialLabel) -> Self::AssignedCommitment {

--- a/circuits/src/verifier/mod.rs
+++ b/circuits/src/verifier/mod.rs
@@ -17,8 +17,8 @@ use std::collections::BTreeMap;
 
 use group::Group;
 use midnight_proofs::{
-    MidnightPCS,
     circuit::Value,
+    pcs::PolynomialCommitmentScheme,
     plonk,
     plonk::ConstraintSystem,
     poly::{EvaluationDomain, PolynomialLabel},
@@ -52,8 +52,9 @@ pub use types::BnEmulation;
 pub use types::{BlstrsEmulation, SelfEmulation};
 pub use verifier_gadget::VerifierGadget;
 
-type VerifyingKey<S> =
-    plonk::VerifyingKey<<S as SelfEmulation>::F, MidnightPCS<<S as SelfEmulation>::Engine>>;
+/// The off-circuit verifying key that a given in-circuit PCS accepts.
+type VerifyingKey<S, PCS> =
+    plonk::VerifyingKey<<S as SelfEmulation>::F, <PCS as InCircuitPCS<S>>::OffCircuit>;
 
 /// Type for in-circuit verifying keys.
 ///
@@ -76,9 +77,9 @@ pub struct AssignedVk<S: SelfEmulation, PCS: InCircuitPCS<S>> {
 }
 
 impl<S: SelfEmulation, PCS: InCircuitPCS<S>> InnerValue for AssignedVk<S, PCS> {
-    type Element = VerifyingKey<S>;
+    type Element = VerifyingKey<S, PCS>;
 
-    fn value(&self) -> Value<VerifyingKey<S>> {
+    fn value(&self) -> Value<VerifyingKey<S, PCS>> {
         unimplemented!(
             "It is not possible to get a full verifying key out of an
              AssignedVk, as the latter does not include fixed commitments."
@@ -87,12 +88,12 @@ impl<S: SelfEmulation, PCS: InCircuitPCS<S>> InnerValue for AssignedVk<S, PCS> {
 }
 
 impl<S: SelfEmulation, PCS: InCircuitPCS<S>> Instantiable<S::F> for AssignedVk<S, PCS> {
-    fn as_public_input(vk: &VerifyingKey<S>) -> Vec<S::F> {
+    fn as_public_input(vk: &VerifyingKey<S, PCS>) -> Vec<S::F> {
         AssignedNative::<S::F>::as_public_input(&vk.transcript_repr())
     }
 
     #[cfg(any(test, feature = "testing"))]
-    fn from_public_input(_fields: &[S::F]) -> Option<VerifyingKey<S>> {
+    fn from_public_input(_fields: &[S::F]) -> Option<VerifyingKey<S, PCS>> {
         unimplemented!("as_public_input encodes the VK as its transcript_repr() — not invertible")
     }
 }
@@ -102,6 +103,20 @@ impl<S: SelfEmulation, PCS: InCircuitPCS<S>> AssignedVk<S, PCS> {
     pub fn transcript_repr(&self) -> &AssignedNative<S::F> {
         &self.transcript_repr
     }
+}
+
+/// An off-circuit commitment to a single polynomial, as a verifying key holds
+/// them.
+///
+/// Every commitment a verifying key carries is to one polynomial: the families
+/// a scheme may bundle are all witnessed, never fixed.
+pub trait SingletonCommitment<C> {
+    /// The curve point of this commitment.
+    ///
+    /// # Panics
+    ///
+    /// If the commitment does not hold exactly one polynomial.
+    fn point(&self) -> C;
 }
 
 /// Builds the map from [`PolynomialLabel`] to curve point for all
@@ -114,18 +129,24 @@ impl<S: SelfEmulation, PCS: InCircuitPCS<S>> AssignedVk<S, PCS> {
 ///   proof.
 ///
 /// Pass this map to [`Accumulator::check`] or [`Msm::eval`].
-pub fn fixed_bases<S: SelfEmulation>(vk: &VerifyingKey<S>) -> BTreeMap<PolynomialLabel, S::C> {
+pub fn fixed_bases<S: SelfEmulation, CS>(
+    vk: &plonk::VerifyingKey<S::F, CS>,
+) -> BTreeMap<PolynomialLabel, S::C>
+where
+    CS: PolynomialCommitmentScheme<S::F>,
+    CS::Commitment: SingletonCommitment<S::C>,
+{
     let mut fixed_bases = BTreeMap::new();
 
     let fixed_commitments = vk.fixed_commitments();
     let perm_commitments = vk.permutation().commitments();
 
     for (i, com) in fixed_commitments.iter().enumerate() {
-        fixed_bases.insert(PolynomialLabel::Fixed(i), *com.0[0].as_point());
+        fixed_bases.insert(PolynomialLabel::Fixed(i), com.point());
     }
 
     for (i, com) in perm_commitments.iter().enumerate() {
-        fixed_bases.insert(PolynomialLabel::PermutationFixed(i), *com.0[0].as_point());
+        fixed_bases.insert(PolynomialLabel::PermutationFixed(i), com.point());
     }
 
     fixed_bases.insert(PolynomialLabel::Custom("-G".into()), -S::C::generator());

--- a/circuits/src/verifier/mod.rs
+++ b/circuits/src/verifier/mod.rs
@@ -34,6 +34,7 @@ mod expressions;
 mod kzg;
 mod lookup;
 mod msm;
+mod multi_open;
 pub(crate) mod pcs;
 mod permutation;
 mod traces;

--- a/circuits/src/verifier/multi_open.rs
+++ b/circuits/src/verifier/multi_open.rs
@@ -1,0 +1,442 @@
+// This file is part of MIDNIGHT-ZK.
+// Copyright (C) Midnight Foundation
+// SPDX-License-Identifier: Apache-2.0
+// Licensed under the Apache License, Version 2.0 (the "License");
+// You may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// http://www.apache.org/licenses/LICENSE-2.0
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! In-circuit multi-point opening argument, shared by every scheme built on a
+//! KZG-style SRS.
+//!
+//! In-circuit analog of `proofs/src/pcs/multi_open.rs`: an `InCircuitPCS`
+//! implementation of `multi_prepare` is its own query expansion followed by a
+//! call into `multi_prepare_core`. Everything from the first squeezed
+//! challenge onwards is scheme-independent and lives here.
+//!
+//! Refer to the [Halo 2 Book](https://zcash.github.io/halo2/design/proving-system/multipoint-opening.html)
+//! for the argument itself.
+
+use std::collections::{BTreeSet, HashMap};
+
+use ff::Field;
+use midnight_proofs::{
+    circuit::Layouter,
+    plonk::Error::{self, Synthesis},
+    poly::PolynomialLabel,
+};
+
+#[cfg(feature = "truncated-challenges")]
+use crate::verifier::utils::truncate;
+use crate::{
+    CircuitField,
+    field::AssignedNative,
+    instructions::{ArithInstructions, AssignmentInstructions},
+    verifier::{
+        AssignedAccumulator, SelfEmulation,
+        msm::{AssignedMsm, AssignedPoint},
+        transcript_gadget::TranscriptGadget,
+        utils::{
+            AssignedBoundedScalar, evaluate_interpolated_polynomial, inner_product, mul_add,
+            truncated_powers,
+        },
+    },
+};
+
+/// Labels carried by the argument's own two commitments, the batch commitment
+/// `f` and the opening proof `π`. Both are variable bases, so neither label is
+/// ever resolved.
+const BATCH_LABEL: &str = "kzg_batch";
+const PROOF_LABEL: &str = "π";
+
+// --------------------------------
+// See proofs/src/pcs/utils.rs
+// --------------------------------
+
+#[derive(Clone, Debug)]
+struct CommitmentData<S: SelfEmulation> {
+    label: PolynomialLabel,
+    set_index: usize,
+    point_indices: Vec<usize>,
+    evals: Vec<AssignedNative<S::F>>,
+}
+
+impl<S: SelfEmulation> CommitmentData<S> {
+    fn new(label: PolynomialLabel) -> Self {
+        CommitmentData {
+            label,
+            set_index: 0,
+            point_indices: vec![],
+            evals: vec![],
+        }
+    }
+}
+
+/// A `(label, point, eval)` opening claim, after any scheme-specific query
+/// expansion.
+pub(crate) type QueryTriple<S> = (
+    PolynomialLabel,
+    AssignedNative<<S as SelfEmulation>::F>,
+    AssignedNative<<S as SelfEmulation>::F>,
+);
+
+type IntermediateSets<S> = (
+    Vec<CommitmentData<S>>,
+    Vec<Vec<AssignedNative<<S as SelfEmulation>::F>>>,
+);
+
+fn construct_intermediate_sets<S: SelfEmulation>(
+    queries: &[QueryTriple<S>],
+    default_eval: AssignedNative<S::F>,
+) -> Result<IntermediateSets<S>, Error> {
+    // Construct sets of unique commitments and corresponding information about
+    // their queries.
+    let mut commitment_map: Vec<CommitmentData<S>> = vec![];
+
+    // Also construct mapping from a unique point to a point_index. This defines
+    // an ordering on the points.
+    // Note that we use a HashMap, whereas halo2 uses a BTreeMap. This is because
+    // `AssignedScalar` does not implement `Ord`, but implements `Hash`.
+    // This difference is not a problem, since the order of keys does not matter
+    // for this algorithm.
+    let mut point_index_map = HashMap::new();
+
+    // Iterate over all of the queries, computing the ordering of the points
+    // while also creating new commitment data.
+    for (query_label, query_point, _query_eval) in queries.iter() {
+        let num_points = point_index_map.len();
+        let point_idx = point_index_map.entry(query_point).or_insert(num_points);
+
+        if let Some(pos) = commitment_map.iter().position(|comm| &comm.label == query_label) {
+            if commitment_map[pos].point_indices.contains(point_idx) {
+                return Err(Error::Synthesis("repeated query".into()));
+            }
+            commitment_map[pos].point_indices.push(*point_idx);
+        } else {
+            let mut tmp = CommitmentData::new(query_label.clone());
+            tmp.point_indices.push(*point_idx);
+            commitment_map.push(tmp);
+        }
+    }
+
+    // Also construct inverse mapping from point_index to the point
+    let mut inverse_point_index_map = HashMap::new();
+    for (&point, &point_index) in point_index_map.iter() {
+        inverse_point_index_map.insert(point_index, point.clone());
+    }
+
+    // Construct map of unique ordered point_idx_sets to their set_idx.
+    let mut point_idx_sets = HashMap::new();
+    // Also construct mapping from commitment to point_idx_set
+    let mut commitment_set_map = Vec::new();
+
+    for commitment_data in commitment_map.iter() {
+        let mut point_index_set = BTreeSet::new();
+        // Note that point_index_set is ordered, unlike point_indices
+        for &point_index in commitment_data.point_indices.iter() {
+            point_index_set.insert(point_index);
+        }
+
+        // Push point_index_set to CommitmentData for the relevant commitment
+        commitment_set_map.push((commitment_data.label.clone(), point_index_set.clone()));
+
+        let num_sets = point_idx_sets.len();
+        point_idx_sets.entry(point_index_set).or_insert(num_sets);
+    }
+
+    // Initialise empty evals vec for each unique commitment
+    for commitment_data in commitment_map.iter_mut() {
+        let len = commitment_data.point_indices.len();
+        commitment_data.evals = vec![default_eval.clone(); len];
+    }
+
+    // Populate set_index, evals and points for each commitment using point_idx_sets
+    for (query_label, query_point, query_eval) in queries.iter() {
+        // The index of the point at which the commitment is queried
+        let point_index = point_index_map.get(&query_point).unwrap();
+
+        // The point_index_set at which the commitment was queried
+        let mut point_index_set = BTreeSet::new();
+        for (l, point_idx_set) in commitment_set_map.iter() {
+            if l == query_label {
+                point_index_set.clone_from(point_idx_set);
+            }
+        }
+        assert!(!point_index_set.is_empty());
+
+        // The set_index of the point_index_set
+        let set_index = point_idx_sets.get(&point_index_set).unwrap();
+        for commitment_data in commitment_map.iter_mut() {
+            if query_label == &commitment_data.label {
+                commitment_data.set_index = *set_index;
+            }
+        }
+        let point_index_set: Vec<usize> = point_index_set.iter().cloned().collect();
+
+        // The offset of the point_index in the point_index_set
+        let point_index_in_set = point_index_set.iter().position(|i| i == point_index).unwrap();
+
+        for commitment_data in commitment_map.iter_mut() {
+            if *query_label == commitment_data.label {
+                // Insert the eval using the ordering of the point_index_set
+                commitment_data.evals[point_index_in_set] = query_eval.clone();
+            }
+        }
+    }
+
+    // Get actual points in each point set
+    let mut point_sets: Vec<Vec<AssignedNative<S::F>>> = vec![Vec::new(); point_idx_sets.len()];
+    for (point_idx_set, &set_idx) in point_idx_sets.iter() {
+        for &point_idx in point_idx_set.iter() {
+            let point = inverse_point_index_map.get(&point_idx).unwrap();
+            point_sets[set_idx].push((*point).clone());
+        }
+    }
+
+    Ok((commitment_map, point_sets))
+}
+
+// ----------------------------------
+// See proofs/src/utils/arithmetic.rs
+// ----------------------------------
+
+fn msm_inner_product<S: SelfEmulation>(
+    layouter: &mut impl Layouter<S::F>,
+    scalar_chip: &S::ScalarChip,
+    msms: &[AssignedMsm<S>],
+    scalars: &[AssignedBoundedScalar<S::F>],
+) -> Result<AssignedMsm<S>, Error> {
+    let mut res = AssignedMsm::empty();
+    let mut msms = msms.to_vec();
+    for (msm, s) in msms.iter_mut().zip(scalars) {
+        msm.scale(layouter, scalar_chip, s)?;
+        res.add_msm(msm)?;
+    }
+    Ok(res)
+}
+
+/// Computes the inner product of a set of polynomial evaluations and a set of
+/// scalar values. This function computes the weighted sum of polynomial
+/// evaluations. Each vector in `evals_set` is multiplied element-wise by a
+/// corresponding scalar from `scalars`, and the results are accumulated
+/// into a single vector.
+fn evals_inner_product<F: CircuitField>(
+    layouter: &mut impl Layouter<F>,
+    scalar_chip: &impl ArithInstructions<F, AssignedNative<F>>,
+    evals_set: &[Vec<AssignedNative<F>>],
+    scalars: &[AssignedBoundedScalar<F>],
+) -> Result<Vec<AssignedNative<F>>, Error> {
+    let zero = scalar_chip.assign_fixed(layouter, F::ZERO)?;
+    let mut res = vec![zero.clone(); evals_set[0].len()];
+    for (poly_evals, s) in evals_set.iter().zip(scalars) {
+        for i in 0..res.len() {
+            // res[i] := s.scalar * poly_evals[i] + res[i]
+            res[i] = mul_add(layouter, scalar_chip, &s.scalar, &poly_evals[i], &res[i])?;
+        }
+    }
+    Ok(res)
+}
+
+/// Sort point sets by ascending cardinality, so the first set is the one
+/// holding commitments evaluated at a single point (the fixed ones). Not
+/// needed by the proving system itself, but the in-circuit verifier relies on
+/// it for a collapse optimization.
+///
+/// The `(len, i)` key gives a deterministic total order when two sets share a
+/// cardinality.
+fn point_set_order<F>(point_sets: &[Vec<F>]) -> Vec<usize> {
+    let mut order: Vec<usize> = (0..point_sets.len()).collect();
+    order.sort_by_key(|&i| (point_sets[i].len(), i));
+    order
+}
+
+// ------------------------------
+// See proofs/src/pcs/multi_open.rs
+// ------------------------------
+
+/// Checks the multi-point opening argument, returning the pairing accumulator
+/// that satisfies the invariant iff all queries are valid.
+///
+/// `triples` are the `(label, point, eval)` claims after any scheme-specific
+/// expansion, and `label_to_com` resolves each label to the MSM it refers to
+/// (one term for a plain commitment, several for a linearization one).
+/// `read_point` reads one of the argument's two group elements off the
+/// transcript; it is a parameter because each scheme serializes its
+/// commitments differently, and both reads have to land at these exact points
+/// of the transcript.
+#[allow(clippy::too_many_arguments)]
+pub(crate) fn multi_prepare_core<S: SelfEmulation, L: Layouter<S::F>>(
+    layouter: &mut L,
+    #[cfg(feature = "truncated-challenges")] curve_chip: &S::CurveChip,
+    scalar_chip: &S::ScalarChip,
+    transcript: &mut TranscriptGadget<S>,
+    triples: &[QueryTriple<S>],
+    label_to_com: &HashMap<PolynomialLabel, AssignedMsm<S>>,
+    read_point: impl Fn(
+        &mut L,
+        &mut TranscriptGadget<S>,
+        PolynomialLabel,
+    ) -> Result<AssignedPoint<S>, Error>,
+) -> Result<AssignedAccumulator<S>, Error> {
+    let x1 = transcript.squeeze_challenge(layouter)?;
+    let x2 = transcript.squeeze_challenge(layouter)?;
+
+    let default_eval = scalar_chip.assign_fixed(layouter, S::F::default())?;
+    let (commitment_map, point_sets) = construct_intermediate_sets::<S>(triples, default_eval)?;
+
+    let mut q_coms: Vec<Vec<AssignedMsm<S>>> = vec![vec![]; point_sets.len()];
+    let mut q_eval_sets = vec![vec![]; point_sets.len()];
+
+    for com_data in commitment_map.into_iter() {
+        let msm = label_to_com.get(&com_data.label).cloned().ok_or_else(|| {
+            Synthesis(format!(
+                "multi_prepare: no commitment registered for label {}",
+                com_data.label
+            ))
+        })?;
+        q_coms[com_data.set_index].push(msm);
+        q_eval_sets[com_data.set_index].push(com_data.evals);
+    }
+
+    let truncated_x1_powers = {
+        let nb_x1_powers = q_coms.iter().map(|v| v.len()).max().unwrap_or(0);
+        assert!(nb_x1_powers >= q_eval_sets.iter().map(|v| v.len()).max().unwrap_or(0));
+        truncated_powers(layouter, scalar_chip, &x1, nb_x1_powers)?
+    };
+
+    let q_coms = q_coms
+        .iter()
+        .map(|msms| msm_inner_product(layouter, scalar_chip, msms, &truncated_x1_powers))
+        .collect::<Result<Vec<_>, Error>>()?;
+
+    let q_eval_sets = q_eval_sets
+        .iter()
+        .map(|evals| evals_inner_product(layouter, scalar_chip, evals, &truncated_x1_powers))
+        .collect::<Result<Vec<_>, Error>>()?;
+
+    let (q_coms, q_eval_sets, point_sets) = {
+        let order = point_set_order(&point_sets);
+        let q_coms: Vec<_> = order.iter().map(|&i| q_coms[i].clone()).collect();
+        let q_eval_sets: Vec<_> = order.iter().map(|&i| q_eval_sets[i].clone()).collect();
+        let point_sets: Vec<_> = order.iter().map(|&i| point_sets[i].clone()).collect();
+        (q_coms, q_eval_sets, point_sets)
+    };
+
+    let f_point = read_point(
+        layouter,
+        transcript,
+        PolynomialLabel::Custom(BATCH_LABEL.into()),
+    )?;
+
+    let x3 = transcript.squeeze_challenge(layouter)?;
+    #[cfg(feature = "truncated-challenges")]
+    let x3 = truncate::<S::F>(layouter, scalar_chip, &x3)?;
+    #[cfg(not(feature = "truncated-challenges"))]
+    let x3 = AssignedBoundedScalar::new(&x3, None);
+
+    let mut q_evals_on_x3 = Vec::with_capacity(q_eval_sets.len());
+    for _ in 0..q_eval_sets.len() {
+        q_evals_on_x3.push(transcript.read_scalar(layouter)?);
+    }
+
+    let zero = scalar_chip.assign_fixed(layouter, S::F::ZERO)?;
+    let f_eval = point_sets
+        .iter()
+        .zip(q_eval_sets.iter())
+        .zip(q_evals_on_x3.iter())
+        .rev()
+        .try_fold(zero, |acc_eval, ((points, evals), proof_eval)| {
+            let r_eval =
+                evaluate_interpolated_polynomial(layouter, scalar_chip, points, evals, &x3.scalar)?;
+
+            // eval = (proof_eval - r_eval) / prod_i (x3 - point_i)
+            let den = points.iter().skip(1).try_fold(
+                scalar_chip.sub(layouter, &x3.scalar, &points[0])?,
+                |acc, point| {
+                    // acc * (x3 - point) computed as acc * x3 - acc * point
+                    scalar_chip.add_and_double_mul(
+                        layouter,
+                        (S::F::ZERO, &acc),
+                        (S::F::ZERO, &x3.scalar),
+                        (S::F::ZERO, point),
+                        S::F::ZERO,
+                        (S::F::ONE, -S::F::ONE),
+                    )
+                },
+            )?;
+            let mut eval = scalar_chip.sub(layouter, proof_eval, &r_eval)?;
+            eval = scalar_chip.div(layouter, &eval, &den)?;
+
+            // acc_eval * x2 + eval
+            mul_add(layouter, scalar_chip, &acc_eval, &x2, &eval)
+        })?;
+
+    let x4 = transcript.squeeze_challenge(layouter)?;
+    let truncated_x4_powers =
+        truncated_powers::<S::F>(layouter, scalar_chip, &x4, q_coms.len() + 1)?;
+
+    let final_com = {
+        let mut coms = q_coms;
+
+        // We collapse all AssignedMsm at this point to later leverage the fact that x4
+        // powers are truncated. Exceptionally, the first one is not collapsed,
+        // as the first x4 power is 1.
+        #[cfg(feature = "truncated-challenges")]
+        coms.iter_mut().skip(1).try_for_each(|com| {
+            com.collapse(layouter, curve_chip, scalar_chip, PolynomialLabel::NoLabel)
+        })?;
+        let one = AssignedBoundedScalar::one(layouter, scalar_chip)?;
+        coms.push(AssignedMsm::from_term(
+            one,
+            f_point,
+            PolynomialLabel::Custom(BATCH_LABEL.into()),
+        ));
+
+        msm_inner_product(layouter, scalar_chip, &coms, &truncated_x4_powers)?
+    };
+
+    let v = {
+        let mut evals = q_evals_on_x3;
+        evals.push(f_eval);
+
+        let scalar_x4_powers: Vec<_> =
+            truncated_x4_powers.iter().map(|s| s.scalar.clone()).collect();
+
+        AssignedBoundedScalar::new(
+            &inner_product(layouter, scalar_chip, &evals, &scalar_x4_powers)?,
+            None,
+        )
+    };
+
+    let pi_point = read_point(
+        layouter,
+        transcript,
+        PolynomialLabel::Custom(PROOF_LABEL.into()),
+    )?;
+    let pi_msm = {
+        let one = AssignedBoundedScalar::one(layouter, scalar_chip)?;
+        AssignedMsm::from_term(one, pi_point, PolynomialLabel::Custom(PROOF_LABEL.into()))
+    };
+
+    // Scale zπ
+    let mut scaled_pi = pi_msm.clone();
+    scaled_pi.scale(layouter, scalar_chip, &x3)?;
+
+    // (π, C − vG + zπ)
+    let left = pi_msm; // π
+
+    let right = {
+        let mut right = final_com; // C
+        let minus_v_gen = AssignedMsm::from_fixed_term(v, PolynomialLabel::Custom("-G".into()));
+        right.add_msm(&minus_v_gen)?; // -vG
+        right.add_msm(&scaled_pi)?; // zπ
+        right
+    };
+
+    Ok(AssignedAccumulator::new(left, right))
+}

--- a/circuits/src/verifier/pcs.rs
+++ b/circuits/src/verifier/pcs.rs
@@ -114,6 +114,21 @@ pub trait InCircuitPCS<S: SelfEmulation>: Sized + Clone + Debug {
         commitment: &Self::AssignedCommitment,
     ) -> Result<(), Error>;
 
+    /// Squeezes the point at which the protocol opens its committed
+    /// polynomials.
+    ///
+    /// The protocol must obtain that point through this method. The default is
+    /// a plain challenge; a scheme whose evaluation point has to satisfy some
+    /// property overrides it (fflonk needs a `t_max`-th power). Mirrors
+    /// [`midnight_proofs::pcs::PolynomialCommitmentScheme::squeeze_evaluation_point`].
+    fn squeeze_evaluation_point(
+        layouter: &mut impl Layouter<S::F>,
+        _scalar_chip: &S::ScalarChip,
+        transcript: &mut TranscriptGadget<S>,
+    ) -> Result<AssignedNative<S::F>, Error> {
+        transcript.squeeze_challenge(layouter)
+    }
+
     /// In-circuit multi-open verification; produces an accumulator.
     fn multi_prepare(
         layouter: &mut impl Layouter<S::F>,

--- a/circuits/src/verifier/pcs.rs
+++ b/circuits/src/verifier/pcs.rs
@@ -19,6 +19,7 @@ use std::fmt::Debug;
 
 use midnight_proofs::{
     circuit::{Layouter, Value},
+    pcs::PolynomialCommitmentScheme,
     plonk::Error,
     poly::PolynomialLabel,
 };
@@ -85,6 +86,10 @@ pub trait InCircuitHomomorphicCommitment<S: SelfEmulation>: Clone + Debug + Size
 /// Analog of [`midnight_proofs::pcs::PolynomialCommitmentScheme`]
 /// for the in-circuit verifier.
 pub trait InCircuitPCS<S: SelfEmulation>: Sized + Clone + Debug {
+    /// The off-circuit scheme whose proofs this gadget verifies. Fixes the
+    /// verifying-key type the gadget accepts.
+    type OffCircuit: PolynomialCommitmentScheme<S::F>;
+
     /// The in-circuit type representing a committed polynomial.
     type AssignedCommitment: InCircuitHomomorphicCommitment<S>;
 

--- a/circuits/src/verifier/transcript_gadget.rs
+++ b/circuits/src/verifier/transcript_gadget.rs
@@ -18,7 +18,6 @@ use ff::Field;
 use midnight_proofs::{
     circuit::{Layouter, Value},
     plonk::Error::{self, Synthesis},
-    poly::PolynomialLabel,
     transcript::{CircuitTranscript, Transcript},
 };
 
@@ -27,11 +26,7 @@ use crate::utils::transcript_trace::in_circuit;
 use crate::{
     instructions::{AssignmentInstructions, PublicInputInstructions, SpongeInstructions},
     types::AssignedNative,
-    verifier::{
-        SelfEmulation,
-        kzg::{AssignedKZGCommitment, AssignedKZGMultiCommitment},
-        msm::AssignedPoint,
-    },
+    verifier::SelfEmulation,
 };
 
 type SpongeState<S> = <<S as SelfEmulation>::SpongeChip as SpongeInstructions<
@@ -119,35 +114,22 @@ impl<S: SelfEmulation> TranscriptGadget<S> {
         self.sponge_chip.absorb(layouter, state, std::slice::from_ref(scalar))
     }
 
-    /// Absorbs a commitment into the transcript, one inner polynomial point at
-    /// a time, matching the off-circuit `Hashable::to_input`.
-    pub fn common_commitment(
+    /// Absorbs a curve point into the transcript, as the same field elements
+    /// the off-circuit `Hashable::to_input` produces for it.
+    pub fn absorb_point(
         &mut self,
         layouter: &mut impl Layouter<S::F>,
-        commitment: &AssignedKZGMultiCommitment<S>,
+        point: &S::AssignedPoint,
     ) -> Result<(), Error> {
-        for inner in commitment.0.iter() {
-            let pis = match inner {
-                AssignedKZGCommitment::Simple(AssignedPoint::Variable(p), _label) => {
-                    self.curve_chip.as_public_input(layouter, p)
-                }
-                AssignedKZGCommitment::Simple(AssignedPoint::Fixed, label) => Err(Synthesis(
-                    format!("Fixed commitments cannot be added to the transcript: {label}"),
-                )),
-                AssignedKZGCommitment::Linear(_, _, labels) => Err(Synthesis(format!(
-                    "Linear commitments cannot be added to the transcript: {labels:?}"
-                ))),
-            }?;
+        let pis = self.curve_chip.as_public_input(layouter, point)?;
 
-            #[cfg(any(test, feature = "testing"))]
-            in_circuit::absorbed(&pis.iter().map(|pi| pi.value().copied()).collect::<Vec<_>>());
+        #[cfg(any(test, feature = "testing"))]
+        in_circuit::absorbed(&pis.iter().map(|pi| pi.value().copied()).collect::<Vec<_>>());
 
-            self.input_len += pis.len();
+        self.input_len += pis.len();
 
-            let state = self.sponge_state.as_mut().expect("You must init the transcript gadget");
-            self.sponge_chip.absorb(layouter, state, &pis)?;
-        }
-        Ok(())
+        let state = self.sponge_state.as_mut().expect("You must init the transcript gadget");
+        self.sponge_chip.absorb(layouter, state, &pis)
     }
 
     /// Derives a scalar challenge from the current transcript.
@@ -162,40 +144,34 @@ impl<S: SelfEmulation> TranscriptGadget<S> {
         self.sponge_chip.squeeze(layouter, state)
     }
 
-    /// Reads `labels.len()` curve points from the prover transcript (one per
-    /// polynomial held by the commitment), absorbs them into the running hash
-    /// state, and tags each polynomial with its label.
+    /// Reads a curve point from the prover transcript.
+    ///
+    /// Does **not** absorb it: a commitment holding several points absorbs them
+    /// together once all are read, matching the off-circuit
+    /// `Hashable::to_input`, and a scheme whose wire format interleaves
+    /// framing with points needs to read them one at a time. The caller
+    /// must pass every point read here to [`Self::absorb_point`], or
+    /// Fiat-Shamir is broken.
     ///
     /// # Warning
     ///
-    /// The received points are not enforced to be in the prime-order subgroup.
-    pub fn read_commitment(
+    /// The received point is not enforced to be in the prime-order subgroup.
+    pub fn read_point(
         &mut self,
         layouter: &mut impl Layouter<S::F>,
-        labels: &[PolynomialLabel],
-    ) -> Result<AssignedKZGMultiCommitment<S>, Error> {
-        let mut inners = Vec::with_capacity(labels.len());
-        for label in labels {
-            let reader =
-                self.transcript_reader.as_mut().expect("You must init the transcript gadget");
-            // If an error, do not fail, assign a default commitment instead.
-            // (This allows us to parse dummy proofs.)
-            let point: Value<S::C> = match reader.read::<S::C>() {
-                Ok(point) => Value::known(point),
-                Err(_) => {
-                    self.nb_failed_reads += 1;
-                    Value::known(S::C::default())
-                }
-            };
-            let assigned_point =
-                S::assign_without_subgroup_check(layouter, &self.curve_chip, point)?;
-            inners.push(AssignedKZGCommitment::simple(assigned_point, label.clone()));
-        }
+    ) -> Result<S::AssignedPoint, Error> {
+        let reader = self.transcript_reader.as_mut().expect("You must init the transcript gadget");
+        // If an error, do not fail, assign a default point instead.
+        // (This allows us to parse dummy proofs.)
+        let point: Value<S::C> = match reader.read::<S::C>() {
+            Ok(point) => Value::known(point),
+            Err(_) => {
+                self.nb_failed_reads += 1;
+                Value::known(S::C::default())
+            }
+        };
 
-        let assigned_com = AssignedKZGMultiCommitment(inners);
-        self.common_commitment(layouter, &assigned_com)?;
-
-        Ok(assigned_com)
+        S::assign_without_subgroup_check(layouter, &self.curve_chip, point)
     }
 
     /// Reads a scalar from the reader buffer, and adds it to the transcript.
@@ -382,25 +358,22 @@ mod tests {
                 .scalar_chip
                 .assign_many(&mut layouter, &self.scalars.transpose_array())?;
 
-            let assigned_commitments = self
+            let assigned_points = self
                 .points
                 .transpose_array()
                 .iter()
                 .map(|p| {
-                    let assigned_p = S::assign_without_subgroup_check(
+                    S::assign_without_subgroup_check(
                         &mut layouter,
                         &transcript_gadget.curve_chip,
                         *p,
-                    )?;
-                    Ok(AssignedKZGMultiCommitment(vec![
-                        AssignedKZGCommitment::simple(assigned_p, PolynomialLabel::NoLabel),
-                    ]))
+                    )
                 })
                 .collect::<Result<Vec<_>, Error>>()?;
 
             for i in 0..(SIZE / 2) {
                 transcript_gadget.common_scalar(&mut layouter, &assigned_scalars[i])?;
-                transcript_gadget.common_commitment(&mut layouter, &assigned_commitments[i])?;
+                transcript_gadget.absorb_point(&mut layouter, &assigned_points[i])?;
             }
 
             let challenge_1 = transcript_gadget.squeeze_challenge(&mut layouter)?;
@@ -410,7 +383,7 @@ mod tests {
 
             for i in (SIZE / 2)..SIZE {
                 transcript_gadget.common_scalar(&mut layouter, &assigned_scalars[i])?;
-                transcript_gadget.common_commitment(&mut layouter, &assigned_commitments[i])?;
+                transcript_gadget.absorb_point(&mut layouter, &assigned_points[i])?;
             }
 
             let challenge_2 = transcript_gadget.squeeze_challenge(&mut layouter)?;

--- a/circuits/src/verifier/transcript_gadget.rs
+++ b/circuits/src/verifier/transcript_gadget.rs
@@ -204,7 +204,7 @@ impl<S: SelfEmulation> TranscriptGadget<S> {
     /// the proof, or that stop short of it, mean the gadget and the prover
     /// disagree on the transcript layout; without this check the only symptom
     /// is an unsatisfiable circuit at some unrelated row, because
-    /// [`Self::read_scalar`] and [`Self::read_commitment`] silently substitute
+    /// [`Self::read_scalar`] and [`Self::read_point`] silently substitute
     /// defaults on a failed read.
     ///
     /// A gadget initialised without a proof (key generation, where every read

--- a/circuits/src/verifier/verifier_gadget.rs
+++ b/circuits/src/verifier/verifier_gadget.rs
@@ -111,7 +111,7 @@ impl<S: SelfEmulation, PCS: InCircuitPCS<S>> PublicInputInstructions<S::F, Assig
     fn assign_as_public_input(
         &self,
         _layouter: &mut impl Layouter<S::F>,
-        _value: Value<VerifyingKey<S>>,
+        _value: Value<VerifyingKey<S, PCS>>,
     ) -> Result<AssignedVk<S, PCS>, Error> {
         unimplemented!(
             "We intend [assign_vk_as_public_input] to be the only entry point
@@ -1196,7 +1196,7 @@ pub(crate) mod tests {
         )
         .expect("Problem preparing the inner proof");
 
-        let fixed_bases = crate::verifier::fixed_bases::<S>(&inner_vk);
+        let fixed_bases = crate::verifier::fixed_bases::<S, _>(&inner_vk);
 
         let mut inner_acc = Accumulator::<S>::from_dual_msm(inner_dual_msm.clone(), &fixed_bases);
 

--- a/circuits/src/verifier/verifier_gadget.rs
+++ b/circuits/src/verifier/verifier_gadget.rs
@@ -566,7 +566,7 @@ impl<S: SelfEmulation> VerifierGadget<S> {
 
         // Sample x challenge, which is used to ensure the circuit is satisfied with
         // high probability
-        let x = transcript.squeeze_challenge(layouter)?;
+        let x = PCS::squeeze_evaluation_point(layouter, &self.scalar_chip, &mut transcript)?;
 
         let instance_evals = {
             let instance_queries = cs.instance_queries();


### PR DESCRIPTION
Pure refactor.

Prepares the verifier gadget to host a second commitment scheme, without changing what it proves. The transcript gadget's commitment primitives become point primitives, the verifying key stops being pinned to KZG through a new OffCircuit associated type, and everything from the first squeezed challenge onwards moves into a scheme-agnostic verifier/multi_open.rs, mirroring the off-circuit split.