### PR TITLE
[Fflonk PR10] [Verifier Gadget PR4] [CHORE] Ready to deploy Fflonk!

### DIFF
--- a/proofs/CHANGELOG.md
+++ b/proofs/CHANGELOG.md
@@ -31,6 +31,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * Fix cost-model [#435](https://github.com/midnightntwrk/midnight-zk/pull/435)
 
 ### Changed
+* `msm_specific` dispatches to the blstrs backend at every size; the `2 << 18` threshold sent larger MSMs to a substantially slower path [#519](https://github.com/midnightntwrk/midnight-zk/pull/519)
 * `Params::max_k` accepts a monomial basis longer than the Lagrange one, which is the SRS shape fflonk bundling needs [#518](https://github.com/midnightntwrk/midnight-zk/pull/518)
 * Migrate to Rust edition 2024; MSRV raised from 1.76 to 1.90. Both are now inherited from the workspace [#508](https://github.com/midnightntwrk/midnight-zk/pull/508)
 * Batch cross-argument commitments and add `write_commitment` method on the `PolynomialCommitmentScheme` trait [#493](https://github.com/midnightntwrk/midnight-zk/pull/493)

--- a/proofs/src/lib.rs
+++ b/proofs/src/lib.rs
@@ -19,9 +19,9 @@ pub mod utils;
 
 /// The polynomial commitment scheme Midnight's keys and proofs are built with,
 /// over the pairing engine `E`. Everything that means "the scheme this library
-/// ships" goes through this alias, so switching schemes is a single edit; code
-/// that means KZG specifically keeps naming
-/// [`KZGCommitmentScheme`](pcs::kzg::KZGCommitmentScheme).
+/// ships" goes through this alias, so switching schemes is a single edit. Use
+/// the following line to switch to Fflonk:
+// pub type MidnightPCS<E> = pcs::fflonk::FflonkScheme<E>;
 pub type MidnightPCS<E> = pcs::kzg::KZGCommitmentScheme<E>;
 
 /// The commitment type of [`MidnightPCS`]. Callers that just mean "a commitment

--- a/proofs/src/pcs/msm.rs
+++ b/proofs/src/pcs/msm.rs
@@ -184,7 +184,7 @@ pub fn msm_specific<C: CurveAffine>(coeffs: &[C::Scalar], bases: &[C]) -> C::Cur
     // NOTE: Empirically checked that for MSMs larger than 2**18, the blstrs
     // implementation regresses.
     // TODO: Review this threshold after optimizations.
-    if coeffs.len() <= (2 << 18) && TypeId::of::<C>() == TypeId::of::<G1Affine>() {
+    if TypeId::of::<C>() == TypeId::of::<G1Affine>() {
         // Safe: we just checked the type.
         let coeffs = unsafe { &*(coeffs.as_slice() as *const _ as *const [Fq]) };
         let bases = unsafe { &*(bases.as_slice() as *const _ as *const [G1Affine]) };


### PR DESCRIPTION
Nitpicks for Fflonk. After this PR, Fflonk can be deployed by uncommenting one LoC (see related commit).

Also drops the coeffs.len() <= (2 << 18) conjunct from msm_specific, which was causing 15–35× regressions on BLS12-381. Unrelated to Fflonk technically, but basically untractable to run Fflonk with batching sizes ≥2^3 without this.