### PR TITLE
[Fflonk PR9] [Verifier Gadget PR3]  Irakoton/fflonk gadget

### DIFF
--- a/aggregation/examples/single_circuit_aggregation.rs
+++ b/aggregation/examples/single_circuit_aggregation.rs
@@ -27,14 +27,14 @@ use midnight_circuits::{
     instructions::{hash::HashCPU, *},
     types::{AssignedNative, Instantiable},
     verifier::{
-        self, Accumulator, AssignedAccumulator, AssignedKZGMultiCommitment, AssignedVk,
-        BlstrsEmulation, InCircuitKZG, SelfEmulation,
+        self, Accumulator, AssignedAccumulator, AssignedVk, BlstrsEmulation,
+        MidnightAssignedCommitment, MidnightInCircuitPCS, SelfEmulation,
     },
 };
 use midnight_proofs::{
-    MidnightPCS,
+    MidnightCommitment, MidnightPCS,
     circuit::{Layouter, Value},
-    pcs::{kzg::commitment::KZGMultiCommitment, params::ParamsVerifierKZG},
+    pcs::params::ParamsVerifierKZG,
     plonk::{self, ConstraintSystem, Error},
     poly::{EvaluationDomain, PolynomialLabel},
     transcript::{CircuitTranscript, Transcript},
@@ -237,7 +237,7 @@ impl IvcTransition for ProofAggregation {
             let dual_msm =
                 plonk::prepare::<F, MidnightPCS<E>, CircuitTranscript<PoseidonState<F>>>(
                     ctx.vk.vk(),
-                    &[KZGMultiCommitment::commitment_to_zero(
+                    &[MidnightCommitment::<E>::commitment_to_zero(
                         PolynomialLabel::CommittedInstance(0),
                     )],
                     &[&statement_pis],
@@ -284,12 +284,13 @@ impl IvcTransition for ProofAggregation {
         witness: Value<Self::Witness>,
     ) -> Result<Self::AssignedState, Error> {
         // Assign inner VK as a hard-coded constant.
-        let inner_vk: AssignedVk<S, InCircuitKZG<S>> = self.std_lib.verifier().assign_fixed_vk(
-            layouter,
-            &self.inner_ctx.domain,
-            &self.inner_ctx.cs,
-            self.inner_ctx.vk.vk().transcript_repr(),
-        )?;
+        let inner_vk: AssignedVk<S, MidnightInCircuitPCS<S>> =
+            self.std_lib.verifier().assign_fixed_vk(
+                layouter,
+                &self.inner_ctx.domain,
+                &self.inner_ctx.cs,
+                self.inner_ctx.vk.vk().transcript_repr(),
+            )?;
 
         // Assign the inner statement as a witness.
         let statement_pis = self.std_lib.assign_many(
@@ -301,7 +302,7 @@ impl IvcTransition for ProofAggregation {
         )?;
 
         // Verify the inner proof in-circuit.
-        let instance_com = AssignedKZGMultiCommitment::commitment_to_zero(
+        let instance_com = MidnightAssignedCommitment::<S>::commitment_to_zero(
             layouter,
             self.std_lib.bls12_381(),
             PolynomialLabel::CommittedInstance(0),

--- a/aggregation/src/ivc/circuit.rs
+++ b/aggregation/src/ivc/circuit.rs
@@ -13,7 +13,8 @@ use midnight_circuits::{
     instructions::{BinaryInstructions, PublicInputInstructions},
     types::Instantiable,
     verifier::{
-        Accumulator, AssignedAccumulator, AssignedKZGMultiCommitment, AssignedVk, InCircuitKZG,
+        Accumulator, AssignedAccumulator, AssignedVk, MidnightAssignedCommitment,
+        MidnightInCircuitPCS,
     },
 };
 use midnight_proofs::{
@@ -144,7 +145,7 @@ impl<T: Ivc> Relation for IvcCircuit<T> {
         let verifier_gadget = std_lib.verifier();
         let ivc_gadget = T::new(std_lib.clone(), &self.ctx);
 
-        let assigned_self_vk: AssignedVk<S, InCircuitKZG<S>> = verifier_gadget
+        let assigned_self_vk: AssignedVk<S, MidnightInCircuitPCS<S>> = verifier_gadget
             .assign_vk_as_public_input(
                 layouter,
                 &self.domain,
@@ -181,7 +182,7 @@ impl<T: Ivc> Relation for IvcCircuit<T> {
         ]
         .concat();
 
-        let instance_com = AssignedKZGMultiCommitment::commitment_to_zero(
+        let instance_com = MidnightAssignedCommitment::<S>::commitment_to_zero(
             layouter,
             std_lib.bls12_381(),
             PolynomialLabel::CommittedInstance(0),

--- a/aggregation/src/ivc/prover.rs
+++ b/aggregation/src/ivc/prover.rs
@@ -10,11 +10,11 @@
 use midnight_circuits::{
     hash::poseidon::PoseidonState,
     types::Instantiable,
-    verifier::{Accumulator, AssignedAccumulator, AssignedVk, InCircuitKZG},
+    verifier::{Accumulator, AssignedAccumulator, AssignedVk, MidnightInCircuitPCS},
 };
 use midnight_proofs::{
-    MidnightPCS,
-    pcs::{kzg::commitment::KZGMultiCommitment, params::ParamsKZG},
+    MidnightCommitment, MidnightPCS,
+    pcs::params::ParamsKZG,
     plonk::{self},
     poly::PolynomialLabel,
     transcript::{CircuitTranscript, Transcript},
@@ -87,7 +87,7 @@ impl<T: Ivc> IvcProver<T> {
         } else {
             // Construct the public inputs of the previous proof.
             let prev_pi = [
-                AssignedVk::<S, InCircuitKZG<S>>::as_public_input(vk),
+                AssignedVk::<S, MidnightInCircuitPCS<S>>::as_public_input(vk),
                 T::format_public_input(&self.state),
                 AssignedAccumulator::<S>::as_public_input(&self.acc),
             ]
@@ -97,7 +97,7 @@ impl<T: Ivc> IvcProver<T> {
                 CircuitTranscript::<PoseidonState<F>>::init_from_bytes(&self.proof);
             let dual_msm = plonk::prepare::<F, MidnightPCS<E>, CircuitTranscript<PoseidonState<F>>>(
                 vk,
-                &[KZGMultiCommitment::commitment_to_zero(
+                &[MidnightCommitment::<E>::commitment_to_zero(
                     PolynomialLabel::CommittedInstance(0),
                 )],
                 &[&prev_pi],
@@ -108,7 +108,7 @@ impl<T: Ivc> IvcProver<T> {
                 return Err(IvcError::InvalidProof);
             }
 
-            Accumulator::from_dual_msm(dual_msm, &fixed_bases)
+            Accumulator::from_dual_msm(dual_msm.into_dual_msm(), &fixed_bases)
         };
 
         // Accumulate the proof accumulator with the previous accumulator.

--- a/aggregation/src/ivc/verifier.rs
+++ b/aggregation/src/ivc/verifier.rs
@@ -7,8 +7,8 @@
 
 use midnight_circuits::{hash::poseidon::PoseidonState, verifier::Accumulator};
 use midnight_proofs::{
-    MidnightPCS,
-    pcs::{kzg::commitment::KZGMultiCommitment, params::ParamsVerifierKZG},
+    MidnightCommitment, MidnightPCS,
+    pcs::params::ParamsVerifierKZG,
     plonk::{self},
     poly::PolynomialLabel,
     transcript::{CircuitTranscript, Transcript},
@@ -63,7 +63,7 @@ impl<T: Ivc> IvcVerifier<T> {
         let mut transcript = CircuitTranscript::<PoseidonState<F>>::init_from_bytes(proof);
         let dual_msm = plonk::prepare::<F, MidnightPCS<E>, CircuitTranscript<PoseidonState<F>>>(
             self.vk.vk(),
-            &[KZGMultiCommitment::commitment_to_zero(
+            &[MidnightCommitment::<E>::commitment_to_zero(
                 PolynomialLabel::CommittedInstance(0),
             )],
             &[&pi],
@@ -73,7 +73,7 @@ impl<T: Ivc> IvcVerifier<T> {
 
         transcript.assert_empty().map_err(|_| IvcError::TranscriptNotEmpty)?;
 
-        let proof_acc = Accumulator::from_dual_msm(dual_msm, &fixed_bases);
+        let proof_acc = Accumulator::from_dual_msm(dual_msm.into_dual_msm(), &fixed_bases);
 
         // Verify that both `proof_acc` and `instance.acc` satisfy the pairing
         // invariant, with a single pairing, by accumulating them first.

--- a/aggregation/src/multi_circuit_aggregator/circuit.rs
+++ b/aggregation/src/multi_circuit_aggregator/circuit.rs
@@ -20,12 +20,12 @@ use midnight_circuits::{
     hash::poseidon::{PoseidonChip, PoseidonState},
     instructions::{hash::HashCPU, *},
     types::{AssignedNative, Instantiable},
-    verifier::{self, Accumulator, AssignedAccumulator, AssignedKZGMultiCommitment},
+    verifier::{self, Accumulator, AssignedAccumulator, MidnightAssignedCommitment},
 };
 use midnight_proofs::{
-    MidnightPCS,
+    MidnightCommitment, MidnightPCS,
     circuit::{Layouter, Value},
-    pcs::{kzg::commitment::KZGMultiCommitment, params::ParamsVerifierKZG},
+    pcs::params::ParamsVerifierKZG,
     plonk::{self, ConstraintSystem, Error},
     poly::{EvaluationDomain, PolynomialLabel},
     transcript::{CircuitTranscript, Transcript},
@@ -260,7 +260,7 @@ impl IvcTransition for ProofAggregation {
             let dual_msm =
                 plonk::prepare::<F, MidnightPCS<E>, CircuitTranscript<PoseidonState<F>>>(
                     witness.claim.vk.vk(),
-                    &[KZGMultiCommitment::commitment_to_zero(
+                    &[MidnightCommitment::<E>::commitment_to_zero(
                         PolynomialLabel::CommittedInstance(0),
                     )],
                     &[&[statement]],
@@ -275,7 +275,7 @@ impl IvcTransition for ProofAggregation {
             );
 
             let vk_bases = verifier::fixed_bases::<S, _>(witness.claim.vk.vk());
-            let mut acc = Accumulator::from_dual_msm(dual_msm, &vk_bases);
+            let mut acc = Accumulator::from_dual_msm(dual_msm.into_dual_msm(), &vk_bases);
             acc.collapse();
             acc.resolve_fixed_bases(&vk_bases);
             acc
@@ -326,7 +326,7 @@ impl IvcTransition for ProofAggregation {
 
         // 3. Verify the inner proof in-circuit against the witnessed VK and statement.
         let inner_proof_acc = {
-            let instance_com = AssignedKZGMultiCommitment::commitment_to_zero(
+            let instance_com = MidnightAssignedCommitment::<S>::commitment_to_zero(
                 layouter,
                 self.std_lib.bls12_381(),
                 PolynomialLabel::CommittedInstance(0),

--- a/aggregation/src/multi_circuit_aggregator/utils.rs
+++ b/aggregation/src/multi_circuit_aggregator/utils.rs
@@ -15,7 +15,7 @@ use midnight_circuits::{
     hash::poseidon::{PoseidonChip, PoseidonState},
     instructions::{hash::HashCPU, *},
     types::AssignedNative,
-    verifier::{AssignedVk, InCircuitKZG, SelfEmulation},
+    verifier::{AssignedVk, MidnightInCircuitPCS, SelfEmulation, SingletonCommitment},
 };
 use midnight_proofs::{
     circuit::{Layouter, Value},
@@ -32,7 +32,7 @@ use crate::ivc::{C, F, S};
 /// is verified against the same VK that was hashed), its VK hash, and a named
 /// map of assigned base points for resolving fixed-base scalars.
 pub type VkHashAndBases = (
-    AssignedVk<S, InCircuitKZG<S>>,
+    AssignedVk<S, MidnightInCircuitPCS<S>>,
     AssignedNative<F>,
     BTreeMap<PolynomialLabel, <S as SelfEmulation>::AssignedPoint>,
 );
@@ -71,13 +71,10 @@ pub fn assign_as_public_inputs_and_hash_vk(
     let nb_perm = cs.permutation().columns.len();
 
     // Witness the VK commitment points.
-    let base_values: Vec<Value<C>> =
-        (0..nb_fixed)
-            .map(|i| vk.map(|vk| vk.vk().fixed_commitments()[i].0[0].clone().into_point()))
-            .chain((0..nb_perm).map(|i| {
-                vk.map(|vk| vk.vk().permutation().commitments()[i].0[0].clone().into_point())
-            }))
-            .collect();
+    let base_values: Vec<Value<C>> = (0..nb_fixed)
+        .map(|i| vk.map(|vk| vk.vk().fixed_commitments()[i].point()))
+        .chain((0..nb_perm).map(|i| vk.map(|vk| vk.vk().permutation().commitments()[i].point())))
+        .collect();
 
     let assigned_bases = base_values
         .into_iter()

--- a/circuits/CHANGELOG.md
+++ b/circuits/CHANGELOG.md
@@ -8,6 +8,7 @@ We use [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 ### Added
+* In-circuit fflonk verifier: `InCircuitFflonk` and `AssignedFflonkCommitment`, with `MidnightInCircuitPCS` deriving the gadget's scheme from `MidnightPCS` [#518](https://github.com/midnightntwrk/midnight-zk/pull/518)
 * `Point`/`AssignedPoint` enums and flat-triple `Msm`/`AssignedMsm` representation to distinguish variable-base from globally-fixed bases [#430](https://github.com/midnightntwrk/midnight-zk/pull/430)
 * `AssignedKZGCommitment` enum as the in-circuit analog of `KZGCommitment` [#430](https://github.com/midnightntwrk/midnight-zk/pull/430)
 * `fixed_base_msm` on the foreign Edwards chip: public fixed-base MSM for compile-time-constant bases, backed by the internal Lim-Lee comb `fixed_base_comb_msm` with a fixed comb width [#467](https://github.com/midnightntwrk/midnight-zk/pull/467)

--- a/circuits/src/verifier/fflonk.rs
+++ b/circuits/src/verifier/fflonk.rs
@@ -1,0 +1,617 @@
+// This file is part of MIDNIGHT-ZK.
+// Copyright (C) Midnight Foundation
+// SPDX-License-Identifier: Apache-2.0
+// Licensed under the Apache License, Version 2.0 (the "License");
+// You may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// http://www.apache.org/licenses/LICENSE-2.0
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! In-circuit fflonk commitment scheme.
+//!
+//! In-circuit analog of `proofs/src/pcs/fflonk`. Holds the in-circuit
+//! commitment type, the wire format of a bundled commitment, and the bundle
+//! pre-expansion that turns queries on a `t > 1` bundle into synthetic queries
+//! on its combined polynomial `g`. The scheme-independent remainder of the
+//! multi-open argument lives in `super::multi_open`.
+//!
+//! # Bundling ceiling
+//!
+//! The gadget imposes the layout instead of parsing it: the number of bundles
+//! and the labels each one packs come from `partition` over the labels the
+//! protocol expects, at the compile-time ceiling [`FFLONK_T_MAX_LOG`]. That
+//! ceiling has to be a circuit constant, since the whole shape of the gadget
+//! depends on it, so the `t_max_log` the prover writes to the transcript is
+//! constrained to it rather than read. A proof produced against an SRS with
+//! too little monomial room degrades to a smaller exponent off-circuit
+//! (`effective_t_max_log`) and is rejected here.
+
+use std::{collections::HashMap, marker::PhantomData};
+
+use group::Group;
+use midnight_curves::pairing::MultiMillerLoop;
+use midnight_proofs::{
+    circuit::{Layouter, Value},
+    pcs::fflonk::{
+        FFLONK_T_MAX_LOG, FflonkCommitment, FflonkScheme, bundle_t, missing_openings, partition,
+        primitive_root_of_unity, t_th_root,
+    },
+    plonk::Error::{self, Synthesis},
+    poly::PolynomialLabel,
+};
+
+use crate::{
+    field::AssignedNative,
+    instructions::{ArithInstructions, AssertionInstructions, AssignmentInstructions},
+    types::InnerValue,
+    verifier::{
+        AssignedAccumulator, SelfEmulation, SingletonCommitment,
+        msm::{AssignedMsm, AssignedPoint},
+        multi_open::{QueryTriple, multi_prepare_core},
+        pcs::{InCircuitHomomorphicCommitment, InCircuitPCS, VerifierQuery},
+        transcript_gadget::TranscriptGadget,
+        utils::{AssignedBoundedScalar, mul_add, mul_bounded_scalars},
+    },
+};
+
+/// The bundling ceiling every fflonk gadget is built at.
+const T_MAX: usize = 1 << FFLONK_T_MAX_LOG;
+
+/// The terms of a lazy linear combination: bases, scalars and labels, flat and
+/// parallel.
+type LinearParts<S> = (
+    Vec<AssignedPoint<S>>,
+    Vec<AssignedBoundedScalar<<S as SelfEmulation>::F>>,
+    Vec<PolynomialLabel>,
+);
+
+// ----------------------------------------
+// See proofs/src/pcs/fflonk/commitment.rs
+// ----------------------------------------
+
+/// In-circuit analog of [`FflonkCommitment`].
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum AssignedFflonkCommitment<S: SelfEmulation> {
+    /// One `(point, labels)` pair per bundle, where `point` commits to the
+    /// `labels.len()` polynomials combined into it.
+    Regular(Vec<(AssignedPoint<S>, Vec<PolynomialLabel>)>),
+    /// A lazy linear combination `∑ scalars[i] * points[i]` with per-term
+    /// labels, accumulated during verification for MSM batching. Produced by
+    /// `Add`/`Mul` on singleton bundles, as its off-circuit counterpart.
+    Linear(
+        Vec<AssignedPoint<S>>,
+        Vec<AssignedBoundedScalar<S::F>>,
+        Vec<PolynomialLabel>,
+    ),
+}
+
+impl<S: SelfEmulation> InnerValue for AssignedFflonkCommitment<S> {
+    type Element = FflonkCommitment<S::Engine>;
+
+    fn value(&self) -> Value<Self::Element> {
+        match self {
+            Self::Regular(pairs) => {
+                let points: Vec<Value<S::C>> =
+                    pairs.iter().map(|(p, _)| p.value().map(|p| *p.get_point())).collect();
+                let labels: Vec<_> = pairs.iter().map(|(_, l)| l.clone()).collect();
+                Value::from_iter(points).map(|ps: Vec<S::C>| {
+                    FflonkCommitment::Regular(ps.into_iter().zip(labels).collect())
+                })
+            }
+            Self::Linear(points, scalars, labels) => {
+                let points: Vec<Value<S::C>> =
+                    points.iter().map(|p| p.value().map(|p| *p.get_point())).collect();
+                let scalars: Vec<Value<S::F>> =
+                    scalars.iter().map(|s| s.scalar.value().copied()).collect();
+                let labels = labels.clone();
+                Value::from_iter(points)
+                    .zip(Value::from_iter(scalars))
+                    .map(|(ps, ss)| FflonkCommitment::Linear(ps, ss, labels))
+            }
+        }
+    }
+}
+
+impl<S: SelfEmulation> AssignedFflonkCommitment<S> {
+    /// A commitment to a single polynomial at a variable-base assigned point.
+    pub fn singleton(point: S::AssignedPoint, label: PolynomialLabel) -> Self {
+        Self::Regular(vec![(AssignedPoint::Variable(point), vec![label])])
+    }
+
+    /// A commitment to a single polynomial at a globally-known constant point.
+    ///
+    /// No circuit cell is allocated for the point; it is identified by its
+    /// label and will be looked up from a fixed-bases map when the accumulator
+    /// is resolved.
+    pub fn fixed(label: PolynomialLabel) -> Self {
+        Self::Regular(vec![(AssignedPoint::Fixed, vec![label])])
+    }
+
+    /// In-circuit commitment to the zero polynomial (the identity point),
+    /// tagged with `label`. Used e.g. for empty committed-instance columns.
+    pub fn commitment_to_zero(
+        layouter: &mut impl Layouter<S::F>,
+        curve_chip: &S::CurveChip,
+        label: PolynomialLabel,
+    ) -> Result<Self, Error>
+    where
+        S::CurveChip: AssignmentInstructions<S::F, S::AssignedPoint>,
+    {
+        let point = curve_chip.assign_fixed(layouter, S::C::identity())?;
+        Ok(Self::singleton(point, label))
+    }
+
+    /// The bundle of a `Regular` commitment whose label set contains `label`.
+    fn find_bundle(
+        &self,
+        label: &PolynomialLabel,
+    ) -> Result<&(AssignedPoint<S>, Vec<PolynomialLabel>), Error> {
+        match self {
+            Self::Regular(pairs) => pairs
+                .iter()
+                .find(|(_, labels)| labels.contains(label))
+                .ok_or_else(|| Synthesis(format!("no bundle of this commitment holds {label}"))),
+            Self::Linear(_, _, labels) => Err(Synthesis(format!(
+                "a linear commitment has no bundles: {labels:?}"
+            ))),
+        }
+    }
+
+    /// Decomposes into `(points, scalars, labels)` for `mul`/`add`. A singleton
+    /// bundle becomes a one-term combination with scalar `1`; a `Linear`
+    /// returns its parts unchanged.
+    fn into_linear_parts(self, one: &AssignedBoundedScalar<S::F>) -> Result<LinearParts<S>, Error> {
+        match self {
+            Self::Regular(pairs) => match pairs.as_slice() {
+                [(point, labels)] if labels.len() == 1 => {
+                    Ok((vec![point.clone()], vec![one.clone()], labels.clone()))
+                }
+                _ => Err(Synthesis(
+                    "linearization requires a commitment to a single polynomial".into(),
+                )),
+            },
+            Self::Linear(points, scalars, labels) => Ok((points, scalars, labels)),
+        }
+    }
+}
+
+impl<S: SelfEmulation> InCircuitHomomorphicCommitment<S> for AssignedFflonkCommitment<S> {
+    fn mul(
+        self,
+        layouter: &mut impl Layouter<S::F>,
+        scalar_chip: &S::ScalarChip,
+        scalar: &AssignedNative<S::F>,
+    ) -> Result<Self, Error> {
+        let scalar = AssignedBoundedScalar::new(scalar, None);
+        match self {
+            Self::Linear(points, scalars, labels) => Ok(Self::Linear(
+                points,
+                scalars
+                    .iter()
+                    .map(|s| mul_bounded_scalars(layouter, scalar_chip, s, &scalar))
+                    .collect::<Result<Vec<_>, _>>()?,
+                labels,
+            )),
+            committed => {
+                let one = AssignedBoundedScalar::one(layouter, scalar_chip)?;
+                let (points, _, labels) = committed.into_linear_parts(&one)?;
+                Ok(Self::Linear(points, vec![scalar], labels))
+            }
+        }
+    }
+
+    fn add(
+        self,
+        layouter: &mut impl Layouter<S::F>,
+        scalar_chip: &S::ScalarChip,
+        other: Self,
+    ) -> Result<Self, Error> {
+        let one = AssignedBoundedScalar::one(layouter, scalar_chip)?;
+        let (mut points, mut scalars, mut labels) = self.into_linear_parts(&one)?;
+        let (other_points, other_scalars, other_labels) = other.into_linear_parts(&one)?;
+        points.extend(other_points);
+        scalars.extend(other_scalars);
+        labels.extend(other_labels);
+        Ok(Self::Linear(points, scalars, labels))
+    }
+}
+
+// ---------------------------------------------
+// See proofs/src/pcs/fflonk/bundle_expansion.rs
+// ---------------------------------------------
+
+/// A bundle's claimed slot evaluations, keyed by `(slot, logical point)`.
+type SlotEvals<S> = Vec<(
+    (usize, AssignedNative<<S as SelfEmulation>::F>),
+    AssignedNative<<S as SelfEmulation>::F>,
+)>;
+
+/// Per-bundle verifier-side accumulator, the in-circuit analog of
+/// `bundle_expansion::BundleAcc`.
+///
+/// `pairs` and `evals` are association lists rather than maps: their point keys
+/// are `AssignedNative` cells, and a lookup by cell is exactly the identity
+/// this gadget needs (see [`t_th_roots_cells`]).
+struct BundleAcc<S: SelfEmulation> {
+    point: AssignedPoint<S>,
+    /// Real labels of the bundle's polynomials, in canonical order. Shorter
+    /// than `t` for a padded trailing bundle.
+    canonical_labels: Vec<PolynomialLabel>,
+    /// Logical bundle size. Slots `[canonical_labels.len(), t)` are pad slots
+    /// whose evals are zero and never travel on the transcript.
+    t: usize,
+    pairs: Vec<(usize, AssignedNative<S::F>)>,
+    evals: SlotEvals<S>,
+}
+
+impl<S: SelfEmulation> BundleAcc<S> {
+    fn eval_at(
+        &self,
+        slot: usize,
+        point: &AssignedNative<S::F>,
+    ) -> Result<&AssignedNative<S::F>, Error> {
+        self.evals
+            .iter()
+            .find(|((s, p), _)| *s == slot && p == point)
+            .map(|(_, eval)| eval)
+            .ok_or_else(|| {
+                Synthesis("fflonk: over-opening should have filled every real slot".into())
+            })
+    }
+}
+
+/// The `t`-th roots computed so far, keyed by the cell of the logical point and
+/// the bundle size. See [`t_th_roots_cells`].
+type RootsCache<S> = Vec<(
+    (AssignedNative<<S as SelfEmulation>::F>, usize),
+    Vec<AssignedNative<<S as SelfEmulation>::F>>,
+)>;
+
+/// The `t` t-th roots of `x`, i.e. `[z, z ω_t, ..., z ω_t^{t-1}]` for a witness
+/// `z` constrained by `z^t = x`.
+///
+/// Cheaper in-circuit than the `log2(t)` square roots the off-circuit verifier
+/// chains: one witness, `log2(t)` squarings and one equality. Which of the `t`
+/// roots the witness lands on does not matter, since the coset it spans is the
+/// same either way.
+///
+/// `cache` is keyed by the *cell* of `x`, not its value, and returns the very
+/// same root cells for a repeated `(x, t)`. That is load-bearing:
+/// `construct_intermediate_sets` identifies points by cell, so two bundles
+/// opened at a shared logical point must share their whole root set, or they
+/// land in distinct point sets in-circuit and a single one off-circuit. Worse,
+/// the pairwise `assert_not_equal` of `evaluate_interpolated_polynomial` would
+/// then compare two cells holding the same value and make the circuit
+/// unsatisfiable.
+fn t_th_roots_cells<S: SelfEmulation>(
+    layouter: &mut impl Layouter<S::F>,
+    scalar_chip: &S::ScalarChip,
+    cache: &mut RootsCache<S>,
+    x: &AssignedNative<S::F>,
+    t: usize,
+) -> Result<Vec<AssignedNative<S::F>>, Error> {
+    if let Some((_, roots)) = cache.iter().find(|((p, s), _)| p == x && *s == t) {
+        return Ok(roots.clone());
+    }
+
+    let z = scalar_chip.assign(layouter, x.value().map(|x| t_th_root(*x, t)))?;
+    let z_pow_t = scalar_chip.pow(layouter, &z, t as u64)?;
+    scalar_chip.assert_equal(layouter, &z_pow_t, x)?;
+
+    // `z * ω_t^i` rather than a chain of multiplications by `ω_t`: same cost,
+    // and it avoids the dead cell `z * ω_t^t` a chain would end on.
+    let omega_t = primitive_root_of_unity::<S::F>(t);
+    let mut roots = Vec::with_capacity(t);
+    roots.push(z.clone());
+    let mut omega_pow = omega_t;
+    for _ in 1..t {
+        roots.push(scalar_chip.mul_by_constant(layouter, &z, omega_pow)?);
+        omega_pow *= omega_t;
+    }
+
+    cache.push(((x.clone(), t), roots.clone()));
+    Ok(roots)
+}
+
+/// Paper's `S̄(root)`: `Σ_i root^i · claimed[i]`, by Horner. Equals `g(root)`
+/// when `root` is a `t`-th root of `x` and `claimed` holds the slot
+/// evaluations at `x` (Lemma 5.1). Trailing pad slots are zero and simply
+/// omitted from `claimed`.
+fn eval_claims_as_poly<S: SelfEmulation>(
+    layouter: &mut impl Layouter<S::F>,
+    scalar_chip: &S::ScalarChip,
+    claimed: &[&AssignedNative<S::F>],
+    root: &AssignedNative<S::F>,
+) -> Result<AssignedNative<S::F>, Error> {
+    let (last, rest) = claimed.split_last().expect("a bundle has at least one real slot");
+    rest.iter().rev().try_fold((*last).clone(), |acc, c| {
+        mul_add(layouter, scalar_chip, &acc, root, c)
+    })
+}
+
+/// Synthetic `(synth_label, root, g(root))` triples for one `t > 1` bundle.
+///
+/// Unlike the off-circuit mirror, the logical points are *not* sorted: their
+/// values are witnesses, so no order over them is available at synthesis time.
+/// It does not have to be: the triples of one bundle all carry the same label,
+/// so a different order only permutes the point indices
+/// `construct_intermediate_sets` hands out, and every consumer of a point set
+/// (the interpolation and the vanishing product) is symmetric in it.
+fn synth_triples_for_bundle<S: SelfEmulation>(
+    layouter: &mut impl Layouter<S::F>,
+    scalar_chip: &S::ScalarChip,
+    synth_label: &PolynomialLabel,
+    acc: &BundleAcc<S>,
+    roots_cache: &mut RootsCache<S>,
+) -> Result<Vec<QueryTriple<S>>, Error> {
+    let real_count = acc.canonical_labels.len();
+
+    let mut union_logicals: Vec<AssignedNative<S::F>> = vec![];
+    for (_, p) in acc.pairs.iter() {
+        if !union_logicals.contains(p) {
+            union_logicals.push(p.clone());
+        }
+    }
+
+    let mut triples = Vec::with_capacity(union_logicals.len() * acc.t);
+    for logical in union_logicals.iter() {
+        let slot_evals = (0..real_count)
+            .map(|slot| acc.eval_at(slot, logical))
+            .collect::<Result<Vec<_>, Error>>()?;
+
+        for root in t_th_roots_cells::<S>(layouter, scalar_chip, roots_cache, logical, acc.t)? {
+            let eval = eval_claims_as_poly::<S>(layouter, scalar_chip, &slot_evals, &root)?;
+            triples.push((synth_label.clone(), root, eval));
+        }
+    }
+    Ok(triples)
+}
+
+// -----------------------------------
+// See proofs/src/pcs/fflonk/mod.rs
+// -----------------------------------
+
+/// fflonk instantiation of [`InCircuitPCS`].
+#[derive(Clone, Copy, Debug)]
+pub struct InCircuitFflonk<S: SelfEmulation>(PhantomData<S>);
+
+impl<E: MultiMillerLoop> SingletonCommitment<E::G1> for FflonkCommitment<E> {
+    fn point(&self) -> E::G1 {
+        *self.as_point()
+    }
+}
+
+impl<S: SelfEmulation> InCircuitPCS<S> for InCircuitFflonk<S> {
+    type OffCircuit = FflonkScheme<S::Engine>;
+    type AssignedCommitment = AssignedFflonkCommitment<S>;
+
+    fn fixed_commitment(label: PolynomialLabel) -> Self::AssignedCommitment {
+        AssignedFflonkCommitment::fixed(label)
+    }
+
+    fn read_commitment(
+        transcript: &mut TranscriptGadget<S>,
+        layouter: &mut impl Layouter<S::F>,
+        labels: &[PolynomialLabel],
+    ) -> Result<Self::AssignedCommitment, Error> {
+        // The wire carries `u8 nb_bundles`, then per bundle a `u8` polynomial
+        // count and its point. Only the points are read: the grouping is
+        // re-derived from the labels, and the counts are skipped.
+        let bundles = partition(T_MAX, labels);
+        transcript.skip_bytes(1)?;
+
+        let mut pairs = Vec::with_capacity(bundles.len());
+        for indices in bundles.iter() {
+            transcript.skip_bytes(1)?;
+            let point = transcript.read_point(layouter)?;
+            pairs.push((
+                AssignedPoint::Variable(point),
+                indices.iter().map(|&i| labels[i].clone()).collect(),
+            ));
+        }
+
+        let commitment = AssignedFflonkCommitment::Regular(pairs);
+        Self::common_commitment(transcript, layouter, &commitment)?;
+
+        Ok(commitment)
+    }
+
+    fn assign_commitment(
+        layouter: &mut impl Layouter<S::F>,
+        curve_chip: &S::CurveChip,
+        value: Value<S::C>,
+        label: PolynomialLabel,
+    ) -> Result<Self::AssignedCommitment, Error> {
+        let point = curve_chip.assign(layouter, value)?;
+        Ok(AssignedFflonkCommitment::singleton(point, label))
+    }
+
+    fn common_commitment(
+        transcript: &mut TranscriptGadget<S>,
+        layouter: &mut impl Layouter<S::F>,
+        commitment: &Self::AssignedCommitment,
+    ) -> Result<(), Error> {
+        match commitment {
+            AssignedFflonkCommitment::Regular(pairs) => {
+                pairs.iter().try_for_each(|(p, labels)| match p {
+                    AssignedPoint::Variable(p) => transcript.absorb_point(layouter, p),
+                    AssignedPoint::Fixed => Err(Synthesis(format!(
+                        "Fixed commitments cannot be added to the transcript: {labels:?}"
+                    ))),
+                })
+            }
+            AssignedFflonkCommitment::Linear(_, _, labels) => Err(Synthesis(format!(
+                "Linear commitments cannot be added to the transcript: {labels:?}"
+            ))),
+        }
+    }
+
+    /// fflonk opens each bundle at the `t`-th roots of the evaluation point, so
+    /// that point must be a `T_MAX`-th power. Squeezes `s` and returns
+    /// `s^T_MAX`, mirroring
+    /// [`FflonkScheme::squeeze_evaluation_point`](midnight_proofs::pcs::PolynomialCommitmentScheme::squeeze_evaluation_point).
+    fn squeeze_evaluation_point(
+        layouter: &mut impl Layouter<S::F>,
+        scalar_chip: &S::ScalarChip,
+        transcript: &mut TranscriptGadget<S>,
+    ) -> Result<AssignedNative<S::F>, Error> {
+        let s = transcript.squeeze_challenge(layouter)?;
+        if T_MAX == 1 {
+            return Ok(s);
+        }
+        scalar_chip.pow(layouter, &s, T_MAX as u64)
+    }
+
+    fn multi_prepare(
+        layouter: &mut impl Layouter<S::F>,
+        _curve_chip: &S::CurveChip,
+        scalar_chip: &S::ScalarChip,
+        transcript: &mut TranscriptGadget<S>,
+        queries: &[VerifierQuery<'_, S, Self>],
+    ) -> Result<AssignedAccumulator<S>, Error> {
+        let one = AssignedBoundedScalar::one(layouter, scalar_chip)?;
+
+        // The prover's bundling ceiling. Off-circuit it selects the partition;
+        // here the partition is a circuit constant, so the claim is bound to it
+        // instead. See the module doc.
+        let claimed_t_max_log = transcript.read_scalar(layouter)?;
+        scalar_chip.assert_equal_to_fixed(
+            layouter,
+            &claimed_t_max_log,
+            S::F::from(FFLONK_T_MAX_LOG as u64),
+        )?;
+
+        // === Bundle pre-expansion (fflonk-specific) ===
+        //
+        // Singletons and `Linear` commitments pass through with their own
+        // (label, point, eval) triple. Queries on a `t > 1` bundle are gathered
+        // per logical point and expanded, below, into synthetic triples on the
+        // bundle's `g`.
+        let mut singleton_triples: Vec<QueryTriple<S>> = Vec::new();
+        let mut label_to_com: HashMap<PolynomialLabel, AssignedMsm<S>> = HashMap::new();
+        let mut bundles: Vec<(PolynomialLabel, BundleAcc<S>)> = Vec::new();
+
+        for q in queries.iter() {
+            match q.commitment {
+                AssignedFflonkCommitment::Linear(points, scalars, labels) => {
+                    singleton_triples.push((q.label.clone(), q.point.clone(), q.eval.clone()));
+                    label_to_com.insert(q.label.clone(), AssignedMsm::new(scalars, points, labels));
+                }
+                regular => {
+                    let (point, labels) = regular.find_bundle(&q.label)?;
+                    if labels.len() == 1 {
+                        singleton_triples.push((q.label.clone(), q.point.clone(), q.eval.clone()));
+                        label_to_com.insert(
+                            q.label.clone(),
+                            AssignedMsm::from_term(one.clone(), point.clone(), q.label.clone()),
+                        );
+                    } else {
+                        let synth = FflonkCommitment::<S::Engine>::synthetic_bundle_label(labels);
+                        let idx = match bundles.iter().position(|(l, _)| *l == synth) {
+                            Some(idx) => idx,
+                            None => {
+                                bundles.push((
+                                    synth,
+                                    BundleAcc {
+                                        point: point.clone(),
+                                        canonical_labels: labels.clone(),
+                                        t: bundle_t(labels.len(), T_MAX),
+                                        pairs: Vec::new(),
+                                        evals: Vec::new(),
+                                    },
+                                ));
+                                bundles.len() - 1
+                            }
+                        };
+                        let acc = &mut bundles[idx].1;
+                        let slot = acc
+                            .canonical_labels
+                            .iter()
+                            .position(|l| *l == q.label)
+                            .expect("the bundle was found by this very label");
+                        acc.pairs.push((slot, q.point.clone()));
+                        acc.evals.push(((slot, q.point.clone()), q.eval.clone()));
+                    }
+                }
+            }
+        }
+
+        // Sorted by synthetic label, as off-circuit, so the over-opening reads
+        // below land in the prover's write order.
+        bundles.sort_by(|a, b| a.0.to_string().cmp(&b.0.to_string()));
+
+        // Over-opening reads: the verifier reconstructs `g` at a root from the
+        // evaluations of *all* slots, so every slot is opened at every logical
+        // point of the bundle's union.
+        for (_synth, acc) in bundles.iter_mut() {
+            let missing = missing_openings(&acc.pairs);
+            for (pair_idx, point) in missing {
+                let slot = acc.pairs[pair_idx].0;
+                let eval = transcript.read_scalar(layouter)?;
+                acc.evals.push(((slot, point), eval));
+            }
+        }
+
+        // Add dummy queries to reduce the number of distinct multi-open point
+        // sets. As off-circuit, this applies to the singleton slice only: the
+        // bundled queries are about to become synthetic ones on `g`, whose
+        // point sets are the `t`-th roots.
+        #[cfg(feature = "fewer-point-sets")]
+        {
+            let pairs: Vec<_> =
+                singleton_triples.iter().map(|(l, p, _)| (l.clone(), p.clone())).collect();
+            for (idx, dummy_point) in midnight_proofs::pcs::compute_dummy_queries(&pairs) {
+                let label = singleton_triples[idx].0.clone();
+                let eval = transcript.read_scalar(layouter)?;
+                // `label_to_com` already maps `label`, so no new entry is needed.
+                singleton_triples.push((label, dummy_point, eval));
+            }
+        }
+
+        let mut triples = singleton_triples;
+        let mut roots_cache = RootsCache::<S>::new();
+        for (synth_label, acc) in bundles.iter() {
+            triples.extend(synth_triples_for_bundle::<S>(
+                layouter,
+                scalar_chip,
+                synth_label,
+                acc,
+                &mut roots_cache,
+            )?);
+            label_to_com.insert(
+                synth_label.clone(),
+                AssignedMsm::from_term(one.clone(), acc.point.clone(), synth_label.clone()),
+            );
+        }
+
+        multi_prepare_core(
+            layouter,
+            #[cfg(feature = "truncated-challenges")]
+            _curve_chip,
+            scalar_chip,
+            transcript,
+            &triples,
+            &label_to_com,
+            |layouter, transcript, label| {
+                // `f` and `π` commit to a single polynomial, so their wire form
+                // is a one-bundle, one-polynomial commitment.
+                match Self::read_commitment(transcript, layouter, &[label])? {
+                    AssignedFflonkCommitment::Regular(pairs) => match pairs.as_slice() {
+                        [(point, _)] => Ok(point.clone()),
+                        _ => Err(Synthesis(
+                            "the multi-open argument reads single-bundle commitments".into(),
+                        )),
+                    },
+                    AssignedFflonkCommitment::Linear(_, _, labels) => Err(Synthesis(format!(
+                        "the multi-open argument reads plain commitments, got a linear one: \
+                         {labels:?}"
+                    ))),
+                }
+            },
+        )
+    }
+}

--- a/circuits/src/verifier/fflonk.rs
+++ b/circuits/src/verifier/fflonk.rs
@@ -477,8 +477,11 @@ impl<S: SelfEmulation> InCircuitPCS<S> for InCircuitFflonk<S> {
 
         // The prover's bundling ceiling. Off-circuit it selects the partition;
         // here the partition is a circuit constant, so the claim is bound to it
-        // instead. See the module doc.
-        let claimed_t_max_log = transcript.read_scalar(layouter)?;
+        // instead. See the module doc. The substitute matters: a dummy proof
+        // (the IVC genesis step) has no bytes to read, and the constraint below
+        // must still be satisfiable.
+        let claimed_t_max_log =
+            transcript.read_scalar_or(layouter, S::F::from(FFLONK_T_MAX_LOG as u64))?;
         scalar_chip.assert_equal_to_fixed(
             layouter,
             &claimed_t_max_log,

--- a/circuits/src/verifier/mod.rs
+++ b/circuits/src/verifier/mod.rs
@@ -55,6 +55,41 @@ pub use types::BnEmulation;
 pub use types::{BlstrsEmulation, SelfEmulation};
 pub use verifier_gadget::VerifierGadget;
 
+/// The in-circuit gadget that verifies proofs of the off-circuit scheme `Self`.
+///
+/// Exists so that a single definition — [`midnight_proofs::MidnightPCS`] —
+/// fixes both halves of the protocol. Without it the two would be named
+/// independently and could silently drift apart.
+pub trait InCircuitCounterpart<S: SelfEmulation>: PolynomialCommitmentScheme<S::F> {
+    /// The gadget verifying this scheme's proofs.
+    type InCircuit: InCircuitPCS<S, OffCircuit = Self>;
+}
+
+impl<S: SelfEmulation> InCircuitCounterpart<S>
+    for midnight_proofs::pcs::kzg::KZGCommitmentScheme<S::Engine>
+{
+    type InCircuit = InCircuitKZG<S>;
+}
+
+impl<S: SelfEmulation> InCircuitCounterpart<S>
+    for midnight_proofs::pcs::fflonk::FflonkScheme<S::Engine>
+{
+    type InCircuit = InCircuitFflonk<S>;
+}
+
+/// The in-circuit counterpart of [`midnight_proofs::MidnightPCS`]: the scheme
+/// the verifier gadget is instantiated at throughout this workspace.
+///
+/// Derived from `MidnightPCS`, so switching the protocol's commitment scheme is
+/// the single edit of that alias; this one follows.
+pub type MidnightInCircuitPCS<S> =
+    <midnight_proofs::MidnightPCS<<S as SelfEmulation>::Engine> as InCircuitCounterpart<S>>::InCircuit;
+
+/// The in-circuit commitment type of [`MidnightInCircuitPCS`], the analog of
+/// [`midnight_proofs::MidnightCommitment`].
+pub type MidnightAssignedCommitment<S> =
+    <MidnightInCircuitPCS<S> as InCircuitPCS<S>>::AssignedCommitment;
+
 /// The off-circuit verifying key that a given in-circuit PCS accepts.
 type VerifyingKey<S, PCS> =
     plonk::VerifyingKey<<S as SelfEmulation>::F, <PCS as InCircuitPCS<S>>::OffCircuit>;

--- a/circuits/src/verifier/mod.rs
+++ b/circuits/src/verifier/mod.rs
@@ -31,6 +31,7 @@ use crate::{
 
 mod accumulator;
 mod expressions;
+mod fflonk;
 mod kzg;
 mod lookup;
 mod msm;
@@ -45,6 +46,7 @@ mod utils;
 mod verifier_gadget;
 
 pub use accumulator::{Accumulator, AssignedAccumulator};
+pub use fflonk::{AssignedFflonkCommitment, InCircuitFflonk};
 pub use kzg::{AssignedKZGCommitment, AssignedKZGMultiCommitment, InCircuitKZG};
 pub use msm::{AssignedMsm, AssignedPoint, Msm, Point};
 pub use pcs::{InCircuitHomomorphicCommitment, InCircuitPCS};

--- a/circuits/src/verifier/transcript_gadget.rs
+++ b/circuits/src/verifier/transcript_gadget.rs
@@ -174,6 +174,24 @@ impl<S: SelfEmulation> TranscriptGadget<S> {
         S::assign_without_subgroup_check(layouter, &self.curve_chip, point)
     }
 
+    /// Consumes `n` framing bytes from the proof without absorbing them.
+    ///
+    /// A commitment whose wire format interleaves structural bytes with its
+    /// points (fflonk's bundle counts) needs them skipped: they are not part of
+    /// `Hashable::to_input`, so the off-circuit transcript never absorbs them
+    /// either. The layout they describe is imposed by the gadget, which derives
+    /// it from the labels it expects, so their content is not read.
+    pub fn skip_bytes(&mut self, n: usize) -> Result<(), Error> {
+        let reader = self.transcript_reader.as_mut().expect("You must init the transcript gadget");
+        let mut buf = vec![0u8; n];
+        // As in `read_point`, a failed read is tolerated so that dummy proofs
+        // still parse; `assert_proof_fully_consumed` reports it afterwards.
+        if std::io::Read::read_exact(reader.buffer(), &mut buf).is_err() {
+            self.nb_failed_reads += 1;
+        }
+        Ok(())
+    }
+
     /// Reads a scalar from the reader buffer, and adds it to the transcript.
     /// Think of the read scalar as a witness freely chosen by the prover.
     pub fn read_scalar(

--- a/circuits/src/verifier/transcript_gadget.rs
+++ b/circuits/src/verifier/transcript_gadget.rs
@@ -198,6 +198,22 @@ impl<S: SelfEmulation> TranscriptGadget<S> {
         &mut self,
         layouter: &mut impl Layouter<S::F>,
     ) -> Result<AssignedNative<S::F>, Error> {
+        self.read_scalar_or(layouter, S::F::ZERO)
+    }
+
+    /// [`Self::read_scalar`] with a caller-chosen substitute for a failed read.
+    ///
+    /// A read fails only on a dummy proof, which a circuit may still have to
+    /// parse: the IVC genesis step runs the whole verifier over an empty proof
+    /// and neutralises the accumulator afterwards. Any constraint the gadget
+    /// puts on a value it read must therefore hold of the substitute too, so a
+    /// scalar that is constrained against a constant has to fall back to that
+    /// constant rather than to zero.
+    pub fn read_scalar_or(
+        &mut self,
+        layouter: &mut impl Layouter<S::F>,
+        default: S::F,
+    ) -> Result<AssignedNative<S::F>, Error> {
         let reader = self.transcript_reader.as_mut().expect("You must init the transcript gadget");
         // If an error, do not fail, assign a default scalar instead.
         // (This allows us to parse dummy proofs.)
@@ -205,7 +221,7 @@ impl<S: SelfEmulation> TranscriptGadget<S> {
             Ok(scalar) => Value::known(scalar),
             Err(_) => {
                 self.nb_failed_reads += 1;
-                Value::known(S::F::ZERO)
+                Value::known(default)
             }
         };
 

--- a/circuits/src/verifier/verifier_gadget.rs
+++ b/circuits/src/verifier/verifier_gadget.rs
@@ -899,15 +899,23 @@ impl<S: SelfEmulation> VerifierGadget<S> {
 #[cfg(test)]
 pub(crate) mod tests {
 
+    use std::marker::PhantomData;
+
     use group::Group;
     use midnight_proofs::{
         MidnightPCS,
         circuit::SimpleFloorPlanner,
         dev::MockProver,
-        pcs::{kzg::commitment::KZGMultiCommitment, params::ParamsKZG},
+        pcs::{
+            PolynomialCommitmentScheme,
+            fflonk::{FFLONK_T_MAX_LOG, FflonkCommitment, FflonkScheme},
+            kzg::{KZGCommitmentScheme, commitment::KZGMultiCommitment},
+            msm::DualMSM,
+            params::ParamsKZG,
+        },
         plonk::{Circuit, Error, create_proof, keygen_pk, keygen_vk_with_k, prepare},
         poly::PolynomialLabel,
-        transcript::{CircuitTranscript, Transcript},
+        transcript::{CircuitTranscript, Hashable, Transcript},
     };
     use rand::SeedableRng;
     use rand_chacha::ChaCha8Rng;
@@ -939,12 +947,14 @@ pub(crate) mod tests {
         },
         testing_utils::{
             FromScratch,
-            transcript_trace::{TracingTranscript, assert_streams_match, in_circuit},
+            transcript_trace::{
+                TracingTranscript, TranscriptEvent, assert_streams_match, in_circuit,
+            },
         },
         types::{ComposableChip, Instantiable},
         verifier::{
-            AssignedKZGCommitment, BlstrsEmulation, InCircuitKZG, accumulator::Accumulator,
-            kzg::AssignedKZGMultiCommitment,
+            BlstrsEmulation, InCircuitFflonk, InCircuitKZG, SingletonCommitment,
+            accumulator::Accumulator,
         },
     };
 
@@ -1013,16 +1023,18 @@ pub(crate) mod tests {
             poseidon_chip.load_from_scratch(&mut layouter)
         }
     }
-
+    /// The self-verification circuit: verifies an `InnerCircuit` proof produced
+    /// under `PCS::OffCircuit`, and exposes the resulting accumulator.
     #[derive(Clone, Debug)]
-    pub struct TestCircuit {
+    pub struct TestCircuit<PCS: InCircuitPCS<S>> {
         inner_vk: (EvaluationDomain<F>, ConstraintSystem<F>, Value<F>), // (domain, cs, vk_repr)
         inner_committed_instance: Value<C>,
         inner_instances: Value<[F; NB_INNER_INSTANCES]>,
         inner_proof: Value<Vec<u8>>,
+        _marker: PhantomData<PCS>,
     }
 
-    impl Circuit<F> for TestCircuit {
+    impl<PCS: InCircuitPCS<S>> Circuit<F> for TestCircuit<PCS> {
         type Config = (
             NativeConfig,
             P2RDecompositionConfig,
@@ -1111,21 +1123,19 @@ pub(crate) mod tests {
             let verifier_chip =
                 VerifierGadget::<S>::new(&curve_chip, &native_gadget, &poseidon_chip);
 
-            let assigned_inner_vk: AssignedVk<S, InCircuitKZG<S>> = verifier_chip
-                .assign_vk_as_public_input(
-                    &mut layouter,
-                    &self.inner_vk.0,
-                    &self.inner_vk.1,
-                    self.inner_vk.2,
-                )?;
+            let assigned_inner_vk: AssignedVk<S, PCS> = verifier_chip.assign_vk_as_public_input(
+                &mut layouter,
+                &self.inner_vk.0,
+                &self.inner_vk.1,
+                self.inner_vk.2,
+            )?;
 
-            let assigned_committed_instance =
-                AssignedKZGMultiCommitment(vec![AssignedKZGCommitment::assign(
-                    &mut layouter,
-                    &curve_chip,
-                    self.inner_committed_instance,
-                    PolynomialLabel::CommittedInstance(0),
-                )?]);
+            let assigned_committed_instance = PCS::assign_commitment(
+                &mut layouter,
+                &curve_chip,
+                self.inner_committed_instance,
+                PolynomialLabel::CommittedInstance(0),
+            )?;
 
             let assigned_inner_pi = native_gadget
                 .assign_many(&mut layouter, &self.inner_instances.transpose_array())?;
@@ -1146,38 +1156,59 @@ pub(crate) mod tests {
         }
     }
 
-    #[test]
-    fn test_verify_proof() {
+    /// The inner circuit, its key material and a proof of it, over `CS`.
+    ///
+    /// The scalar field is spelled out rather than taken as `F`: a bound stated
+    /// through the `SelfEmulation::F` projection does not normalise, and every
+    /// use of `CS` below then fails to see it.
+    struct InnerProof<CS: PolynomialCommitmentScheme<midnight_curves::Fq>> {
+        vk: midnight_proofs::plonk::VerifyingKey<F, CS>,
+        public_inputs: Vec<F>,
+        proof: Vec<u8>,
+    }
+
+    /// Sets up the inner circuit and proves it under `CS`.
+    ///
+    /// The SRS is `FFLONK_T_MAX_LOG` bits larger than the circuit domain in the
+    /// monomial basis, which is what a bundling scheme needs to reach its
+    /// nominal ceiling (see `effective_t_max_log`); for KZG the extra room is
+    /// simply unused.
+    fn prove_inner<CS>(inner_k: u32) -> (ParamsKZG<E>, InnerProof<CS>)
+    where
+        CS: PolynomialCommitmentScheme<midnight_curves::Fq, Parameters = ParamsKZG<E>>,
+        CS::Commitment: Hashable<PoseidonState<F>>,
+    {
         let mut rng = ChaCha8Rng::from_seed([0u8; 32]);
 
-        let inner_k = 10;
         #[cfg(not(feature = "single-h-commitment"))]
-        let inner_params = ParamsKZG::unsafe_setup(inner_k, &mut rng);
-
+        let extended_k = inner_k + FFLONK_T_MAX_LOG;
         #[cfg(feature = "single-h-commitment")]
-        let inner_params: ParamsKZG<_> = {
+        let extended_k = {
             let inner_cs_degree = 5;
-            let extended_k = inner_k + ((inner_cs_degree - 1) as f64).log2().ceil() as u32;
-            let mut extended = ParamsKZG::unsafe_setup(extended_k, &mut rng);
-            extended.downsize_lagrange(inner_k);
-            extended
+            inner_k + FFLONK_T_MAX_LOG + ((inner_cs_degree - 1) as f64).log2().ceil() as u32
         };
 
-        let inner_vk = keygen_vk_with_k(&inner_params, &InnerCircuit::default(), inner_k).unwrap();
-        let inner_pk = keygen_pk(inner_vk.clone(), &InnerCircuit::default()).unwrap();
+        let mut inner_params: ParamsKZG<E> = ParamsKZG::unsafe_setup(extended_k, &mut rng);
+        if extended_k > inner_k {
+            inner_params.downsize_lagrange(inner_k);
+        }
+
+        let vk =
+            keygen_vk_with_k::<F, CS, _>(&inner_params, &InnerCircuit::default(), inner_k).unwrap();
+        let pk = keygen_pk(vk.clone(), &InnerCircuit::default()).unwrap();
 
         let preimage = [F::random(&mut rng), F::random(&mut rng)];
         let output = <PoseidonChip<F> as HashCPU<F, F>>::hash(&preimage);
-        let inner_public_inputs = vec![output];
+        let public_inputs = vec![output];
 
-        let inner_proof = {
+        let proof = {
             let mut transcript = CircuitTranscript::<PoseidonState<F>>::init();
-            create_proof::<F, MidnightPCS<E>, CircuitTranscript<PoseidonState<F>>, InnerCircuit>(
+            create_proof::<F, CS, CircuitTranscript<PoseidonState<F>>, InnerCircuit>(
                 &inner_params,
-                &inner_pk,
+                &pk,
                 &InnerCircuit::from_witness(preimage),
                 1,
-                &[&[], &inner_public_inputs],
+                &[&[], &public_inputs],
                 &mut transcript,
                 &mut rng,
             )
@@ -1185,19 +1216,27 @@ pub(crate) mod tests {
             transcript.finalize()
         };
 
-        let mut off_circuit_transcript = TracingTranscript::<F>::init_from_bytes(&inner_proof);
-        let inner_dual_msm = prepare::<F, MidnightPCS<E>, TracingTranscript<F>>(
-            &inner_vk,
-            &[KZGMultiCommitment::commitment_to_zero(
-                PolynomialLabel::CommittedInstance(0),
-            )],
-            &[&inner_public_inputs],
-            &mut off_circuit_transcript,
+        (
+            inner_params,
+            InnerProof {
+                vk,
+                public_inputs,
+                proof,
+            },
         )
-        .expect("Problem preparing the inner proof");
+    }
 
-        let fixed_bases = crate::verifier::fixed_bases::<S, _>(&inner_vk);
-
+    /// Runs the self-verification circuit on an inner proof, after checking
+    /// off-circuit that the accumulator it must reproduce is a valid one.
+    fn check_self_verification<PCS: InCircuitPCS<S>>(
+        inner_params: &ParamsKZG<E>,
+        inner: &InnerProof<PCS::OffCircuit>,
+        inner_dual_msm: DualMSM<E>,
+        off_circuit_events: &[TranscriptEvent],
+    ) where
+        <PCS::OffCircuit as PolynomialCommitmentScheme<F>>::Commitment: SingletonCommitment<C>,
+    {
+        let fixed_bases = crate::verifier::fixed_bases::<S, _>(&inner.vk);
         let mut inner_acc = Accumulator::<S>::from_dual_msm(inner_dual_msm.clone(), &fixed_bases);
 
         let inner_verifier_params = inner_params.verifier_params();
@@ -1206,21 +1245,19 @@ pub(crate) mod tests {
 
         inner_acc.collapse();
 
-        // The inner proof is ready.
-        // Now, let us make a proof that we know an inner proof.
-
-        let mut public_inputs = AssignedVk::<S, InCircuitKZG<S>>::as_public_input(&inner_vk);
+        let mut public_inputs = AssignedVk::<S, PCS>::as_public_input(&inner.vk);
         public_inputs.extend(AssignedAccumulator::as_public_input(&inner_acc));
 
-        let circuit = TestCircuit {
+        let circuit = TestCircuit::<PCS> {
             inner_vk: (
-                inner_vk.get_domain().clone(),
-                inner_vk.cs().clone(),
-                Value::known(inner_vk.transcript_repr()),
+                inner.vk.get_domain().clone(),
+                inner.vk.cs().clone(),
+                Value::known(inner.vk.transcript_repr()),
             ),
             inner_committed_instance: Value::known(C::identity()),
-            inner_instances: Value::known([output]),
-            inner_proof: Value::known(inner_proof),
+            inner_instances: Value::known([inner.public_inputs[0]]),
+            inner_proof: Value::known(inner.proof.clone()),
+            _marker: PhantomData,
         };
 
         in_circuit::start();
@@ -1231,8 +1268,54 @@ pub(crate) mod tests {
         // and squeeze at the same points. This diff names the first operation where
         // they part ways; without it a mismatch only shows up as an unsatisfiable
         // circuit at an unrelated row.
-        assert_streams_match(off_circuit_transcript.events(), &in_circuit::take());
+        assert_streams_match(off_circuit_events, &in_circuit::take());
 
         prover.assert_satisfied();
+    }
+
+    #[test]
+    fn test_verify_proof() {
+        let (inner_params, inner) = prove_inner::<KZGCommitmentScheme<E>>(10);
+
+        let mut off_circuit_transcript = TracingTranscript::<F>::init_from_bytes(&inner.proof);
+        let inner_dual_msm = prepare::<F, KZGCommitmentScheme<E>, TracingTranscript<F>>(
+            &inner.vk,
+            &[KZGMultiCommitment::commitment_to_zero(
+                PolynomialLabel::CommittedInstance(0),
+            )],
+            &[&inner.public_inputs],
+            &mut off_circuit_transcript,
+        )
+        .expect("Problem preparing the inner proof");
+
+        check_self_verification::<InCircuitKZG<S>>(
+            &inner_params,
+            &inner,
+            inner_dual_msm,
+            off_circuit_transcript.events(),
+        );
+    }
+
+    #[test]
+    fn test_verify_fflonk_proof() {
+        let (inner_params, inner) = prove_inner::<FflonkScheme<E>>(10);
+
+        let mut off_circuit_transcript = TracingTranscript::<F>::init_from_bytes(&inner.proof);
+        let inner_guard = prepare::<F, FflonkScheme<E>, TracingTranscript<F>>(
+            &inner.vk,
+            &[FflonkCommitment::commitment_to_zero(
+                PolynomialLabel::CommittedInstance(0),
+            )],
+            &[&inner.public_inputs],
+            &mut off_circuit_transcript,
+        )
+        .expect("Problem preparing the inner proof");
+
+        check_self_verification::<InCircuitFflonk<S>>(
+            &inner_params,
+            &inner,
+            inner_guard.into_dual_msm(),
+            off_circuit_transcript.events(),
+        );
     }
 }

--- a/circuits/src/verifier/verifier_gadget.rs
+++ b/circuits/src/verifier/verifier_gadget.rs
@@ -903,7 +903,6 @@ pub(crate) mod tests {
 
     use group::Group;
     use midnight_proofs::{
-        MidnightPCS,
         circuit::SimpleFloorPlanner,
         dev::MockProver,
         pcs::{

--- a/proofs/CHANGELOG.md
+++ b/proofs/CHANGELOG.md
@@ -31,6 +31,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * Fix cost-model [#435](https://github.com/midnightntwrk/midnight-zk/pull/435)
 
 ### Changed
+* `Params::max_k` accepts a monomial basis longer than the Lagrange one, which is the SRS shape fflonk bundling needs [#518](https://github.com/midnightntwrk/midnight-zk/pull/518)
 * Migrate to Rust edition 2024; MSRV raised from 1.76 to 1.90. Both are now inherited from the workspace [#508](https://github.com/midnightntwrk/midnight-zk/pull/508)
 * Batch cross-argument commitments and add `write_commitment` method on the `PolynomialCommitmentScheme` trait [#493](https://github.com/midnightntwrk/midnight-zk/pull/493)
 * Extend `PolynomialCommitmentScheme` with `squeeze_evaluation_point` and `srs_monomial_blowup` and add a `k` argument to `multi_prepare`, as PCS-agnostic extension points for fflonk [#487](https://github.com/midnightntwrk/midnight-zk/pull/487)

--- a/proofs/src/lib.rs
+++ b/proofs/src/lib.rs
@@ -23,3 +23,10 @@ pub mod utils;
 /// that means KZG specifically keeps naming
 /// [`KZGCommitmentScheme`](pcs::kzg::KZGCommitmentScheme).
 pub type MidnightPCS<E> = pcs::kzg::KZGCommitmentScheme<E>;
+
+/// The commitment type of [`MidnightPCS`]. Callers that just mean "a commitment
+/// as this library produces them" name this rather than a concrete scheme's
+/// type, so it follows the alias above.
+pub type MidnightCommitment<E> = <MidnightPCS<E> as pcs::PolynomialCommitmentScheme<
+    <E as midnight_curves::pairing::Engine>::Fr,
+>>::Commitment;

--- a/proofs/src/pcs/fflonk/bundle_expansion.rs
+++ b/proofs/src/pcs/fflonk/bundle_expansion.rs
@@ -91,9 +91,7 @@ pub(super) struct BundleAcc<E: MultiMillerLoop> {
 /// `fewer-point-sets`'s
 /// `compute_dummy_queries`,
 /// which pads towards multi-point keys only.
-pub(super) fn missing_openings<K: PartialEq, P: PartialEq + Clone>(
-    pairs: &[(K, P)],
-) -> Vec<(usize, P)> {
+pub fn missing_openings<K: PartialEq, P: PartialEq + Clone>(pairs: &[(K, P)]) -> Vec<(usize, P)> {
     // Group by key, tracking each key's first occurrence index.
     let mut groups: Vec<(usize, Vec<P>)> = vec![];
     for (i, (key, point)) in pairs.iter().enumerate() {

--- a/proofs/src/pcs/fflonk/commitment.rs
+++ b/proofs/src/pcs/fflonk/commitment.rs
@@ -118,7 +118,7 @@ impl<E: MultiMillerLoop> FflonkCommitment<E> {
 
     /// Canonical synthetic label for a `t > 1` bundle. Both prover and verifier
     /// compute this for the same bundle.
-    pub(super) fn synthetic_bundle_label(bundle_labels: &[PolynomialLabel]) -> PolynomialLabel {
+    pub fn synthetic_bundle_label(bundle_labels: &[PolynomialLabel]) -> PolynomialLabel {
         let first = bundle_labels.first().expect("fflonk: multi-poly bundle must be non-empty");
         PolynomialLabel::Custom(format!("fflonk_bundle[{first}]"))
     }

--- a/proofs/src/pcs/fflonk/math.rs
+++ b/proofs/src/pcs/fflonk/math.rs
@@ -39,7 +39,7 @@ pub(super) fn combine<F: Field>(slots: &[&[F]], t: usize) -> Vec<F> {
 ///
 /// # Panics
 /// If `t` is not a power of two, or `log2 t > F::S`.
-pub(super) fn primitive_root_of_unity<F: PrimeField>(t: usize) -> F {
+pub fn primitive_root_of_unity<F: PrimeField>(t: usize) -> F {
     assert!(t.is_power_of_two(), "t must be a power of two");
     let log_t = t.trailing_zeros();
     assert!(log_t <= F::S, "t exceeds field 2-adicity (F::S)");
@@ -83,7 +83,7 @@ pub(super) fn eval_claims_as_poly<F: Field>(claimed: &[F], root: F) -> F {
 /// If `t` is not a power of two, or if `x` is not a `t`-th power in `F`
 /// (an intermediate `sqrt()` returns `None`). For fflonk, the caller guarantees
 /// `x` is a `t`-th power by construction (logical points are `s^t · ω_n^r`).
-pub(super) fn t_th_root<F: PrimeField>(x: F, t: usize) -> F {
+pub fn t_th_root<F: PrimeField>(x: F, t: usize) -> F {
     assert!(t.is_power_of_two(), "t must be a power of two");
     let log_t = t.trailing_zeros();
     let mut r = x;

--- a/proofs/src/pcs/fflonk/mod.rs
+++ b/proofs/src/pcs/fflonk/mod.rs
@@ -49,8 +49,13 @@ mod math;
 mod partition;
 
 pub use commitment::FflonkCommitment;
+// Re-exported for the in-circuit fflonk verifier, which re-derives the same
+// bundle layout and the same `t`-th roots the off-circuit verifier does.
+pub use math::{primitive_root_of_unity, t_th_root};
+pub use partition::{bundle_t, partition};
 
-use self::math::{combine, primitive_root_of_unity, roots as t_th_roots, t_th_root};
+pub use self::bundle_expansion::missing_openings;
+use self::math::{combine, roots as t_th_roots};
 #[cfg(feature = "fewer-point-sets")]
 use crate::pcs::utils::compute_dummy_queries;
 use crate::{

--- a/proofs/src/pcs/fflonk/mod.rs
+++ b/proofs/src/pcs/fflonk/mod.rs
@@ -134,6 +134,21 @@ where
     pub fn into_dual_msm(self) -> DualMSM<E> {
         self.0
     }
+
+    /// Scales both sides of the accumulated pairing check.
+    pub fn scale(&mut self, factor: E::Fr) {
+        self.0.scale(factor)
+    }
+
+    /// Folds another guard into this one, for batch verification.
+    pub fn add_msm(&mut self, other: Self) {
+        self.0.add_msm(other.0)
+    }
+
+    /// Whether the accumulated pairing check holds.
+    pub fn check(self, params: &ParamsVerifierKZG<E>) -> bool {
+        self.0.check(params)
+    }
 }
 
 impl<E: MultiMillerLoop> PolynomialCommitmentScheme<E::Fr> for FflonkScheme<E>

--- a/proofs/src/pcs/fflonk/partition.rs
+++ b/proofs/src/pcs/fflonk/partition.rs
@@ -58,7 +58,7 @@ use crate::poly::query::PolynomialLabel;
 ///
 /// TODO: this function should be removed once linearisation and fflonk are made
 /// compatible.
-pub(super) fn poly_is_combinable(label: &PolynomialLabel) -> bool {
+pub fn poly_is_combinable(label: &PolynomialLabel) -> bool {
     matches!(
         label,
         PolynomialLabel::Advice(_)
@@ -92,7 +92,7 @@ fn chunk_family(result: &mut Vec<Vec<usize>>, family_indices: &[usize], t_max: u
 /// per-family canonical key both sides must agree on. This ordering is
 /// independent of the bundling factor; only the chunk boundaries drawn over it
 /// depend on `t_max`.
-pub(super) fn canonical_order(labels: &[PolynomialLabel]) -> Vec<usize> {
+pub fn canonical_order(labels: &[PolynomialLabel]) -> Vec<usize> {
     let mut combinable: Vec<usize> = Vec::new();
     let mut singletons: Vec<usize> = Vec::new();
     for (idx, label) in labels.iter().enumerate() {
@@ -120,7 +120,7 @@ pub(super) fn canonical_order(labels: &[PolynomialLabel]) -> Vec<usize> {
 /// fixed columns, because of their use in linearisation. A multi-poly bundle
 /// exposes only the combined group element, from which the individual
 /// commitments cannot be recovered.
-pub(super) fn partition(t_max: usize, labels: &[PolynomialLabel]) -> Vec<Vec<usize>> {
+pub fn partition(t_max: usize, labels: &[PolynomialLabel]) -> Vec<Vec<usize>> {
     let order = canonical_order(labels);
 
     let mut result: Vec<Vec<usize>> = Vec::new();
@@ -150,7 +150,7 @@ pub(super) fn partition(t_max: usize, labels: &[PolynomialLabel]) -> Vec<Vec<usi
 /// Logical bundle size for a bundle holding `real_count` real polynomials at
 /// ceiling `t_max`. fflonk requires bundle sizes to be a power of two, so
 /// bundles are padded with null polynomials up to the next power.
-pub(super) fn bundle_t(real_count: usize, t_max: usize) -> usize {
+pub fn bundle_t(real_count: usize, t_max: usize) -> usize {
     real_count.next_power_of_two().min(t_max)
 }
 

--- a/proofs/src/pcs/msm.rs
+++ b/proofs/src/pcs/msm.rs
@@ -286,6 +286,16 @@ where
         self.right.add_msm(&other.right);
     }
 
+    /// Returns this accumulator unchanged.
+    ///
+    /// The identity exists so that callers can be written against any scheme
+    /// whose verification guard is a `DualMSM` or wraps one: KZG's guard *is*
+    /// this type, fflonk's is a newtype around it, and both answer
+    /// `into_dual_msm`.
+    pub fn into_dual_msm(self) -> Self {
+        self
+    }
+
     /// Performs final pairing check with given verifier params and two channel
     /// linear combination
     pub fn check(self, params: &ParamsVerifierKZG<E>) -> bool {

--- a/proofs/src/pcs/params.rs
+++ b/proofs/src/pcs/params.rs
@@ -62,8 +62,10 @@ where
     E::G1Affine: CurveAffine,
 {
     fn max_k(&self) -> u32 {
-        #[cfg(not(feature = "single-h-commitment"))]
-        assert_eq!(self.g.len(), self.g_lagrange.len());
+        // The monomial basis may exceed the circuit domain: `single-h-commitment`
+        // commits an unsplit quotient, and fflonk commits a bundle of `t`
+        // polynomials as one of degree `t * 2^k`. It may never fall short of it.
+        assert!(self.g.len() >= self.g_lagrange.len());
         self.g_lagrange.len().ilog2()
     }
 

--- a/zk_stdlib/src/interface.rs
+++ b/zk_stdlib/src/interface.rs
@@ -19,12 +19,11 @@ use ff::Field;
 use midnight_circuits::types::ComposableChip;
 use midnight_curves::G1Projective;
 use midnight_proofs::{
-    MidnightPCS,
+    MidnightCommitment, MidnightPCS,
     circuit::{Layouter, SimpleFloorPlanner, Value},
     dev::cost_model::{CircuitModel, circuit_model},
     pcs::{
         Guard, Params,
-        kzg::commitment::KZGMultiCommitment,
         params::{ParamsKZG, ParamsVerifierKZG},
     },
     plonk::{
@@ -560,7 +559,7 @@ pub fn verify<R: Relation, H: TranscriptHash>(
     params_verifier: &ParamsVerifierKZG<midnight_curves::Bls12>,
     vk: &MidnightVK,
     instance: &R::Instance,
-    committed_instance: Option<KZGMultiCommitment<midnight_curves::Bls12>>,
+    committed_instance: Option<MidnightCommitment<midnight_curves::Bls12>>,
     proof: &[u8],
 ) -> Result<(), R::Error>
 where
@@ -568,9 +567,11 @@ where
     F: Hashable<H> + Sampleable<H>,
 {
     let pi = R::format_instance(instance)?;
-    let committed_pi = committed_instance.unwrap_or(KZGMultiCommitment::commitment_to_zero(
-        PolynomialLabel::CommittedInstance(0),
-    ));
+    let committed_pi = committed_instance.unwrap_or(
+        MidnightCommitment::<midnight_curves::Bls12>::commitment_to_zero(
+            PolynomialLabel::CommittedInstance(0),
+        ),
+    );
     if pi.len() != vk.nb_public_inputs {
         return Err(Error::InvalidInstances.into());
     }
@@ -625,9 +626,11 @@ where
                 CircuitTranscript<H>,
             >(
                 &vk.vk,
-                &[KZGMultiCommitment::commitment_to_zero(
-                    PolynomialLabel::CommittedInstance(0),
-                )],
+                &[
+                    MidnightCommitment::<midnight_curves::Bls12>::commitment_to_zero(
+                        PolynomialLabel::CommittedInstance(0),
+                    ),
+                ],
                 &[pi],
                 &mut transcript,
             )?;

--- a/zk_stdlib/src/utils/plonk_api.rs
+++ b/zk_stdlib/src/utils/plonk_api.rs
@@ -25,10 +25,9 @@ use std::{
 
 use midnight_curves::Bls12;
 use midnight_proofs::{
-    MidnightPCS,
+    MidnightCommitment, MidnightPCS,
     pcs::{
         Guard, PolynomialCommitmentScheme,
-        kzg::commitment::KZGMultiCommitment,
         params::{ParamsKZG, ParamsVerifierKZG},
     },
     plonk::{
@@ -127,7 +126,7 @@ macro_rules! plonk_api {
             pub fn verify<H>(
                 params_verifier: &ParamsVerifierKZG<$engine>,
                 vk: &VerifyingKey<$native, MidnightPCS<$engine>>,
-                instance_commitments: &[KZGMultiCommitment<$engine>],
+                instance_commitments: &[MidnightCommitment<$engine>],
                 pi: &[&[$native]],
                 proof: &[u8],
             ) -> Result<(), Error>


### PR DESCRIPTION
Adds the in-circuit fflonk verifier: InCircuitFflonk and AssignedFflonkCommitment, the analog of proofs/src/pcs/fflonk. Queries are pre-expanded into synthetic queries on the combined polynomial, and everything downstream reuses the shared multi-open core (see previous PR).

NB: MidnightInCircuitPCS derives the gadget's scheme from MidnightPCS through a new InCircuitCounterpart trait, so the two halves cannot drift and the eventual switch is a one-line edit. MidnightPCS still resolves to KZG at the moment.